### PR TITLE
Fixes in toJSONString functions

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/AmountInfo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/AmountInfo.swift
@@ -48,6 +48,10 @@ public class AmountInfo: NSObject {
     }
     
     public func toJSONString() -> String {
+       return self.toJSON().toString()
+    }
+    
+    public func toJSON() -> JSON {
         let obj:[String:AnyObject] = [
             "amount": self.amount!,
             "thousands_separator": self.currency == nil ? JSON.null : String(self.currency!.thousandsSeparator),
@@ -56,7 +60,7 @@ public class AmountInfo: NSObject {
             "decimal_places": self.currency == nil ? JSON.null : self.currency!.decimalPlaces
         ]
         
-        return JSON(obj).toString()
+        return JSON(obj)
     }
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Card.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Card.swift
@@ -64,7 +64,7 @@ public class Card : NSObject {
     
     public func toJSON() -> JSON {
         let obj:[String:AnyObject] = [
-            "cardHolder" : self.cardHolder == nil ? JSON.null : self.cardHolder!.toJSONString(),
+            "cardHolder" : self.cardHolder == nil ? JSON.null : self.cardHolder!.toJSON().mutableCopyOfTheObject(),
             "customer_id": self.customerId == nil ? JSON.null : self.customerId!,
             "dateCreated" : self.dateCreated == nil ? JSON.null : String(self.dateCreated!),
             "dateLastUpdated" : self.dateLastUpdated == nil ? JSON.null : String(self.dateLastUpdated!),

--- a/MercadoPagoSDK/MercadoPagoSDK/Card.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Card.swift
@@ -60,14 +60,18 @@ public class Card : NSObject {
     
     public func toJSONString() -> String {
         let obj:[String:AnyObject] = [
-            "customer_id": self.customerId != nil ? JSON.null : self.customerId!,
-            "dateCreated" : self.dateCreated == nil ? JSON.null : self.dateCreated!,
-            "dateLastUpdated" : self.dateLastUpdated == nil ? JSON.null : self.dateLastUpdated!,
+            "cardHolder" : self.cardHolder == nil ? JSON.null : self.cardHolder!.toJSONString(),
+            "customer_id": self.customerId == nil ? JSON.null : self.customerId!,
+            "dateCreated" : self.dateCreated == nil ? JSON.null : String(self.dateCreated!),
+            "dateLastUpdated" : self.dateLastUpdated == nil ? JSON.null : String(self.dateLastUpdated!),
             "expirationMonth" : self.expirationMonth,
-            "expirationMonth" : self.expirationMonth,
+            "expirationYear" : self.expirationYear,
             "firstSixDigits" : self.firstSixDigits == nil ? JSON.null : self.firstSixDigits!,
             "idCard" : self.idCard,
-            "lastFourDigits" : self.lastFourDigits == nil ? JSON.null : self.lastFourDigits!
+            "lastFourDigits" : self.lastFourDigits == nil ? JSON.null : self.lastFourDigits!,
+            "paymentMethod" : self.paymentMethod == nil ? JSON.null : self.paymentMethod!.toJSONString(),
+            "issuer" : self.issuer == nil ? JSON.null : self.issuer!.toJSONString(),
+            "securityCode" : self.securityCode == nil ? JSON.null : self.securityCode!.toJSONString()
             ]
         return JSON(obj).toString()
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Card.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Card.swift
@@ -34,7 +34,7 @@ public class Card : NSObject {
 			card.expirationMonth = JSON(json["expiration_month"]!).asInt!
 		}
 		if json["expiration_year"] != nil && !(json["expiration_year"]! is NSNull) {
-			card.expirationMonth = JSON(json["expiration_year"]!).asInt!
+			card.expirationYear = JSON(json["expiration_year"]!).asInt!
 		}
 		if json["id"] != nil && !(json["id"]! is NSNull) {
 			card.idCard = NSNumber(longLong: (json["id"]! as? NSString)!.longLongValue)
@@ -59,6 +59,10 @@ public class Card : NSObject {
     }
     
     public func toJSONString() -> String {
+        return self.toJSON().toString()
+    }
+    
+    public func toJSON() -> JSON {
         let obj:[String:AnyObject] = [
             "cardHolder" : self.cardHolder == nil ? JSON.null : self.cardHolder!.toJSONString(),
             "customer_id": self.customerId == nil ? JSON.null : self.customerId!,
@@ -69,11 +73,10 @@ public class Card : NSObject {
             "firstSixDigits" : self.firstSixDigits == nil ? JSON.null : self.firstSixDigits!,
             "idCard" : self.idCard,
             "lastFourDigits" : self.lastFourDigits == nil ? JSON.null : self.lastFourDigits!,
-            "paymentMethod" : self.paymentMethod == nil ? JSON.null : self.paymentMethod!.toJSONString(),
+            "paymentMethod" : self.paymentMethod == nil ? JSON.null : self.paymentMethod!.toJSON().mutableCopyOfTheObject(),
             "issuer" : self.issuer == nil ? JSON.null : self.issuer!.toJSONString(),
-            "securityCode" : self.securityCode == nil ? JSON.null : self.securityCode!.toJSONString()
-            ]
-        return JSON(obj).toString()
+            "securityCode" : self.securityCode == nil ? JSON.null : self.securityCode!.toJSON().mutableCopyOfTheObject()       ]
+        return JSON(obj)
     }
     
     public func isSecurityCodeRequired() -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/CardToken.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardToken.swift
@@ -289,6 +289,7 @@ public class CardToken : NSObject {
     public func toJSONString() -> String {
         let obj:[String:AnyObject] = [
             "card_number": String.isNullOrEmpty(self.cardNumber) ? JSON.null : self.cardNumber!,
+            "cardholder": (self.cardholder == nil) ? JSON.null : self.cardholder!.toJSON().mutableCopyOfTheObject(),
             "security_code" : String.isNullOrEmpty(self.securityCode) ? JSON.null : self.securityCode!,
             "expiration_month" : self.expirationMonth,
             "expiration_year" : self.expirationYear,
@@ -296,7 +297,6 @@ public class CardToken : NSObject {
         ]
         return JSON(obj).toString()
     }
-    
     
     public func getNumberFormated() -> NSString {
         

--- a/MercadoPagoSDK/MercadoPagoSDK/CardToken.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardToken.swift
@@ -292,7 +292,6 @@ public class CardToken : NSObject {
             "security_code" : String.isNullOrEmpty(self.securityCode) ? JSON.null : self.securityCode!,
             "expiration_month" : self.expirationMonth,
             "expiration_year" : self.expirationYear,
-            "cardholder" : self.cardholder == nil ? JSON.null : JSON.parse(self.cardholder!.toJSONString()).mutableCopyOfTheObject(),
             "device" : self.device == nil ? JSON.null : self.device!.toJSONString()
         ]
         return JSON(obj).toString()

--- a/MercadoPagoSDK/MercadoPagoSDK/Cardholder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Cardholder.swift
@@ -24,7 +24,7 @@ public class Cardholder : NSObject {
     public func toJSONString() -> String {
         let obj:[String:AnyObject] = [
             "name": String.isNullOrEmpty(self.name) ? JSON.null : self.name!,
-            "identification" : self.identification == nil ? JSON.null : JSON.parse(self.identification!.toJSONString()).mutableCopyOfTheObject()
+            "identification" : self.identification == nil ? JSON.null : self.identification!.toJSONString()
         ]
         return JSON(obj).toString()
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Cardholder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Cardholder.swift
@@ -22,11 +22,15 @@ public class Cardholder : NSObject {
     }
     
     public func toJSONString() -> String {
+        return self.toJSON().toString()
+    }
+    
+    public func toJSON() -> JSON {
         let obj:[String:AnyObject] = [
             "name": String.isNullOrEmpty(self.name) ? JSON.null : self.name!,
-            "identification" : self.identification == nil ? JSON.null : self.identification!.toJSONString()
+            "identification" : self.identification == nil ? JSON.null : self.identification!.toJSON().mutableCopyOfTheObject()
         ]
-        return JSON(obj).toString()
+        return JSON(obj)
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Identification.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Identification.swift
@@ -27,11 +27,15 @@ public class Identification : NSObject {
     }
     
     public func toJSONString() -> String {
+        return self.toJSON().toString()
+    }
+    
+    public func toJSON() -> JSON {
         let obj:[String:AnyObject] = [
             "type": String.isNullOrEmpty(self.type) ? JSON.null : self.type!,
             "number": String.isNullOrEmpty(self.number) ? JSON.null : self.number!
         ]
-        return JSON(obj).toString()
+        return JSON(obj)
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Instruction.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Instruction.swift
@@ -65,11 +65,15 @@ public class Instruction: NSObject {
     }
     
     public func toJSONString() -> String {
+        return self.toJSON().toString()
+    }
+    
+    public func toJSON() -> JSON {
         let obj:[String:AnyObject] = [
             "title": self.title,
             "accreditationMessage" : self.accreditationMessage
-            ]
-        return JSON(obj).toString()
+        ]
+        return JSON(obj)
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/InstructionsInfo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/InstructionsInfo.swift
@@ -37,15 +37,13 @@ public class InstructionsInfo: NSObject {
     
     public func toJSONString() -> String {
         var obj:[String:AnyObject] = [
-            "amount_info": self.amountInfo.toJSONString()
+            "amount_info": self.amountInfo.toJSON()
         ]
     
-        var instructionsJson = ""
         if self.instructions != nil && self.instructions.count > 0 {
-            for item in self.instructions {
-                instructionsJson = instructionsJson + item.toJSONString()
-            }
-            obj["instructions"] = instructionsJson
+            let instructionsStringArr = self.instructions.map({$0.toJSON()})
+            obj["instructions"] = NSArray(array :instructionsStringArr)
+            
         }
             
         return JSON(obj).toString()

--- a/MercadoPagoSDK/MercadoPagoSDK/InstructionsInfo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/InstructionsInfo.swift
@@ -41,10 +41,12 @@ public class InstructionsInfo: NSObject {
         ]
     
         var instructionsJson = ""
-        for item in self.instructions {
-            instructionsJson = instructionsJson + item.toJSONString()
+        if self.instructions != nil && self.instructions.count > 0 {
+            for item in self.instructions {
+                instructionsJson = instructionsJson + item.toJSONString()
+            }
+            obj["instructions"] = instructionsJson
         }
-        obj["instructions"] = instructionsJson
             
         return JSON(obj).toString()
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Issuer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Issuer.swift
@@ -26,11 +26,15 @@ public class Issuer : NSObject {
     }
     
     public func toJSONString() -> String {
+       return self.toJSON().toString()
+    }
+    
+    public func toJSON() -> JSON {
         let obj:[String:AnyObject] = [
             "id": self._id != nil ? JSON.null : self._id!,
             "name" : self.name == nil ? JSON.null : self.name!,
             ]
-        return JSON(obj).toString()
+        return JSON(obj)
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Payment.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Payment.swift
@@ -172,7 +172,7 @@ public class Payment : NSObject {
             "payment_method_id" : self.paymentMethodId,
             "status" : self.status,
             "status_detail" : self.statusDetail,
-            "card" : card == nil ? "" : card.toJSONString()
+            "card" : card == nil ? "" : card.toJSON().mutableCopyOfTheObject()
         ]
         
         return JSON(obj).toString()

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethod.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethod.swift
@@ -60,13 +60,18 @@ public class PaymentMethod : NSObject  {
     }
     
     public func toJSONString() -> String {
+        return self.toJSON().toString()
+    }
+    
+    public func toJSON() -> JSON {
         let obj:[String:AnyObject] = [
             "id": String.isNullOrEmpty(self._id) ? JSON.null : self._id!,
             "name" : self.name == nil ? JSON.null : self.name,
             "payment_type_id" : self.paymentTypeId == nil ? JSON.null : self.paymentTypeId,
-        ]
-        return JSON(obj).toString()
+            ]
+        return JSON(obj)
     }
+    
     
     public class func fromJSON(json : NSDictionary) -> PaymentMethod {
         let paymentMethod : PaymentMethod = PaymentMethod()

--- a/MercadoPagoSDK/MercadoPagoSDK/Promo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Promo.swift
@@ -15,7 +15,7 @@ public class Promo : NSObject {
 	public var recommendedMessage : String!
 	public var paymentMethods : [PaymentMethod]!
 	public var legals : String!
-	public var url : String!
+	public var url : String?
 	
 	public class func fromJSON(json : NSDictionary) -> Promo {
 		
@@ -51,17 +51,19 @@ public class Promo : NSObject {
     public func toJSONString() -> String {
         var obj:[String:AnyObject] = [
             "promoId": self.promoId,
-            "issuer" : self.issuer.toJSONString(),
+            "issuer" : self.issuer != nil ? self.issuer.toJSONString() : JSON.null,
             "recommendedMessage" : self.recommendedMessage,
             "legals" : self.legals,
-            "url" : self.url
+            "url" : (self.url != nil && self.url!.characters.count > 0) ? self.url! : ""
         ]
         
-        var pmsJson = ""
-        for pm in self.paymentMethods {
-            pmsJson = pmsJson + pm.toJSONString()
+        if self.paymentMethods != nil && self.paymentMethods.count > 0 {
+            var pmsJson = ""
+            for pm in self.paymentMethods {
+                pmsJson = pmsJson + pm.toJSONString()
+            }
+            obj["payment_methods"] = pmsJson
         }
-        obj["payment_methods"] = pmsJson
 
         return JSON(obj).toString()
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Promo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Promo.swift
@@ -51,18 +51,15 @@ public class Promo : NSObject {
     public func toJSONString() -> String {
         var obj:[String:AnyObject] = [
             "promoId": self.promoId,
-            "issuer" : self.issuer != nil ? self.issuer.toJSONString() : JSON.null,
+            "issuer" : self.issuer != nil ? self.issuer.toJSON().mutableCopyOfTheObject() : JSON.null,
             "recommendedMessage" : self.recommendedMessage,
             "legals" : self.legals,
             "url" : (self.url != nil && self.url!.characters.count > 0) ? self.url! : ""
         ]
         
         if self.paymentMethods != nil && self.paymentMethods.count > 0 {
-            var pmsJson = ""
-            for pm in self.paymentMethods {
-                pmsJson = pmsJson + pm.toJSONString()
-            }
-            obj["payment_methods"] = pmsJson
+            let paymentMethodsArr = self.paymentMethods.map({$0.toJSON()})
+            obj["payment_methods"] = NSArray(array :paymentMethodsArr)
         }
 
         return JSON(obj).toString()

--- a/MercadoPagoSDK/MercadoPagoSDK/SecurityCode.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecurityCode.swift
@@ -30,6 +30,17 @@ public class SecurityCode : NSObject {
         }
         return securityCode
     }
+    
+    public func toJSONString() -> String {
+        let obj:[String:AnyObject] = [
+            "length": self.length,
+            "cardLocation": self.cardLocation == nil ? "" : self.cardLocation!,
+            "mode" : self.mode
+        ]
+        
+        return JSON(obj).toString()
+    }
+
 }
 
 public func ==(obj1: SecurityCode, obj2: SecurityCode) -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/SecurityCode.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecurityCode.swift
@@ -32,15 +32,19 @@ public class SecurityCode : NSObject {
     }
     
     public func toJSONString() -> String {
+        return self.toJSON().toString()
+    }
+
+    public func toJSON() -> JSON {
         let obj:[String:AnyObject] = [
             "length": self.length,
             "cardLocation": self.cardLocation == nil ? "" : self.cardLocation!,
             "mode" : self.mode
         ]
         
-        return JSON(obj).toString()
+        return JSON(obj)
     }
-
+    
 }
 
 public func ==(obj1: SecurityCode, obj2: SecurityCode) -> Bool {


### PR DESCRIPTION
- Fixes en funciones de toJSONString de Card, CardHolder, CardToken, SecurityCode, Promo e InstructionInfo

#### Para evitar errores con GA, las funciones de toJSON siempre tienen que insertar strings como valores en los diccionarios (lease que no sean NSDate, u otro tipo de objeto)