### PR TITLE
Internalization

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -243,8 +243,6 @@
 		150786A41CD7CD1E0034C5B1 /* IdentificationCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 150786A21CD7CD1E0034C5B1 /* IdentificationCardView.swift */; };
 		150786A61CD7CD340034C5B1 /* IdentificationCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 150786A51CD7CD340034C5B1 /* IdentificationCardView.xib */; };
 		150786A71CD7CD340034C5B1 /* IdentificationCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 150786A51CD7CD340034C5B1 /* IdentificationCardView.xib */; };
-		15142CF21D5385570037E504 /* MercadoPagoTracker.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 15142CF01D5385570037E504 /* MercadoPagoTracker.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		15142CF31D5385570037E504 /* MPGoogleAnalytics.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 15142CF11D5385570037E504 /* MPGoogleAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		15142CF51D53855D0037E504 /* Pods_MercadoPagoSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15142CF41D53855D0037E504 /* Pods_MercadoPagoSDK.framework */; };
 		1529D9A51C7DEA4E00880C29 /* CheckoutViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1529D9A41C7DEA4E00880C29 /* CheckoutViewController.xib */; };
 		1529D9A61C7DEA4E00880C29 /* CheckoutViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1529D9A41C7DEA4E00880C29 /* CheckoutViewController.xib */; };
@@ -335,6 +333,8 @@
 		761B89431C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B89401C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.swift */; };
 		761B89441C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 761B89411C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib */; };
 		761B89451C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 761B89411C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib */; };
+		7622C9A11D58D65300BFAA94 /* MercadoPagoTracker.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7622C99F1D58D65300BFAA94 /* MercadoPagoTracker.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7622C9A21D58D65300BFAA94 /* MPGoogleAnalytics.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7622C9A01D58D65300BFAA94 /* MPGoogleAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		762B8C221D19752A00A86097 /* MPFlowBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1D1D19752A00A86097 /* MPFlowBuilder.swift */; };
 		762B8C231D19752A00A86097 /* MPFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1E1D19752A00A86097 /* MPFlowController.swift */; };
 		762B8C241D19752A00A86097 /* MPServicesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1F1D19752A00A86097 /* MPServicesBuilder.swift */; };
@@ -558,8 +558,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				15142CF21D5385570037E504 /* MercadoPagoTracker.framework in CopyFiles */,
-				15142CF31D5385570037E504 /* MPGoogleAnalytics.framework in CopyFiles */,
+				7622C9A11D58D65300BFAA94 /* MercadoPagoTracker.framework in CopyFiles */,
+				7622C9A21D58D65300BFAA94 /* MPGoogleAnalytics.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -693,8 +693,6 @@
 		0FE3E38C1AE7174600C27B97 /* Serializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serializable.swift; sourceTree = "<group>"; };
 		150786A21CD7CD1E0034C5B1 /* IdentificationCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentificationCardView.swift; sourceTree = "<group>"; };
 		150786A51CD7CD340034C5B1 /* IdentificationCardView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IdentificationCardView.xib; sourceTree = "<group>"; };
-		15142CF01D5385570037E504 /* MercadoPagoTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MercadoPagoTracker.framework; path = "/Users/dtejo/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-clouekhgdljdjohihvewaepnmhhy/Build/Products/Debug-iphonesimulator/MercadoPagoTracker/MercadoPagoTracker.framework"; sourceTree = "<absolute>"; };
-		15142CF11D5385570037E504 /* MPGoogleAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MPGoogleAnalytics.framework; path = "/Users/dtejo/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-clouekhgdljdjohihvewaepnmhhy/Build/Products/Debug-iphonesimulator/MPGoogleAnalytics/MPGoogleAnalytics.framework"; sourceTree = "<absolute>"; };
 		15142CF41D53855D0037E504 /* Pods_MercadoPagoSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods_MercadoPagoSDK.framework; path = "../../../../Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-clouekhgdljdjohihvewaepnmhhy/Build/Products/Debug-iphonesimulator/Pods_MercadoPagoSDK.framework"; sourceTree = "<group>"; };
 		1529D9A41C7DEA4E00880C29 /* CheckoutViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CheckoutViewController.xib; sourceTree = "<group>"; };
 		1565B1301CBFD7F100181998 /* GuessingFormTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GuessingFormTest.swift; sourceTree = "<group>"; };
@@ -744,6 +742,8 @@
 		761B89391C625C130015D0BE /* MercadoPagoUIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoUIViewController.swift; sourceTree = "<group>"; };
 		761B89401C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferenceDescriptionTableViewCell.swift; sourceTree = "<group>"; };
 		761B89411C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PreferenceDescriptionTableViewCell.xib; sourceTree = "<group>"; };
+		7622C99F1D58D65300BFAA94 /* MercadoPagoTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MercadoPagoTracker.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-agowycilgfvevqdpjnbljdhlqjht/Build/Products/Debug-iphonesimulator/MercadoPagoTracker/MercadoPagoTracker.framework"; sourceTree = "<absolute>"; };
+		7622C9A01D58D65300BFAA94 /* MPGoogleAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MPGoogleAnalytics.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-agowycilgfvevqdpjnbljdhlqjht/Build/Products/Debug-iphonesimulator/MPGoogleAnalytics/MPGoogleAnalytics.framework"; sourceTree = "<absolute>"; };
 		762B8C1C1D19752A00A86097 /* MercadoPagoContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoContext.swift; sourceTree = "<group>"; };
 		762B8C1D1D19752A00A86097 /* MPFlowBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPFlowBuilder.swift; sourceTree = "<group>"; };
 		762B8C1E1D19752A00A86097 /* MPFlowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPFlowController.swift; sourceTree = "<group>"; };
@@ -907,10 +907,13 @@
 		0F9883001AD2A97A00F750F0 = {
 			isa = PBXGroup;
 			children = (
+<<<<<<< 26703eadf810b1b84861e7717eeaff2468dfc67a
 				0F9883261AD2AA9900F750F0 /* UIKit.framework */,
 				0F9883281AD2AAA100F750F0 /* Foundation.framework */,
 				15142CF01D5385570037E504 /* MercadoPagoTracker.framework */,
 				15142CF11D5385570037E504 /* MPGoogleAnalytics.framework */,
+=======
+>>>>>>> Languages for siteIds
 				0F0749081AED5BAE003DD39D /* Localizable.strings */,
 				0F98830C1AD2A97A00F750F0 /* MercadoPagoSDK */,
 				0F9883191AD2A97A00F750F0 /* MercadoPagoSDKTests */,
@@ -1736,6 +1739,8 @@
 		C21B34312E09C5D174785343 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7622C99F1D58D65300BFAA94 /* MercadoPagoTracker.framework */,
+				7622C9A01D58D65300BFAA94 /* MPGoogleAnalytics.framework */,
 				15142CF41D53855D0037E504 /* Pods_MercadoPagoSDK.framework */,
 			);
 			name = Frameworks;
@@ -2541,7 +2546,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2585,7 +2590,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -2599,6 +2604,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD1C9F6E4E9EDDB95170C225 /* Pods-MercadoPagoSDK.debug.xcconfig */;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					x86_64,
+					i386,
+				);
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -2618,14 +2628,14 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mercadopago.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VALID_ARCHS = "arm64 armv7 armv7s i386";
+				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 			};
 			name = Debug;
 		};
@@ -2633,6 +2643,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 37DB7C1D71C9DE1107904676 /* Pods-MercadoPagoSDK.release.xcconfig */;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					x86_64,
+					i386,
+				);
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
@@ -2652,13 +2667,13 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mercadopago.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				VALID_ARCHS = "arm64 armv7 armv7s i386";
+				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 			};
 			name = Release;
 		};

--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -913,13 +913,6 @@
 		0F9883001AD2A97A00F750F0 = {
 			isa = PBXGroup;
 			children = (
-<<<<<<< 26703eadf810b1b84861e7717eeaff2468dfc67a
-				0F9883261AD2AA9900F750F0 /* UIKit.framework */,
-				0F9883281AD2AAA100F750F0 /* Foundation.framework */,
-				15142CF01D5385570037E504 /* MercadoPagoTracker.framework */,
-				15142CF11D5385570037E504 /* MPGoogleAnalytics.framework */,
-=======
->>>>>>> Languages for siteIds
 				0F0749081AED5BAE003DD39D /* Localizable.strings */,
 				0F98830C1AD2A97A00F750F0 /* MercadoPagoSDK */,
 				0F9883191AD2A97A00F750F0 /* MercadoPagoSDKTests */,

--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -333,8 +333,6 @@
 		761B89431C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B89401C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.swift */; };
 		761B89441C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 761B89411C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib */; };
 		761B89451C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 761B89411C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib */; };
-		7622C9A11D58D65300BFAA94 /* MercadoPagoTracker.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7622C99F1D58D65300BFAA94 /* MercadoPagoTracker.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		7622C9A21D58D65300BFAA94 /* MPGoogleAnalytics.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7622C9A01D58D65300BFAA94 /* MPGoogleAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		762B8C221D19752A00A86097 /* MPFlowBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1D1D19752A00A86097 /* MPFlowBuilder.swift */; };
 		762B8C231D19752A00A86097 /* MPFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1E1D19752A00A86097 /* MPFlowController.swift */; };
 		762B8C241D19752A00A86097 /* MPServicesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1F1D19752A00A86097 /* MPServicesBuilder.swift */; };
@@ -461,6 +459,8 @@
 		76B64B231C75FAFC00300F50 /* SimpleInstructionsWithButtonViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B64B201C75FAFC00300F50 /* SimpleInstructionsWithButtonViewCell.swift */; };
 		76B64B241C75FAFC00300F50 /* SimpleInstructionsWithButtonViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76B64B211C75FAFC00300F50 /* SimpleInstructionsWithButtonViewCell.xib */; };
 		76B64B251C75FAFC00300F50 /* SimpleInstructionsWithButtonViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76B64B211C75FAFC00300F50 /* SimpleInstructionsWithButtonViewCell.xib */; };
+		76C1C1031D59208A002B016F /* MercadoPagoTracker.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 76C1C1011D59208A002B016F /* MercadoPagoTracker.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		76C1C1041D59208A002B016F /* MPGoogleAnalytics.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 76C1C1021D59208A002B016F /* MPGoogleAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		76C834131D4FD8C2003C4717 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		76C834411D510CD4003C4717 /* AmountInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C834401D510CD4003C4717 /* AmountInfo.swift */; };
 		76D00A011CA2CA3E00F52BC6 /* UtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D00A001CA2CA3E00F52BC6 /* UtilsTest.swift */; };
@@ -539,6 +539,8 @@
 		76FD24881C5BFEA1008C5DC0 /* PaymentMethod.plist in Resources */ = {isa = PBXBuildFile; fileRef = 76FD24771C5BFEA1008C5DC0 /* PaymentMethod.plist */; };
 		76FD24891C5BFEA1008C5DC0 /* TextFieldsEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FD24781C5BFEA1008C5DC0 /* TextFieldsEffects.swift */; };
 		76FD248A1C5BFEA1008C5DC0 /* TextFieldsEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FD24781C5BFEA1008C5DC0 /* TextFieldsEffects.swift */; };
+		8C9C867E02CCDF7E77AF76FC /* Pods_MercadoPagoSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDC20F2B89DC9B4B55961266 /* Pods_MercadoPagoSDKTests.framework */; };
+		A1504846E77D9FB0A2AB756A /* Pods_MercadoPagoSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D47AA26579C73533B165AC6 /* Pods_MercadoPagoSDK.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -558,8 +560,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				7622C9A11D58D65300BFAA94 /* MercadoPagoTracker.framework in CopyFiles */,
-				7622C9A21D58D65300BFAA94 /* MPGoogleAnalytics.framework in CopyFiles */,
+				76C1C1031D59208A002B016F /* MercadoPagoTracker.framework in CopyFiles */,
+				76C1C1041D59208A002B016F /* MPGoogleAnalytics.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -742,8 +744,6 @@
 		761B89391C625C130015D0BE /* MercadoPagoUIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoUIViewController.swift; sourceTree = "<group>"; };
 		761B89401C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferenceDescriptionTableViewCell.swift; sourceTree = "<group>"; };
 		761B89411C637DBD0015D0BE /* PreferenceDescriptionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PreferenceDescriptionTableViewCell.xib; sourceTree = "<group>"; };
-		7622C99F1D58D65300BFAA94 /* MercadoPagoTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MercadoPagoTracker.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-agowycilgfvevqdpjnbljdhlqjht/Build/Products/Debug-iphonesimulator/MercadoPagoTracker/MercadoPagoTracker.framework"; sourceTree = "<absolute>"; };
-		7622C9A01D58D65300BFAA94 /* MPGoogleAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MPGoogleAnalytics.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-agowycilgfvevqdpjnbljdhlqjht/Build/Products/Debug-iphonesimulator/MPGoogleAnalytics/MPGoogleAnalytics.framework"; sourceTree = "<absolute>"; };
 		762B8C1C1D19752A00A86097 /* MercadoPagoContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoContext.swift; sourceTree = "<group>"; };
 		762B8C1D1D19752A00A86097 /* MPFlowBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPFlowBuilder.swift; sourceTree = "<group>"; };
 		762B8C1E1D19752A00A86097 /* MPFlowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPFlowController.swift; sourceTree = "<group>"; };
@@ -820,6 +820,8 @@
 		76B64B1B1C75F91D00300F50 /* InstructionsWithButtonViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InstructionsWithButtonViewCell.xib; sourceTree = "<group>"; };
 		76B64B201C75FAFC00300F50 /* SimpleInstructionsWithButtonViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleInstructionsWithButtonViewCell.swift; sourceTree = "<group>"; };
 		76B64B211C75FAFC00300F50 /* SimpleInstructionsWithButtonViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SimpleInstructionsWithButtonViewCell.xib; sourceTree = "<group>"; };
+		76C1C1011D59208A002B016F /* MercadoPagoTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MercadoPagoTracker.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-agowycilgfvevqdpjnbljdhlqjht/Build/Products/Debug-iphoneos/MercadoPagoTracker/MercadoPagoTracker.framework"; sourceTree = "<absolute>"; };
+		76C1C1021D59208A002B016F /* MPGoogleAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MPGoogleAnalytics.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-agowycilgfvevqdpjnbljdhlqjht/Build/Products/Debug-iphoneos/MPGoogleAnalytics/MPGoogleAnalytics.framework"; sourceTree = "<absolute>"; };
 		76C834401D510CD4003C4717 /* AmountInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmountInfo.swift; sourceTree = "<group>"; };
 		76D00A001CA2CA3E00F52BC6 /* UtilsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtilsTest.swift; sourceTree = "<group>"; };
 		76D00A0D1CB5917600F52BC6 /* MPCellValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPCellValidator.swift; sourceTree = "<group>"; };
@@ -879,7 +881,9 @@
 		76FD24761C5BFEA1008C5DC0 /* HoshiTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoshiTextField.swift; sourceTree = "<group>"; };
 		76FD24771C5BFEA1008C5DC0 /* PaymentMethod.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PaymentMethod.plist; sourceTree = "<group>"; };
 		76FD24781C5BFEA1008C5DC0 /* TextFieldsEffects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldsEffects.swift; sourceTree = "<group>"; };
+		9D47AA26579C73533B165AC6 /* Pods_MercadoPagoSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD1C9F6E4E9EDDB95170C225 /* Pods-MercadoPagoSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDK.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK.debug.xcconfig"; sourceTree = "<group>"; };
+		EDC20F2B89DC9B4B55961266 /* Pods_MercadoPagoSDKTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDKTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -890,6 +894,7 @@
 				0F9883271AD2AA9900F750F0 /* UIKit.framework in Frameworks */,
 				0F9883291AD2AAA100F750F0 /* Foundation.framework in Frameworks */,
 				15142CF51D53855D0037E504 /* Pods_MercadoPagoSDK.framework in Frameworks */,
+				A1504846E77D9FB0A2AB756A /* Pods_MercadoPagoSDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -898,6 +903,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0F9883161AD2A97A00F750F0 /* MercadoPagoSDK.framework in Frameworks */,
+				8C9C867E02CCDF7E77AF76FC /* Pods_MercadoPagoSDKTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1739,9 +1745,11 @@
 		C21B34312E09C5D174785343 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				7622C99F1D58D65300BFAA94 /* MercadoPagoTracker.framework */,
-				7622C9A01D58D65300BFAA94 /* MPGoogleAnalytics.framework */,
+				76C1C1011D59208A002B016F /* MercadoPagoTracker.framework */,
+				76C1C1021D59208A002B016F /* MPGoogleAnalytics.framework */,
 				15142CF41D53855D0037E504 /* Pods_MercadoPagoSDK.framework */,
+				9D47AA26579C73533B165AC6 /* Pods_MercadoPagoSDK.framework */,
+				EDC20F2B89DC9B4B55961266 /* Pods_MercadoPagoSDKTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -2628,7 +2636,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mercadopago.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -2667,7 +2675,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mercadopago.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";

--- a/MercadoPagoSDK/MercadoPagoSDK/ApprovedPaymentBodyTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ApprovedPaymentBodyTableViewCell.swift
@@ -55,9 +55,10 @@ class ApprovedPaymentBodyTableViewCell: CallbackCancelTableViewCell, CongratsFil
         if payment.feesDetails != nil && payment.feesDetails.count > 0 {
             let financingFee = payment.feesDetails.filter({ return $0.isFinancingFeeType()})
             if financingFee.count > 0 {
+                let currency = MercadoPagoContext.getCurrency()
                 if payment.transactionDetails != nil && payment.transactionDetails.totalPaidAmount > 0 && payment.installments > 0 {
                     additionalString.appendAttributedString(NSAttributedString(string : "( ", attributes: additionalTextAttributes))
-                    additionalString.appendAttributedString(Utils.getAttributedAmount(payment.transactionDetails.totalPaidAmount, thousandSeparator: ".", decimalSeparator: ",", currencySymbol: "$", color: greenLabelColor, fontSize : 14, baselineOffset: 3))
+                    additionalString.appendAttributedString(Utils.getAttributedAmount(payment.transactionDetails.totalPaidAmount, thousandSeparator: String(currency.thousandsSeparator), decimalSeparator: String(currency.decimalSeparator), currencySymbol:currency.symbol, color: greenLabelColor, fontSize : 14, baselineOffset: 3))
                     additionalString.appendAttributedString(NSAttributedString(string : " )", attributes: additionalTextAttributes))
                 } else {
                     self.amountDescription.hidden = true

--- a/MercadoPagoSDK/MercadoPagoSDK/AuthorizePaymentHeaderTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/AuthorizePaymentHeaderTableViewCell.swift
@@ -68,8 +68,9 @@ class AuthorizePaymentHeaderTableViewCell: UITableViewCell, CongratsFillmentDele
             return NSMutableAttributedString(string: "Debes autorizar el pago ante tu tarjeta".localized)
         }
         
+        let currency = MercadoPagoContext.getCurrency()
         let title = NSMutableAttributedString(string: "Debes autorizar ante ".localized + paymentMethod.name.localized + " el pago de ".localized)
-        let attributedAmount = Utils.getAttributedAmount(payment.transactionDetails.totalPaidAmount, thousandSeparator: ".", decimalSeparator: ",", currencySymbol: "$", color: UIColor(red: 102, green: 102, blue: 102))
+        let attributedAmount = Utils.getAttributedAmount(payment.transactionDetails.totalPaidAmount, thousandSeparator: String(currency.thousandsSeparator), decimalSeparator: String(currency.decimalSeparator), currencySymbol: String(currency.symbol), color: UIColor(red: 102, green: 102, blue: 102))
         title.appendAttributedString(attributedAmount)
         title.appendAttributedString(NSMutableAttributedString(string : " a MercadoPago".localized))
         return title

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -274,7 +274,7 @@ public class CheckoutViewController: MercadoPagoUIViewController, UITableViewDat
     internal func startPaymentVault(animated : Bool = false){
         self.registerAllCells()
         
-        let paymentVaultVC = MPFlowBuilder.startPaymentVaultInCheckout(self.preference!.getAmount(), currencyId: self.preference!.getCurrencyId(), paymentPreference: self.preference!.getPaymentSettings(), paymentMethodSearch: self.paymentMethodSearch!, callback: { (paymentMethod, token, issuer, payerCost) in
+        let paymentVaultVC = MPFlowBuilder.startPaymentVaultInCheckout(self.preference!.getAmount(), paymentPreference: self.preference!.getPaymentSettings(), paymentMethodSearch: self.paymentMethodSearch!, callback: { (paymentMethod, token, issuer, payerCost) in
             self.paymentVaultCallback(paymentMethod, token : token, issuer : issuer, payerCost : payerCost, animated : animated)
         })
         

--- a/MercadoPagoSDK/MercadoPagoSDK/ExitButtonTableViewCell.xib
+++ b/MercadoPagoSDK/MercadoPagoSDK/ExitButtonTableViewCell.xib
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -16,14 +15,14 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ymm-p4-4K8" customClass="MPButton" customModule="MercadoPagoSDK" customModuleProvider="target">
-                        <rect key="frame" x="102" y="8" width="120" height="30"/>
+                        <rect key="frame" x="97" y="8" width="130" height="30"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="120" id="6Jh-Mf-4re"/>
+                            <constraint firstAttribute="width" constant="130" id="6Jh-Mf-4re"/>
                             <constraint firstAttribute="height" constant="30" id="km2-Ra-PMo"/>
                         </constraints>
                         <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
-                        <state key="normal" title="Cancelar pago">
+                        <state key="normal" title="Cancelar Pago">
                             <color key="titleColor" red="0.0" green="0.40000000000000002" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                         </state>
                     </button>

--- a/MercadoPagoSDK/MercadoPagoSDK/InstallmentSelectionTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/InstallmentSelectionTableViewCell.swift
@@ -29,7 +29,8 @@ class InstallmentSelectionTableViewCell: UITableViewCell {
         let additionalText = NSMutableAttributedString(string : "")
         if payerCost.installmentRate > 0 && payerCost.installments > 1 {
             let totalAmountStr = NSMutableAttributedString(string:" ( ", attributes: totalAttributes)
-            let totalAmount = Utils.getAttributedAmount(payerCost.totalAmount, thousandSeparator: ".", decimalSeparator: ",", currencySymbol: "$" , color:mpLightGrayColor)
+            let currency = MercadoPagoContext.getCurrency()
+            let totalAmount = Utils.getAttributedAmount(payerCost.totalAmount, thousandSeparator: String(currency.thousandsSeparator), decimalSeparator: String(currency.decimalSeparator), currencySymbol: String(currency.symbol), color:mpLightGrayColor)
             totalAmountStr.appendAttributedString(totalAmount)
             totalAmountStr.appendAttributedString(NSMutableAttributedString(string:" ) ", attributes: totalAttributes))
             additionalText.appendAttributedString(totalAmountStr)

--- a/MercadoPagoSDK/MercadoPagoSDK/MPFlowBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPFlowBuilder.swift
@@ -27,9 +27,9 @@ public class MPFlowBuilder : NSObject {
     }
     
     
-    public class func startPaymentVaultViewController(amount: Double, currencyId : String!,paymentPreference : PaymentPreference? = nil, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost : PayerCost?) -> Void) -> MPNavigationController {
+    public class func startPaymentVaultViewController(amount: Double, paymentPreference : PaymentPreference? = nil, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost : PayerCost?) -> Void) -> MPNavigationController {
          MercadoPagoContext.initFlavor2()
-        let paymentVault = PaymentVaultViewController(amount: amount, currencyId : currencyId, paymentPreference : paymentPreference, callback: callback)
+        let paymentVault = PaymentVaultViewController(amount: amount, paymentPreference : paymentPreference, callback: callback)
 
         paymentVault.callback = {(paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost : PayerCost?) -> Void in
             paymentVault.dismissViewControllerAnimated(true, completion: { () -> Void in
@@ -41,9 +41,9 @@ public class MPFlowBuilder : NSObject {
         return MPFlowController.createNavigationControllerWith(paymentVault)
     }
     
-    internal class func startPaymentVaultInCheckout(amount: Double, currencyId : String!, paymentPreference: PaymentPreference?, paymentMethodSearch : PaymentMethodSearch, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost : PayerCost?) -> Void) -> MPNavigationController {
+    internal class func startPaymentVaultInCheckout(amount: Double, paymentPreference: PaymentPreference?, paymentMethodSearch : PaymentMethodSearch, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost : PayerCost?) -> Void) -> MPNavigationController {
         MercadoPagoContext.initFlavor2()
-        let paymentVault = PaymentVaultViewController(amount: amount, currencyId : currencyId, paymentPreference: paymentPreference, paymentMethodSearchItem: paymentMethodSearch.groups, paymentMethods: paymentMethodSearch.paymentMethods, tintColor: true, callback: callback)
+        let paymentVault = PaymentVaultViewController(amount: amount, paymentPreference: paymentPreference, paymentMethodSearchItem: paymentMethodSearch.groups, paymentMethods: paymentMethodSearch.paymentMethods, tintColor: true, callback: callback)
         
         paymentVault.modalTransitionStyle = .CrossDissolve
         return MPFlowController.createNavigationControllerWith(paymentVault)

--- a/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
@@ -226,8 +226,7 @@ public class MPServicesBuilder : NSObject {
         MPTracker.trackEvent(MercadoPagoContext.sharedInstance, action: "GET_PREFERENCE", result: nil)
         let preferenceService = PreferenceService()
         preferenceService.getPreference(preferenceId, success: { (preference : CheckoutPreference) in
-            
-            MercadoPagoContext.sharedInstance.setSiteID(preference.siteId)
+            MercadoPagoContext.setSite(MercadoPagoContext.Site.getByName(preference.siteId))
             success(preference: preference)
             }, failure: failure)
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
@@ -227,7 +227,7 @@ public class MPServicesBuilder : NSObject {
         let preferenceService = PreferenceService()
         preferenceService.getPreference(preferenceId, success: { (preference : CheckoutPreference) in
             
-            MercadoPagoContext.sharedInstance.setSideID(preference.siteId)
+            MercadoPagoContext.sharedInstance.setSiteID(preference.siteId)
             success(preference: preference)
             }, failure: failure)
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
@@ -226,7 +226,7 @@ public class MPServicesBuilder : NSObject {
         MPTracker.trackEvent(MercadoPagoContext.sharedInstance, action: "GET_PREFERENCE", result: nil)
         let preferenceService = PreferenceService()
         preferenceService.getPreference(preferenceId, success: { (preference : CheckoutPreference) in
-            MercadoPagoContext.setSite(MercadoPagoContext.Site.getByName(preference.siteId))
+            MercadoPagoContext.setSiteID(preference.siteId)
             success(preference: preference)
             }, failure: failure)
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -32,11 +32,11 @@ public class MercadoPagoContext : NSObject, MPTrackerDelegate {
     
     var payment_key : String = ""
     
-    var site = Site.MLA
+    var site : Site!
     
-    var language = "es"
+    var language : String!
     
-    var currency = CurrenciesUtil.getCurrencyFor("ARS")!
+    var currency : Currency!
     
     public class var PUBLIC_KEY : String {
         return "public_key"

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -156,6 +156,7 @@ public class MercadoPagoContext : NSObject, MPTrackerDelegate {
     private override init() {
     
         MercadoPagoUIViewController.loadFont(MercadoPago.DEFAULT_FONT_NAME)
+        MercadoPagoContext.setSite(Site.MLA)
     }
     
     public class func setPrivateKey(private_key : String){

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -72,53 +72,25 @@ public class MercadoPagoContext : NSObject, MPTrackerDelegate {
         "MLM" : ["language" : "es", "currency" : "MXN"]
      ]
 
-    public enum Site : Int {
-        case MLA = 1
-        case MLB = 2
-        case MLM = 3
-        case MLV = 4
-        case MLU = 5
-        case MPE = 6
-        case MLC = 7
-        case MCO = 8
-        
-        func getName()->String!{
-            switch self.rawValue {
-            case 1 : return "MLA"
-            case 2 : return "MLB"
-            case 3 : return "MLM"
-            case 4 : return "MLV"
-            case 5 : return "MLU"
-            case 6 : return "MPE"
-            case 7 : return "MLC"
-            case 8 : return "MCO"
-            default : return "MLA"
-            }
-        }
-        
-        static func getByName(siteId : String) -> Site {
-            switch siteId {
-            case "MLA" : return MLA
-            case "MLB" : return MLB
-            case "MLM" : return MLM
-            case "MLV" : return MLV
-            case "MLU" : return MLU
-            case "MPE" : return MPE
-            case "MLC" : return MLC
-            case "MCO" : return MCO
-            default : return MLA
-            }
-        }
+    public enum Site : String {
+        case MLA = "MLA"
+        case MLB = "MLB"
+        case MLM = "MLM"
+        case MLV = "MLV"
+        case MLU = "MLU"
+        case MPE = "MPE"
+        case MLC = "MLC"
+        case MCO = "MCO"
     }
     
     
     
     public func siteId() -> String! {
-        return site.getName()
+        return site.rawValue
     }
     
     public class func setSite(site : Site) {
-        let siteConfig = siteIdsSettings[site.getName()]
+        let siteConfig = siteIdsSettings[site.rawValue]
         if siteConfig != nil {
             sharedInstance.site = site
             sharedInstance.language = siteConfig!["language"] as! String
@@ -130,7 +102,10 @@ public class MercadoPagoContext : NSObject, MPTrackerDelegate {
     }
     
     public class func setSiteID(siteId : String) {
-        MercadoPagoContext.setSite(Site.getByName(siteId))
+        let site = Site(rawValue: siteId)
+        if site != nil {
+            MercadoPagoContext.setSite(site!)
+        }
     }
     
     public static func getLanguage() -> String {

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -59,31 +59,34 @@ public class MercadoPagoContext : NSObject, MPTrackerDelegate {
         return "1.0.0"
     }
  
-    var site = GAKey.MLA
-    
+    let siteIdsSettings : [String : NSDictionary] = [
+        "MLA" : ["language" : "es"],
+        "MLB" : ["language" : "pt"],
+        "MLC" : ["language" : "es"],
+        "MLM" : ["language" : "es"]
+     ]
+
+    var gaSiteId = GAKey.MLA
+    var language = "es"
+    var mpSiteId = "MLA"
     
     public func siteId() -> GAKey!{
-        return site
+        return gaSiteId
     }
-    public func setSideID(siteId : String){
-        switch siteId {
-        case "MLA":
-            site = GAKey.MLA
-        case "MLB":
-            site = GAKey.MLB
-        case "MLM":
-            site = GAKey.MLM
-        case "MLC":
-            site = GAKey.MLC
-        case "MCO":
-            site = GAKey.MCO
-        case "MLV":
-            site = GAKey.MLV
-        default:
-             site = GAKey.MLA
+    
+    public func setSiteID(siteId : String) {
+        let siteIdConfig = siteIdsSettings[siteId]
+        if siteIdConfig != nil {
+            self.gaSiteId = siteIdConfig!["GASiteId"] as! GAKey
+            self.language = siteIdConfig!["language"] as! String
+            self.mpSiteId = siteId
         }
-  
     }
+    
+    public static func getLanguage() -> String {
+        return sharedInstance.language
+    }
+    
     public func publicKey() -> String!{
         return self.public_key
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -32,6 +32,12 @@ public class MercadoPagoContext : NSObject, MPTrackerDelegate {
     
     var payment_key : String = ""
     
+    var site = Site.MLA
+    
+    var language = "es"
+    
+    var currency = CurrenciesUtil.getCurrencyFor("ARS")!
+    
     public class var PUBLIC_KEY : String {
         return "public_key"
     }
@@ -59,32 +65,80 @@ public class MercadoPagoContext : NSObject, MPTrackerDelegate {
         return "1.0.0"
     }
  
-    let siteIdsSettings : [String : NSDictionary] = [
-        "MLA" : ["language" : "es"],
-        "MLB" : ["language" : "pt"],
-        "MLC" : ["language" : "es"],
-        "MLM" : ["language" : "es"]
+    static let siteIdsSettings : [String : NSDictionary] = [
+        "MLA" : ["language" : "es", "currency" : "ARS"],
+        "MLB" : ["language" : "pt", "currency" : "BRL"],
+        "MLC" : ["language" : "es", "currency" : "CLP"],
+        "MLM" : ["language" : "es", "currency" : "MXN"]
      ]
 
-    var gaSiteId = GAKey.MLA
-    var language = "es"
-    var mpSiteId = "MLA"
-    
-    public func siteId() -> GAKey!{
-        return gaSiteId
+    public enum Site : Int {
+        case MLA = 1
+        case MLB = 2
+        case MLM = 3
+        case MLV = 4
+        case MLU = 5
+        case MPE = 6
+        case MLC = 7
+        case MCO = 8
+        
+        func getName()->String!{
+            switch self.rawValue {
+            case 1 : return "MLA"
+            case 2 : return "MLB"
+            case 3 : return "MLM"
+            case 4 : return "MLV"
+            case 5 : return "MLU"
+            case 6 : return "MPE"
+            case 7 : return "MLC"
+            case 8 : return "MCO"
+            default : return "MLA"
+            }
+        }
+        
+        static func getByName(siteId : String) -> Site {
+            switch siteId {
+            case "MLA" : return MLA
+            case "MLB" : return MLB
+            case "MLM" : return MLM
+            case "MLV" : return MLV
+            case "MLU" : return MLU
+            case "MPE" : return MPE
+            case "MLC" : return MLC
+            case "MCO" : return MCO
+            default : return MLA
+            }
+        }
     }
     
-    public func setSiteID(siteId : String) {
-        let siteIdConfig = siteIdsSettings[siteId]
-        if siteIdConfig != nil {
-            self.gaSiteId = siteIdConfig!["GASiteId"] as! GAKey
-            self.language = siteIdConfig!["language"] as! String
-            self.mpSiteId = siteId
+    
+    
+    public func siteId() -> String! {
+        return site.getName()
+    }
+    
+    public class func setSite(site : Site) {
+        let siteConfig = siteIdsSettings[site.getName()]
+        if siteConfig != nil {
+            sharedInstance.site = site
+            sharedInstance.language = siteConfig!["language"] as! String
+            let currency = CurrenciesUtil.getCurrencyFor(siteConfig!["currency"] as? String)
+            if currency != nil {
+                sharedInstance.currency = currency!
+            }
         }
+    }
+    
+    public class func setSiteID(siteId : String) {
+        MercadoPagoContext.setSite(Site.getByName(siteId))
     }
     
     public static func getLanguage() -> String {
         return sharedInstance.language
+    }
+    
+    public static func getCurrency() -> Currency {
+        return sharedInstance.currency
     }
     
     public func publicKey() -> String!{

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
@@ -14,11 +14,11 @@ public class PaymentVaultViewController: MercadoPagoUIViewController, UITableVie
     var merchantBaseUrl : String!
     var merchantAccessToken : String!
     var publicKey : String!
+    var currency : Currency!
     var amount : Double!
-    var currencyId : String!
     var paymentPreference : PaymentPreference?
     var callback : ((paymentMethod: PaymentMethod, token:Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void)!
-
+    
     var defaultInstallments : Int?
     var installments : Int?
 
@@ -36,7 +36,7 @@ public class PaymentVaultViewController: MercadoPagoUIViewController, UITableVie
     @IBOutlet weak var paymentsTable: UITableView!
     
 
-    internal init(amount: Double, currencyId : String, paymentPreference : PaymentPreference?, paymentMethodSearchItem : [PaymentMethodSearchItem], paymentMethods: [PaymentMethod], title: String? = "", tintColor : Bool = false, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void, callbackCancel : (Void -> Void)? = nil) {
+    internal init(amount: Double, paymentPreference : PaymentPreference?, paymentMethodSearchItem : [PaymentMethodSearchItem], paymentMethods: [PaymentMethod], title: String? = "", tintColor : Bool = false, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void, callbackCancel : (Void -> Void)? = nil) {
 
         super.init(nibName: "PaymentVaultViewController", bundle: bundle)
         
@@ -47,10 +47,10 @@ public class PaymentVaultViewController: MercadoPagoUIViewController, UITableVie
         //Vaidar que no excluyo todos los payment method
         
         self.publicKey = MercadoPagoContext.publicKey()
+        self.currency = MercadoPagoContext.getCurrency()
         self.title = title
         self.tintColor = tintColor
         self.amount = amount // mayor o igual a 0
-        self.currencyId = currencyId
         self.paymentPreference = paymentPreference
 
         self.currentPaymentMethodSearch = paymentMethodSearchItem
@@ -72,14 +72,14 @@ public class PaymentVaultViewController: MercadoPagoUIViewController, UITableVie
         }
     }
     
-    init(amount: Double, currencyId : String, paymentPreference : PaymentPreference?, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void, callbackCancel : (Void -> Void)? = nil) {
+    init(amount: Double, paymentPreference : PaymentPreference?, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void, callbackCancel : (Void -> Void)? = nil) {
         super.init(nibName: "PaymentVaultViewController", bundle: bundle)
         
         self.merchantBaseUrl = MercadoPagoContext.baseURL()
         self.merchantAccessToken = MercadoPagoContext.merchantAccessToken()
         self.publicKey = MercadoPagoContext.publicKey()
+        self.currency = MercadoPagoContext.getCurrency()
         self.amount = amount
-        self.currencyId = currencyId
         self.paymentPreference = paymentPreference
         self.callback = callback
         
@@ -125,9 +125,6 @@ public class PaymentVaultViewController: MercadoPagoUIViewController, UITableVie
     public override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
         self.loadPaymentMethodSearch()
-        
-      
-        
     }
     
     public func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -177,7 +174,7 @@ public class PaymentVaultViewController: MercadoPagoUIViewController, UITableVie
         switch indexPath.section {
             case 0 :
                 let preferenceDescriptionCell = self.paymentsTable.dequeueReusableCellWithIdentifier("preferenceDescriptionCell") as! PreferenceDescriptionTableViewCell
-                preferenceDescriptionCell.fillRowWithSettings(self.amount, currency: CurrenciesUtil.getCurrencyFor(self.currencyId)!)
+                preferenceDescriptionCell.fillRowWithSettings(self.amount, currency: self.currency)
                 return preferenceDescriptionCell
             default :
                 let currentPaymentMethod = self.currentPaymentMethodSearch[indexPath.row]
@@ -202,7 +199,7 @@ public class PaymentVaultViewController: MercadoPagoUIViewController, UITableVie
         if indexPath.section == 1 {
             self.paymentsTable.deselectRowAtIndexPath(indexPath, animated: true)
             if (paymentSearchItemSelected.children.count > 0) {
-                let paymentVault = PaymentVaultViewController(amount: self.amount, currencyId : self.currencyId, paymentPreference: paymentPreference, paymentMethodSearchItem: paymentSearchItemSelected.children, paymentMethods : self.paymentMethods, title:paymentSearchItemSelected.childrenHeader, callback: { (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void in
+                let paymentVault = PaymentVaultViewController(amount: self.amount, paymentPreference: paymentPreference, paymentMethodSearchItem: paymentSearchItemSelected.children, paymentMethods : self.paymentMethods, title:paymentSearchItemSelected.childrenHeader, callback: { (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void in
                     self.callback(paymentMethod: paymentMethod, token: token, issuer: issuer, payerCost: payerCost)
                 })
                 paymentVault.isRoot = false

--- a/MercadoPagoSDK/MercadoPagoSDK/String+Additions.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/String+Additions.swift
@@ -15,7 +15,10 @@ extension String {
 		if bundle == nil {
 			bundle = NSBundle.mainBundle()
 		}
-		return NSLocalizedString(self, tableName: nil, bundle: bundle!, value: "", comment: "")
+        let currentLanguage = MercadoPagoContext.getLanguage()
+        let path = bundle!.pathForResource(currentLanguage, ofType : "lproj")
+        let languageBundle = NSBundle(path : path!)
+        return languageBundle!.localizedStringForKey(self, value : "", table : nil)
 	}
 	
     public func existsLocalized() -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/TermsAndConditionsViewCell.xib
+++ b/MercadoPagoSDK/MercadoPagoSDK/TermsAndConditionsViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>

--- a/MercadoPagoSDK/Podfile
+++ b/MercadoPagoSDK/Podfile
@@ -4,7 +4,7 @@
 target 'MercadoPagoSDK' do
   # Comment this line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
-pod 'MercadoPagoTracker', '0.8.13' 
+pod 'MercadoPagoTracker', '0.8.15' 
   # Pods for MercadoPagoSDK
 
   target 'MercadoPagoSDKTests' do

--- a/MercadoPagoSDK/Pods/MercadoPagoTracker/MPTracker/GATracker.swift
+++ b/MercadoPagoSDK/Pods/MercadoPagoTracker/MPTracker/GATracker.swift
@@ -59,7 +59,7 @@ public class GATracker: NSObject {
         eventTracker.set(paymentInformer.statusDetail(), forKey: GAIFields.customDimensionForIndex(PaymentTrackInfo.PAYMENT_STATUS_DETAIL))
         eventTracker.set(paymentInformer.typeId(), forKey: GAIFields.customDimensionForIndex(PaymentTrackInfo.PAYMENT_TYPE_ID))
 
-         tracker.send(eventTracker.build() as! [NSObject : AnyObject])
+         tracker.send(eventTracker.build() as [NSObject : AnyObject])
     }
     
     internal func trackEvent(category: String!, action: String!, label: String!, value: NSNumber = 0){

--- a/MercadoPagoSDK/Pods/MercadoPagoTracker/MPTracker/MPTracker.swift
+++ b/MercadoPagoSDK/Pods/MercadoPagoTracker/MPTracker/MPTracker.swift
@@ -20,6 +20,26 @@ public enum GAKey : String {
     case MLC = "UA-46085697-7"
     case MCO = "UA-46087162-10"
     case MLV = "UA-46090035-10"
+    
+    
+    static func parseToGAKey(gakeyString : String) -> GAKey{
+        switch gakeyString {
+        case "MLA":
+            return GAKey.MLA
+        case "MLB":
+            return GAKey.MLB
+        case "MLM":
+            return GAKey.MLM
+        case "MLC":
+            return GAKey.MLC
+        case "MCO":
+            return GAKey.MCO
+        case "MLV":
+            return GAKey.MLV
+        default:
+            return GAKey.MLA
+        }
+    }
 }
 
 
@@ -29,7 +49,7 @@ public protocol MPTrackerDelegate {
     func framework() -> String!
     func sdkVersion() -> String!
     func publicKey() -> String!
-    func siteId() -> GAKey!
+    func siteId() -> String!
 
 }
 
@@ -56,7 +76,7 @@ public class MPTracker {
     
     private class func initialize (mpDelegate : MPTrackerDelegate!){
         MPTracker.initialized = true
-        siteGAKey = mpDelegate.siteId()
+        siteGAKey = GAKey.parseToGAKey(mpDelegate.siteId())
         GATracker.sharedInstance.initialized(flowTrackInfo(mpDelegate), gaKey: siteGAKey)
         MPTracker.flavor = mpDelegate.flavor()
     }

--- a/MercadoPagoSDK/Pods/MercadoPagoTracker/MPTracker/PaymentTracker.swift
+++ b/MercadoPagoSDK/Pods/MercadoPagoTracker/MPTracker/PaymentTracker.swift
@@ -22,7 +22,7 @@ public class PaymentTracker: NSObject {
 
     public class func trackToken(token: String!, delegate : MPTrackerDelegate!){
         
-        let obj:[String:AnyObject] = ["public_key": delegate.publicKey() , "token":token!,"sdk_flavor":(delegate.flavor()?.rawValue)!,"sdk_platform":"iOS","sdk_type":"native","sdk_version":delegate.sdkVersion(),"sdk_framework":"","site_id":siteAlias(delegate)]
+        let obj:[String:AnyObject] = ["public_key": delegate.publicKey() , "token":token!,"sdk_flavor":(delegate.flavor()?.rawValue)!,"sdk_platform":"iOS","sdk_type":"native","sdk_version":delegate.sdkVersion(),"sdk_framework":"","site_id":delegate.siteId()]
             
         self.request(PaymentTracker.MP_TRACK_TOKEN_URL, params: nil, body: JSON(obj).toString(), method: "POST", headers: nil, success: { (jsonResult) -> Void in
             
@@ -30,31 +30,11 @@ public class PaymentTracker: NSObject {
                 
         }
     }
-    
-    private class func siteAlias(delegate : MPTrackerDelegate!) -> String{
-        switch String(delegate.siteId()) {
-        case "MLA":
-            return "MLA"
-        case "MLB":
-            return "MLB"
-        case "MLM":
-            return "MLM"
-        case "MLC":
-            return "MLC"
-        case "MCO":
-            return "MCO"
-        case "MLV":
-            return "MLV"
-        default:
-            return "MLA"
-        }
-        
-    }
- 
+   
     
     public class func trackPaymentOff(paymentId: String!, delegate : MPTrackerDelegate!){
         
-        let obj:[String:AnyObject] = ["public_key":delegate.publicKey() , "payment_id":paymentId!,"sdk_flavor":(delegate.flavor()?.rawValue)!,"sdk_platform":"iOS","sdk_type":"native","sdk_version":delegate.sdkVersion(),"sdk_framework":"","site_id" :siteAlias(delegate)]
+        let obj:[String:AnyObject] = ["public_key":delegate.publicKey() , "payment_id":paymentId!,"sdk_flavor":(delegate.flavor()?.rawValue)!,"sdk_platform":"iOS","sdk_type":"native","sdk_version":delegate.sdkVersion(),"sdk_framework":"","site_id" :delegate.siteId()]
         
         self.request(PaymentTracker.MP_TRACK_PAYMENTOFF_URL, params: nil, body: JSON(obj).toString(), method: "POST", headers: nil, success: { (jsonResult) -> Void in
             

--- a/MercadoPagoSDK/Pods/Pods.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/Pods/Pods.xcodeproj/project.pbxproj
@@ -595,6 +595,45 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		05A8CCE8A29F51C87AB1E8BF6FDCB2CD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 07AC03BA6BE6EB8914FFFD602DEFC69F /* Pods-MercadoPagoSDK.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					i386,
+					x86_64,
+				);
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-MercadoPagoSDK/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Pods_MercadoPagoSDK;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		0723C61906F79877ED3653A83453E159 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2EC83B67FFFB22DCDEF07833CE63377D /* Pods-MercadoPagoSDKTests.release.xcconfig */;
@@ -629,11 +668,15 @@
 			};
 			name = Release;
 		};
-		1B3A6F5E3768F0D30CADCCBF67BCA300 /* Release */ = {
+		16327D670AE63AFE2F2C657292AD019B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3139DC4248D8CBB2067E80913AB1C361 /* MPGoogleAnalytics.xcconfig */;
+			baseConfigurationReference = 5ED84F4424647196C3F742656AF99F7D /* Pods-MercadoPagoSDK.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					i386,
+					x86_64,
+				);
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -643,14 +686,18 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/MPGoogleAnalytics/MPGoogleAnalytics-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/MPGoogleAnalytics/Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Pods-MercadoPagoSDK/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/MPGoogleAnalytics/MPGoogleAnalytics.modulemap";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = MPGoogleAnalytics;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = Pods_MercadoPagoSDK;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -688,36 +735,6 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		32896A18981DD7F4011AF98C1492B77E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3139DC4248D8CBB2067E80913AB1C361 /* MPGoogleAnalytics.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/MPGoogleAnalytics/MPGoogleAnalytics-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/MPGoogleAnalytics/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/MPGoogleAnalytics/MPGoogleAnalytics.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = MPGoogleAnalytics;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -766,110 +783,15 @@
 			};
 			name = Debug;
 		};
-		601F101FFBF3D6B0AD4CD0A88806C128 /* Release */ = {
+		495F384EC1E310859D4B11CCB97EA495 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 36E5268F3E8B8C648DA23CE66F4CB88D /* MercadoPagoTracker.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/MercadoPagoTracker/MercadoPagoTracker-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/MercadoPagoTracker/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/MercadoPagoTracker/MercadoPagoTracker.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = MercadoPagoTracker;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		7F335F44D44749BD354FF230D33B1F9B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 07AC03BA6BE6EB8914FFFD602DEFC69F /* Pods-MercadoPagoSDK.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-MercadoPagoSDK/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = Pods_MercadoPagoSDK;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		89073470FFF63A4EAF0A29219B708C96 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5ED84F4424647196C3F742656AF99F7D /* Pods-MercadoPagoSDK.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = "Target Support Files/Pods-MercadoPagoSDK/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = Pods_MercadoPagoSDK;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		9D409B6783CE8C71C449FDD60616AE5D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 36E5268F3E8B8C648DA23CE66F4CB88D /* MercadoPagoTracker.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					i386,
+					x86_64,
+				);
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -928,12 +850,113 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				ONLY_ACTIVE_ARCH = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
 				SYMROOT = "${SRCROOT}/../build";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
+		};
+		CACF8B8615A5FE71DFF74B1083D50018 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3139DC4248D8CBB2067E80913AB1C361 /* MPGoogleAnalytics.xcconfig */;
+			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					i386,
+					x86_64,
+				);
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/MPGoogleAnalytics/MPGoogleAnalytics-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/MPGoogleAnalytics/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/MPGoogleAnalytics/MPGoogleAnalytics.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = MPGoogleAnalytics;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		CF9791909C64EF152252DC56A852BFE9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 36E5268F3E8B8C648DA23CE66F4CB88D /* MercadoPagoTracker.xcconfig */;
+			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					i386,
+					x86_64,
+				);
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/MercadoPagoTracker/MercadoPagoTracker-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/MercadoPagoTracker/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/MercadoPagoTracker/MercadoPagoTracker.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = MercadoPagoTracker;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		EFF3941F213A458EF0116A8D952D6BA7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3139DC4248D8CBB2067E80913AB1C361 /* MPGoogleAnalytics.xcconfig */;
+			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					i386,
+					x86_64,
+				);
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/MPGoogleAnalytics/MPGoogleAnalytics-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/MPGoogleAnalytics/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/MPGoogleAnalytics/MPGoogleAnalytics.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = MPGoogleAnalytics;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 /* End XCBuildConfiguration section */
 
@@ -941,8 +964,8 @@
 		03E3B506F0AFCE187AFBDC7ACBA62DCD /* Build configuration list for PBXNativeTarget "MercadoPagoTracker" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9D409B6783CE8C71C449FDD60616AE5D /* Debug */,
-				601F101FFBF3D6B0AD4CD0A88806C128 /* Release */,
+				495F384EC1E310859D4B11CCB97EA495 /* Debug */,
+				CF9791909C64EF152252DC56A852BFE9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -959,8 +982,8 @@
 		6D1F2C97B82AFC429BBF951232420B2F /* Build configuration list for PBXNativeTarget "MPGoogleAnalytics" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				32896A18981DD7F4011AF98C1492B77E /* Debug */,
-				1B3A6F5E3768F0D30CADCCBF67BCA300 /* Release */,
+				EFF3941F213A458EF0116A8D952D6BA7 /* Debug */,
+				CACF8B8615A5FE71DFF74B1083D50018 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -968,8 +991,8 @@
 		6F5CED53685007D0AE17D40EA66565BA /* Build configuration list for PBXNativeTarget "Pods-MercadoPagoSDK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7F335F44D44749BD354FF230D33B1F9B /* Debug */,
-				89073470FFF63A4EAF0A29219B708C96 /* Release */,
+				05A8CCE8A29F51C87AB1E8BF6FDCB2CD /* Debug */,
+				16327D670AE63AFE2F2C657292AD019B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MercadoPagoSDK/Pods/Target Support Files/MercadoPagoTracker/Info.plist
+++ b/MercadoPagoSDK/Pods/Target Support Files/MercadoPagoTracker/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.8.13</string>
+  <string>0.8.15</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
@@ -29,6 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
        
         //Pinto de rojo el color primerio
         MercadoPagoContext.setupPrimaryColor(UIColor.redColor())
+        MercadoPagoContext.setSite(MercadoPagoContext.Site.MLA)
       //  MercadoPagoContext.secundaryColor = UIColor.yellowColor()
         
         

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/ServicesExamplesViewController.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/ServicesExamplesViewController.swift
@@ -108,7 +108,7 @@ class ServicesExamplesViewController: UIViewController, UITableViewDataSource, U
     
     private func startFinalVault(){
         let settings = PaymentPreference(defaultPaymentTypeId: nil, excludedPaymentMethodsIds: nil, excludedPaymentTypesIds: ["credit_card"], defaultPaymentMethodId: nil, maxAcceptedInstallment: nil, defaultInstallments: nil)
-        let finalVault = MPFlowBuilder.startPaymentVaultViewController(1000, currencyId: "ARS", paymentPreference: settings) { (paymentMethod, token, issuer, payerCost) in
+        let finalVault = MPFlowBuilder.startPaymentVaultViewController(1000, paymentPreference: settings) { (paymentMethod, token, issuer, payerCost) in
             
         }
         

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/StepsExamplesViewController.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/StepsExamplesViewController.swift
@@ -92,7 +92,7 @@ class StepsExamplesViewController: UIViewController, UITableViewDelegate, UITabl
     }
     
     public func startPaymentVault(){
-        let pv = MPFlowBuilder.startPaymentVaultViewController(1000, currencyId: "ARS") { (paymentMethod, token, issuer, payerCost) in
+        let pv = MPFlowBuilder.startPaymentVaultViewController(1000) { (paymentMethod, token, issuer, payerCost) in
             self.paymentMethod = paymentMethod
             self.createdToken = token
             self.selectedIssuer = issuer

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/AppDelegate.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/AppDelegate.m
@@ -25,6 +25,7 @@
     [MercadoPagoContext setMerchantAccessToken: MERCHANT_ACCESS_TOKEN];
     [MercadoPagoContext setBaseURL: MERCHANT_MOCK_BASE_URL];
     [MercadoPagoContext setCustomerURI: MERCHANT_MOCK_GET_CUSTOMER_URI];
+    [MercadoPagoContext setSiteID:@"MLB"];
    [MercadoPagoContext setupPrimaryColor:[UIColor redColor] ];
    [MercadoPagoContext setDarkTextColor];
     return YES;

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
@@ -63,7 +63,7 @@ int installmentsSelected = 1;
 }
 
 - (void)startPaymentVault {
-    UIViewController *paymentVaultVC = [MPFlowBuilder startPaymentVaultViewController:AMOUNT currencyId:CURRENCY paymentPreference:nil callback:^(PaymentMethod *pm, Token *token, Issuer *issuer, PayerCost *payerCost) {
+    UIViewController *paymentVaultVC = [MPFlowBuilder startPaymentVaultViewController:AMOUNT paymentPreference:nil callback:^(PaymentMethod *pm, Token *token, Issuer *issuer, PayerCost *payerCost) {
         currentToken = token;
         selectedIssuer = issuer;
         paymentMethod = pm;


### PR DESCRIPTION
- Se agrega lenaguaje pt o es según el siteId seteado en applicación (y no según el idioma configurado en el dispositivo)
- Se determina la currency según el siteId y se remueve como parámetro en F2

#### En el caso de F3, el siteId se determina por preferencia. En los otros casos el integrador lo tiene que setear a mano o es MLA por default. 
#### En swift se puede setear el site con el método setSide que recibe como parámetro un enum. En objective-C se utiliza el método setSideId que tiene un parámetro String con el id correspondiente a "MLA" o "MLB"