### PR TITLE
Align methods signature

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutPreference.swift
@@ -152,10 +152,14 @@ public class CheckoutPreference : NSObject {
     }
     
     
-    public func getPaymentSettings () -> PaymentPreference {
-        let settings = PaymentPreference(excludedPaymentMethodsIds: self.getExcludedPaymentMethodsIds(), excludedPaymentTypesIds: self.getExcludedPaymentTypesIds(), defaultPaymentMethodId: self.getDefaultPaymentMethodId(), maxAcceptedInstallment: self.getMaxAcceptedInstallments(), defaultInstallments: self.getDefaultInstallments())
-        
-        return settings
+    public func getPaymentPreference () -> PaymentPreference {
+        let paymentPreference = PaymentPreference()
+        paymentPreference.excludedPaymentMethodIds = self.getExcludedPaymentMethodsIds()
+        paymentPreference.excludedPaymentTypeIds = self.getExcludedPaymentTypesIds()
+        paymentPreference.defaultPaymentMethodId = self.getDefaultPaymentMethodId()
+        paymentPreference.maxAcceptedInstallments = self.getMaxAcceptedInstallments()
+        paymentPreference.defaultInstallments = self.getDefaultInstallments()
+        return paymentPreference
     }
     
     public func getExcludedPaymentTypesIds() -> Set<String>? {
@@ -165,18 +169,18 @@ public class CheckoutPreference : NSObject {
         return nil
     }
     
-    public func getDefaultInstallments() -> Int? {
+    public func getDefaultInstallments() -> Int {
         if (self.paymentPreference != nil && self.paymentPreference!.defaultInstallments > 0) {
             return self.paymentPreference!.defaultInstallments
         }
-        return nil
+        return 0
     }
     
-    public func getMaxAcceptedInstallments() -> Int? {
+    public func getMaxAcceptedInstallments() -> Int {
         if (self.paymentPreference != nil && self.paymentPreference!.maxAcceptedInstallments > 0) {
             return self.paymentPreference!.maxAcceptedInstallments
         }
-        return nil
+        return 0
     }
     
     public func getExcludedPaymentMethodsIds() -> Set<String>? {

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutPreference.swift
@@ -142,10 +142,10 @@ public class CheckoutPreference : NSObject {
     
     public func getInstallments() -> Int {
         if self.paymentPreference != nil {
-            if (self.paymentPreference!.maxAcceptedInstallments != nil) {
-                return self.paymentPreference!.maxAcceptedInstallments!
-            } else if (self.paymentPreference!.defaultInstallments != nil) {
-                return self.paymentPreference!.defaultInstallments!
+            if (self.paymentPreference!.maxAcceptedInstallments > 0) {
+                return self.paymentPreference!.maxAcceptedInstallments
+            } else if (self.paymentPreference!.defaultInstallments > 0) {
+                return self.paymentPreference!.defaultInstallments
             }
         }
         return 1
@@ -166,14 +166,14 @@ public class CheckoutPreference : NSObject {
     }
     
     public func getDefaultInstallments() -> Int? {
-        if (self.paymentPreference != nil && self.paymentPreference!.defaultInstallments != nil) {
+        if (self.paymentPreference != nil && self.paymentPreference!.defaultInstallments > 0) {
             return self.paymentPreference!.defaultInstallments
         }
         return nil
     }
     
     public func getMaxAcceptedInstallments() -> Int? {
-        if (self.paymentPreference != nil && self.paymentPreference!.maxAcceptedInstallments != nil) {
+        if (self.paymentPreference != nil && self.paymentPreference!.maxAcceptedInstallments > 0) {
             return self.paymentPreference!.maxAcceptedInstallments
         }
         return nil

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -274,7 +274,7 @@ public class CheckoutViewController: MercadoPagoUIViewController, UITableViewDat
     internal func startPaymentVault(animated : Bool = false){
         self.registerAllCells()
         
-        let paymentVaultVC = MPFlowBuilder.startPaymentVaultInCheckout(self.preference!.getAmount(), paymentPreference: self.preference!.getPaymentSettings(), paymentMethodSearch: self.paymentMethodSearch!, callback: { (paymentMethod, token, issuer, payerCost) in
+        let paymentVaultVC = MPFlowBuilder.startPaymentVaultInCheckout(self.preference!.getAmount(), paymentPreference: self.preference!.getPaymentPreference(), paymentMethodSearch: self.paymentMethodSearch!, callback: { (paymentMethod, token, issuer, payerCost) in
             self.paymentVaultCallback(paymentMethod, token : token, issuer : issuer, payerCost : payerCost, animated : animated)
         })
         

--- a/MercadoPagoSDK/MercadoPagoSDK/CongratsViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CongratsViewController.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-@available(*, deprecated=1.0, message="Use PaymentCongratsViewController instead")
+@available(*, deprecated=2.0.0, message="Use PaymentCongratsViewController instead")
 public class CongratsViewController : MercadoPagoUIViewController, UITableViewDataSource, UITableViewDelegate, UITextFieldDelegate {
     
     var payment: Payment!

--- a/MercadoPagoSDK/MercadoPagoSDK/Installment.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Installment.swift
@@ -54,7 +54,7 @@ public class Installment : NSObject {
     
     public func numberOfPayerCostToShow(maxNumberOfInstallments : Int? = nil) -> Int{
         var count = 0
-        if (maxNumberOfInstallments == nil){
+        if (maxNumberOfInstallments == 0){
             return self.payerCosts!.count
         }
         for pc in payerCosts! {

--- a/MercadoPagoSDK/MercadoPagoSDK/MPFlowBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPFlowBuilder.swift
@@ -73,7 +73,7 @@ public class MPFlowBuilder : NSObject {
 
     
     
-    public class func startCardFlow(paymentPreference: PaymentPreference? = nil  , amount: Double, paymentMethods : [PaymentMethod]? = nil,
+    public class func startCardFlow(paymentPreference: PaymentPreference? = nil  , amount: Double, paymentMethods : [PaymentMethod]? = nil, token : Token? = nil, 
                                       callback: (paymentMethod: PaymentMethod, token: Token? ,  issuer: Issuer?, payerCost: PayerCost?) -> Void,
                                       callbackCancel : (Void -> Void)? = nil) -> MPNavigationController {
         
@@ -87,7 +87,7 @@ public class MPFlowBuilder : NSObject {
         } else {
             currentCallbackCancel = callbackCancel!
         }
-        cardVC = MPStepBuilder.startCreditCardForm(paymentPreference, amount: amount, paymentMethods : paymentMethods,
+        cardVC = MPStepBuilder.startCreditCardForm(paymentPreference, amount: amount, paymentMethods : paymentMethods, token: token,
                                                      callback: { (paymentMethod, token, issuer) -> Void in
             
             MPServicesBuilder.getInstallments(token!.firstSixDigit, amount: amount, issuer: issuer, paymentMethodId: paymentMethod._id, success: { (installments) -> Void in

--- a/MercadoPagoSDK/MercadoPagoSDK/MPFlowBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPFlowBuilder.swift
@@ -46,6 +46,19 @@ public class MPFlowBuilder : NSObject {
         return MPFlowController.createNavigationControllerWith(paymentVault)
     }
 
+    
+    public class func startPaymentVaultViewController(amount : Double, paymentPreference : PaymentPreference? = nil, paymentMethodSearch : PaymentMethodSearch, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void, callbackCancel : (Void -> Void)? = nil) -> MPNavigationController {
+        MercadoPagoContext.initFlavor2()
+        var paymentVault : PaymentVaultViewController?
+        paymentVault = PaymentVaultViewController(amount: amount, paymentPreference: paymentPreference, paymentMethodSearch: paymentMethodSearch)  {(paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost : PayerCost?) -> Void in
+                paymentVault!.dismissViewControllerAnimated(true, completion: { () -> Void in
+                callback(paymentMethod: paymentMethod, token: token, issuer: issuer, payerCost: payerCost)}
+        )}
+        paymentVault!.callbackCancel = callbackCancel
+        paymentVault!.modalTransitionStyle = .CrossDissolve
+        return MPFlowController.createNavigationControllerWith(paymentVault!)
+    }
+    
     internal class func startPaymentVaultInCheckout(amount: Double, paymentPreference: PaymentPreference?, paymentMethodSearch : PaymentMethodSearch,
                                                     callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost : PayerCost?) -> Void,
                                                     callbackCancel : (Void -> Void)? = nil) -> MPNavigationController {

--- a/MercadoPagoSDK/MercadoPagoSDK/MPFlowBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPFlowBuilder.swift
@@ -11,7 +11,7 @@ import UIKit
 
 public class MPFlowBuilder : NSObject {
     
-    @available(*, deprecated=2.0, message="Use startCheckoutViewController instead")
+    @available(*, deprecated=2.0.0, message="Use startCheckoutViewController instead")
     public class func startVaultViewController(amount: Double, paymentPreference : PaymentPreference? = nil,
                             callback: (paymentMethod: PaymentMethod, tokenId: String?, issuer: Issuer?, installments: Int) -> Void) -> VaultViewController {
         MercadoPagoContext.initFlavor3()

--- a/MercadoPagoSDK/MercadoPagoSDK/MPStepBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPStepBuilder.swift
@@ -27,11 +27,20 @@ public class MPStepBuilder : NSObject {
         
     }
     
-    public class func startPaymentMethodsStep(paymentPreference: PaymentPreference? = nil,
+    public class func startPaymentMethodsStep(withPreference paymentPreference: PaymentPreference? = nil,
                                               callback:(paymentMethod: PaymentMethod) -> Void) -> PaymentMethodsViewController {
         MercadoPagoContext.initFlavor2()
         return PaymentMethodsViewController(paymentPreference: paymentPreference, callback: callback)
     }
+    
+    @available(*, deprecated=2.0.0, message="Use startPaymentMethodsStep with paymentPreference instead")
+    public class func startPaymentMethodsStep(supportedPaymentTypes: Set<String>, callback:(paymentMethod: PaymentMethod) -> Void) -> PaymentMethodsViewController {
+        MercadoPagoContext.initFlavor2()
+        let paymentPreference = PaymentPreference()
+        paymentPreference.excludedPaymentTypeIds = PaymentType.allPaymentIDs.subtract(supportedPaymentTypes)
+        return PaymentMethodsViewController(paymentPreference: paymentPreference, callback: callback)
+    }
+
     
 
     public class func startInstallmentsStep(payerCosts: [PayerCost]? = nil, paymentPreference: PaymentPreference? = nil, amount: Double, issuer: Issuer?, paymentMethodId: String?,
@@ -42,7 +51,7 @@ public class MPStepBuilder : NSObject {
     
     
 
-    @available(*, deprecated=2.0, message="Use startPaymentCongratsStep instead")
+    @available(*, deprecated=2.0.0, message="Use startPaymentCongratsStep instead")
     public class func startCongratsStep(payment: Payment, paymentMethod: PaymentMethod) -> CongratsViewController {
         MercadoPagoContext.initFlavor2()
         return CongratsViewController(payment: payment, paymentMethod: paymentMethod)

--- a/MercadoPagoSDK/MercadoPagoSDK/MPStepBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPStepBuilder.swift
@@ -12,6 +12,12 @@ import MercadoPagoTracker
 
 public class MPStepBuilder : NSObject {
     
+    @objc
+    public enum CongratsState : Int {
+        case OK = 0
+        case CANCEL_SELECT_OTHER = 1
+        case CANCEL_RETRY = 2
+    }
     
     public class func startCustomerCardsStep(cards: [Card],
                                              callback: (selectedCard: Card?) -> Void) -> CustomerCardsViewController {
@@ -57,18 +63,33 @@ public class MPStepBuilder : NSObject {
         return CongratsViewController(payment: payment, paymentMethod: paymentMethod)
     }
 
+    
+    public class func startPaymentResultStep(payment: Payment, paymentMethod : PaymentMethod,
+                                               callback : (payment : Payment, status : CongratsState) -> Void) -> MercadoPagoUIViewController {
+        
+        MercadoPagoContext.initFlavor2()
+        if (paymentMethod.isOfflinePaymentMethod()){
+            return self.startInstructionsStep(payment, paymentTypeId: paymentMethod.paymentTypeId, callback: callback)
+        } else {
+            return self.startPaymentCongratsStep(payment, paymentMethod: paymentMethod, callback : callback)
+        }
+
+    }
+    
     public class func startPaymentCongratsStep(payment: Payment, paymentMethod : PaymentMethod,
-                         callback : (payment : Payment, status : String) -> Void) -> PaymentCongratsViewController {
+                         callback : (payment : Payment, status : CongratsState) -> Void) -> PaymentCongratsViewController {
         
         MercadoPagoContext.initFlavor2()
         return PaymentCongratsViewController(payment: payment, paymentMethod : paymentMethod, callback : callback)
     }
     
     public class func startInstructionsStep(payment: Payment, paymentTypeId : String,
-                        callback : (payment : Payment) -> Void) -> InstructionsViewController {
+                        callback : (payment : Payment, status: CongratsState) -> Void) -> InstructionsViewController {
         
         MercadoPagoContext.initFlavor2()
-        return InstructionsViewController(payment: payment, paymentTypeId : PaymentTypeId(rawValue: paymentTypeId)!, callback : callback)
+        return InstructionsViewController(payment: payment, paymentTypeId : PaymentTypeId(rawValue: paymentTypeId)!, callback : {(payment : Payment) -> Void in
+            callback(payment: payment, status: CongratsState.OK)
+        })
     }
     
      public class func startPromosStep(

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentCongratsViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentCongratsViewController.swift
@@ -221,9 +221,9 @@ public class PaymentCongratsViewController: MercadoPagoUIViewController , MPPaym
             var status = MPStepBuilder.CongratsState.OK
             if self.payment.status == PaymentStatus.REJECTED.rawValue {
                 if self.payment.statusDetail == "cc_rejected_call_for_authorize" {
-                    status = MPStepBuilder.CongratsState.CANCEl_SELECT_OTHER
+                    status = MPStepBuilder.CongratsState.CANCEL_SELECT_OTHER
                 } else {
-                    status = MPStepBuilder.CongratsState.CANCEl_SELECT_OTHER
+                    status = MPStepBuilder.CongratsState.CANCEL_SELECT_OTHER
                 }
             } else {
                 //status = "OK"

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentCongratsViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentCongratsViewController.swift
@@ -22,13 +22,13 @@ public class PaymentCongratsViewController: MercadoPagoUIViewController , MPPaym
     var payment : Payment!
     var paymentMethod : PaymentMethod!
     var layoutTemplate : String!
-    var callback : ((payment : Payment, status : String) -> Void)!
+    var callback : ((payment : Payment, status : MPStepBuilder.CongratsState) -> Void)!
     
     
     
     @IBOutlet weak var congratsContentTable: UITableView!
 
-    init(payment: Payment, paymentMethod : PaymentMethod, callback : (payment : Payment, status : String) -> Void){
+    init(payment: Payment, paymentMethod : PaymentMethod, callback : (payment : Payment, status : MPStepBuilder.CongratsState) -> Void){
         super.init(nibName: "PaymentCongratsViewController", bundle : bundle)
         self.payment = payment
         self.callback = callback
@@ -105,14 +105,10 @@ public class PaymentCongratsViewController: MercadoPagoUIViewController , MPPaym
             if self.navigationController != nil && self.navigationController?.navigationBar != nil {
                 self.navigationController?.setNavigationBarHidden(false, animated: false)
             }
-            self.invokeCallback("OK")
+            self.invokeCallback(MPStepBuilder.CongratsState.OK)
             
         }
         return exitButtonCell
-    }
-    
-    public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        let cell = tableView.cellForRowAtIndexPath(indexPath)
     }
     
     public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -216,21 +212,21 @@ public class PaymentCongratsViewController: MercadoPagoUIViewController , MPPaym
         return false
     }
     
-    internal func invokeCallback(status : String){
+    internal func invokeCallback(status : MPStepBuilder.CongratsState){
         self.callback(payment: self.payment, status: status)
     }
     
     func congratsCallback() -> (Void -> Void){
         return {
-            var status = ""
+            var status = MPStepBuilder.CongratsState.OK
             if self.payment.status == PaymentStatus.REJECTED.rawValue {
                 if self.payment.statusDetail == "cc_rejected_call_for_authorize" {
-                    status = "AUTH"
+                    status = MPStepBuilder.CongratsState.CANCEl_SELECT_OTHER
                 } else {
-                    status = "CANCEL"
+                    status = MPStepBuilder.CongratsState.CANCEl_SELECT_OTHER
                 }
             } else {
-                status = "OK"
+                //status = "OK"
             }
             self.invokeCallback(status)
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodsViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodsViewController.swift
@@ -59,10 +59,10 @@ public class PaymentMethodsViewController : MercadoPagoUIViewController, UITable
                     if self.paymentPreference != nil {
                         var currenPaymentMethods = paymentMethods
                         if self.paymentPreference?.excludedPaymentTypeIds != nil && self.paymentPreference?.excludedPaymentTypeIds?.count > 0 {
-                            currenPaymentMethods = currenPaymentMethods?.filter({return (self.paymentPreference?.excludedPaymentTypeIds!.contains($0.paymentTypeId))!})
+                            currenPaymentMethods = currenPaymentMethods?.filter({return !(self.paymentPreference?.excludedPaymentTypeIds!.contains($0.paymentTypeId))!})
                         }
                         if self.paymentPreference?.excludedPaymentMethodIds != nil && self.paymentPreference?.excludedPaymentMethodIds?.count > 0 {
-                            currenPaymentMethods = currenPaymentMethods?.filter({return (self.paymentPreference?.excludedPaymentMethodIds?.contains($0._id))!})
+                            currenPaymentMethods = currenPaymentMethods?.filter({return !(self.paymentPreference?.excludedPaymentMethodIds?.contains($0._id))!})
                         }
                         self.items = currenPaymentMethods
                     } else {

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentPreference.swift
@@ -12,10 +12,10 @@ public class PaymentPreference: NSObject {
     
     public var excludedPaymentMethodIds : Set<String>?
     public var excludedPaymentTypeIds : Set<String>?
-    var defaultPaymentMethodId : String?
-    var maxAcceptedInstallments : Int?
-    var defaultInstallments : Int?
-    var defaultPaymentTypeId : String?
+    public var defaultPaymentMethodId : String?
+    public var maxAcceptedInstallments : Int?
+    public var defaultInstallments : Int?
+    public var defaultPaymentTypeId : String?
     
     //installments = sea mayor a cero y que el defaults_istallment sea mayor a 0
     // excluded_payment_method < payment_methods
@@ -139,6 +139,32 @@ public class PaymentPreference: NSObject {
         
         return preferencePaymentMethods
     }
+    
+    public func toJSONString() -> String {
+        var obj:[String:AnyObject] = [
+            
+            "defaultInstallments": self.defaultInstallments == nil ? JSON.null : (self.defaultInstallments)!,
+            "defaultPaymentTypeId": self.defaultPaymentTypeId == nil ? JSON.null : (self.defaultPaymentTypeId)!,
+            "defaultPaymentMethodId": self.defaultPaymentMethodId == nil ? JSON.null : (self.defaultPaymentMethodId)!,
+            "maxAcceptedInstallments": self.maxAcceptedInstallments == nil ? JSON.null : (self.maxAcceptedInstallments)!,
+        ]
+        
+        var excludedPaymentMethodIdsJson = ""
+        if excludedPaymentMethodIds != nil && excludedPaymentMethodIds?.count > 0 {
+            excludedPaymentMethodIdsJson = self.excludedPaymentMethodIds!.reduce("", combine: {$0.stringByAppendingString($1).stringByAppendingString(",")})
+        }
+        obj["excludedPaymentMethodIds"] = String(excludedPaymentMethodIdsJson.characters.dropLast())
+        
+        var excludedPaymentTypeIdsJson = ""
+        if excludedPaymentTypeIds != nil && excludedPaymentTypeIds?.count > 0 {
+            excludedPaymentTypeIdsJson = self.excludedPaymentTypeIds!.reduce("", combine: {$0.stringByAppendingString($1).stringByAppendingString(",")})
+        }
+        obj["excludedPaymentTypeIds"] = String(excludedPaymentTypeIdsJson.characters.dropLast(1))
+        
+        
+        return JSON(obj).toString()
+    }
+
 }
 
 public func ==(obj1: PaymentPreference, obj2: PaymentPreference) -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentPreference.swift
@@ -13,8 +13,8 @@ public class PaymentPreference: NSObject {
     public var excludedPaymentMethodIds : Set<String>?
     public var excludedPaymentTypeIds : Set<String>?
     public var defaultPaymentMethodId : String?
-    public var maxAcceptedInstallments : Int?
-    public var defaultInstallments : Int?
+    public var maxAcceptedInstallments : Int = 0
+    public var defaultInstallments : Int = 0
     public var defaultPaymentTypeId : String?
     
     //installments = sea mayor a cero y que el defaults_istallment sea mayor a 0
@@ -29,13 +29,13 @@ public class PaymentPreference: NSObject {
         if (payerCostList.count == 1){
             return payerCostList.first
         }
-        if((defaultInstallments != nil)&&(defaultInstallments > 0)){
+        
             for payercost in payerCostList{
                 if (payercost.installments == defaultInstallments){
                     return payercost
                 }
             }
-        }
+        
         if ((payerCostList.first?.installments <= maxAcceptedInstallments)
             && (payerCostList[1].installments > maxAcceptedInstallments)){
                 return payerCostList.first
@@ -62,8 +62,8 @@ public class PaymentPreference: NSObject {
         self.excludedPaymentMethodIds =  excludedPaymentMethodsIds
         self.excludedPaymentTypeIds = excludedPaymentTypesIds
         self.defaultPaymentMethodId = defaultPaymentMethodId
-        self.maxAcceptedInstallments = maxAcceptedInstallment
-        self.defaultInstallments = defaultInstallments
+        self.maxAcceptedInstallments = maxAcceptedInstallment!
+        self.defaultInstallments = defaultInstallments!
         self.defaultPaymentTypeId = defaultPaymentTypeId
     }
     
@@ -83,11 +83,11 @@ public class PaymentPreference: NSObject {
         }
       
         if(maxAcceptedInstallment != nil){
-            self.maxAcceptedInstallments = maxAcceptedInstallment
+            self.maxAcceptedInstallments = maxAcceptedInstallment!
         }
         
         if(defaultInstallments != nil){
-            self.defaultInstallments = defaultInstallments
+            self.defaultInstallments = defaultInstallments!
         }
        
         if(defaultPaymentTypeId != nil){
@@ -130,11 +130,11 @@ public class PaymentPreference: NSObject {
         }
         
         if json["installments"] != nil && !(json["installments"]! is NSNull) {
-            preferencePaymentMethods.maxAcceptedInstallments = JSON(json["installments"]!).asInt
+            preferencePaymentMethods.maxAcceptedInstallments = JSON(json["installments"]!).asInt!
         }
         
         if json["default_installments"] != nil && !(json["default_installments"]! is NSNull) {
-            preferencePaymentMethods.maxAcceptedInstallments = JSON(json["default_installments"]!).asInt
+            preferencePaymentMethods.maxAcceptedInstallments = JSON(json["default_installments"]!).asInt!
         }
         
         return preferencePaymentMethods
@@ -143,10 +143,10 @@ public class PaymentPreference: NSObject {
     public func toJSONString() -> String {
         var obj:[String:AnyObject] = [
             
-            "defaultInstallments": self.defaultInstallments == nil ? JSON.null : (self.defaultInstallments)!,
+            "defaultInstallments": self.defaultInstallments == 0 ? JSON.null : (self.defaultInstallments),
             "defaultPaymentTypeId": self.defaultPaymentTypeId == nil ? JSON.null : (self.defaultPaymentTypeId)!,
             "defaultPaymentMethodId": self.defaultPaymentMethodId == nil ? JSON.null : (self.defaultPaymentMethodId)!,
-            "maxAcceptedInstallments": self.maxAcceptedInstallments == nil ? JSON.null : (self.maxAcceptedInstallments)!,
+            "maxAcceptedInstallments": self.maxAcceptedInstallments == 0 ? JSON.null : (self.maxAcceptedInstallments),
         ]
         
         var excludedPaymentMethodIdsJson = ""

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentPreference.swift
@@ -25,6 +25,7 @@ public class PaymentPreference: NSObject {
         super.init()
     }
     
+    
     public func autoSelectPayerCost(payerCostList:[PayerCost])-> PayerCost?
     {
         if (payerCostList.count == 0){
@@ -128,7 +129,7 @@ public class PaymentPreference: NSObject {
         }
         
         if json["default_installments"] != nil && !(json["default_installments"]! is NSNull) {
-            preferencePaymentMethods.maxAcceptedInstallments = JSON(json["default_installments"]!).asInt!
+            preferencePaymentMethods.defaultInstallments = JSON(json["default_installments"]!).asInt!
         }
         
         return preferencePaymentMethods
@@ -137,23 +138,31 @@ public class PaymentPreference: NSObject {
     public func toJSONString() -> String {
         var obj:[String:AnyObject] = [
             
-            "defaultInstallments": self.defaultInstallments == 0 ? JSON.null : (self.defaultInstallments),
-            "defaultPaymentTypeId": self.defaultPaymentTypeId == nil ? JSON.null : (self.defaultPaymentTypeId)!,
-            "defaultPaymentMethodId": self.defaultPaymentMethodId == nil ? JSON.null : (self.defaultPaymentMethodId)!,
-            "maxAcceptedInstallments": self.maxAcceptedInstallments == 0 ? JSON.null : (self.maxAcceptedInstallments),
+            "default_installments": self.defaultInstallments == 0 ? JSON.null : (self.defaultInstallments),
+            "default_payment_method_id": self.defaultPaymentMethodId == nil ? JSON.null : (self.defaultPaymentMethodId)!,
+            "installments": self.maxAcceptedInstallments == 0 ? JSON.null : (self.maxAcceptedInstallments),
         ]
         
-        var excludedPaymentMethodIdsJson = ""
+        var excludedPaymentMethodIdsJson = [NSDictionary]()
         if excludedPaymentMethodIds != nil && excludedPaymentMethodIds?.count > 0 {
-            excludedPaymentMethodIdsJson = self.excludedPaymentMethodIds!.reduce("", combine: {$0.stringByAppendingString($1).stringByAppendingString(",")})
+            for pmId in excludedPaymentMethodIds! {
+                let pmIdElement = NSMutableDictionary()
+                pmIdElement.setValue(pmId, forKey: "id")
+                excludedPaymentMethodIdsJson.append(pmIdElement)
+            }
         }
-        obj["excludedPaymentMethodIds"] = String(excludedPaymentMethodIdsJson.characters.dropLast())
+        obj["excluded_payment_methods"] = excludedPaymentMethodIdsJson
         
-        var excludedPaymentTypeIdsJson = ""
+        
+        var excludedPaymentTypeIdsJson = [NSDictionary]()
         if excludedPaymentTypeIds != nil && excludedPaymentTypeIds?.count > 0 {
-            excludedPaymentTypeIdsJson = self.excludedPaymentTypeIds!.reduce("", combine: {$0.stringByAppendingString($1).stringByAppendingString(",")})
+            for ptId in excludedPaymentTypeIds! {
+                let ptIdElement = NSMutableDictionary()
+                ptIdElement.setValue(ptId, forKey: "id")
+                excludedPaymentTypeIdsJson.append(ptIdElement)
+            }
         }
-        obj["excludedPaymentTypeIds"] = String(excludedPaymentTypeIdsJson.characters.dropLast(1))
+        obj["excluded_payment_types"] = excludedPaymentTypeIdsJson
         
         
         return JSON(obj).toString()

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentPreference.swift
@@ -21,6 +21,10 @@ public class PaymentPreference: NSObject {
     // excluded_payment_method < payment_methods
     //excluded_payment_types < payment_types
     
+    public override init(){
+        super.init()
+    }
+    
     public func autoSelectPayerCost(payerCostList:[PayerCost])-> PayerCost?
     {
         if (payerCostList.count == 0){
@@ -55,16 +59,6 @@ public class PaymentPreference: NSObject {
         }
 
         return true
-    }
-    
-    
-    public init(defaultPaymentTypeId: String? = nil ,excludedPaymentMethodsIds : Set<String>? = nil, excludedPaymentTypesIds: Set<String>? = nil, defaultPaymentMethodId: String? = nil, maxAcceptedInstallment : Int? = nil, defaultInstallments : Int? = nil){
-        self.excludedPaymentMethodIds =  excludedPaymentMethodsIds
-        self.excludedPaymentTypeIds = excludedPaymentTypesIds
-        self.defaultPaymentMethodId = defaultPaymentMethodId
-        self.maxAcceptedInstallments = maxAcceptedInstallment!
-        self.defaultInstallments = defaultInstallments!
-        self.defaultPaymentTypeId = defaultPaymentTypeId
     }
     
     

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentType.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentType.swift
@@ -31,10 +31,7 @@ public class PaymentType: NSObject {
         }
         return paymentType
     }
-    
-    public func paymentSettingAssociated() -> PaymentPreference {
-        return PaymentPreference(defaultPaymentTypeId:self.paymentTypeId.rawValue)
-    }
+
 
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
@@ -36,30 +36,6 @@ public class PaymentVaultViewController: MercadoPagoUIViewController, UITableVie
     @IBOutlet weak var paymentsTable: UITableView!
     
     
-    internal init(amount: Double, paymentPreference : PaymentPreference?, paymentMethodSearchItem : [PaymentMethodSearchItem], paymentMethods: [PaymentMethod], title: String? = "", tintColor : Bool = false, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void, callbackCancel : (Void -> Void)? = nil) {
-
-        super.init(nibName: "PaymentVaultViewController", bundle: bundle)
-        
-        self.merchantBaseUrl = MercadoPagoContext.baseURL() //distinta de null y vacia
-        self.merchantAccessToken = MercadoPagoContext.merchantAccessToken()//Distinta de null y vacio
-        //Installment > 0
-        
-        //Vaidar que no excluyo todos los payment method
-        
-        self.publicKey = MercadoPagoContext.publicKey()
-        self.currency = MercadoPagoContext.getCurrency()
-        self.title = title
-        self.tintColor = tintColor
-        self.amount = amount // mayor o igual a 0
-        self.paymentPreference = paymentPreference
-
-        self.currentPaymentMethodSearch = paymentMethodSearchItem
-        self.paymentMethods = paymentMethods
-        self.callback = callback
-        
-      
-    }
-    
     public init(amount: Double, paymentPreference : PaymentPreference?, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void, callbackCancel : (Void -> Void)? = nil) {
         super.init(nibName: "PaymentVaultViewController", bundle: bundle)
         
@@ -84,6 +60,59 @@ public class PaymentVaultViewController: MercadoPagoUIViewController, UITableVie
         } else {
             self.callbackCancel = callbackCancel
         }
+    }
+    
+    public init(amount : Double, paymentPreference : PaymentPreference? = nil, paymentMethodSearch : PaymentMethodSearch, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void) {
+        super.init(nibName: "PaymentVaultViewController", bundle: bundle)
+        
+        self.merchantBaseUrl = MercadoPagoContext.baseURL()
+        self.merchantAccessToken = MercadoPagoContext.merchantAccessToken()
+        self.publicKey = MercadoPagoContext.publicKey()
+        self.currency = MercadoPagoContext.getCurrency()
+        self.amount = amount
+        self.paymentPreference = paymentPreference
+        self.callback = callback
+        self.paymentMethods = paymentMethodSearch.paymentMethods
+        self.currentPaymentMethodSearch = paymentMethodSearch.groups
+        
+        if callbackCancel == nil {
+            self.callbackCancel = {(Void) -> Void in
+                if self.navigationController?.viewControllers[0] == self {
+                    self.dismissViewControllerAnimated(true, completion: {
+                        
+                    })
+                } else {
+                    self.navigationController!.popViewControllerAnimated(true)
+                }
+            }
+        } else {
+            self.callbackCancel = callbackCancel
+        }
+
+    }
+    
+    internal init(amount: Double, paymentPreference : PaymentPreference?, paymentMethodSearchItem : [PaymentMethodSearchItem], paymentMethods: [PaymentMethod], title: String? = "", tintColor : Bool = false, callback: (paymentMethod: PaymentMethod, token: Token?, issuer: Issuer?, payerCost: PayerCost?) -> Void, callbackCancel : (Void -> Void)? = nil) {
+        
+        super.init(nibName: "PaymentVaultViewController", bundle: bundle)
+        
+        self.merchantBaseUrl = MercadoPagoContext.baseURL() //distinta de null y vacia
+        self.merchantAccessToken = MercadoPagoContext.merchantAccessToken()//Distinta de null y vacio
+        //Installment > 0
+        
+        //Vaidar que no excluyo todos los payment method
+        
+        self.publicKey = MercadoPagoContext.publicKey()
+        self.currency = MercadoPagoContext.getCurrency()
+        self.title = title
+        self.tintColor = tintColor
+        self.amount = amount // mayor o igual a 0
+        self.paymentPreference = paymentPreference
+        
+        self.currentPaymentMethodSearch = paymentMethodSearchItem
+        self.paymentMethods = paymentMethods
+        self.callback = callback
+        
+        
     }
     
     required  public init(coder aDecoder: NSCoder) {

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/ExamplesUtils.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/ExamplesUtils.swift
@@ -181,8 +181,12 @@ class ExamplesUtils {
         let preference = self.createCheckoutPreferenceWithNoExclusions()
         
         //Preference payment methods
-        let paymentPreference = PaymentPreference(excludedPaymentMethodsIds: ["oxxo", "bancomer_bank_transfer"], excludedPaymentTypesIds: [PaymentTypeId.DEBIT_CARD.rawValue], defaultPaymentMethodId: nil, maxAcceptedInstallment: 1, defaultInstallments: 1)
+        let paymentPreference = PaymentPreference()
         
+        paymentPreference.excludedPaymentMethodIds = ["oxxo", "bancomer_bank_transfer"]
+        paymentPreference.excludedPaymentTypeIds = [PaymentTypeId.DEBIT_CARD.rawValue]
+        paymentPreference.maxAcceptedInstallments = 1
+        paymentPreference.defaultInstallments = 1
         preference.paymentPreference = paymentPreference
         
         return preference

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/ServicesExamplesViewController.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/ServicesExamplesViewController.swift
@@ -107,7 +107,8 @@ class ServicesExamplesViewController: UIViewController, UITableViewDataSource, U
     
     
     private func startFinalVault(){
-        let settings = PaymentPreference(defaultPaymentTypeId: nil, excludedPaymentMethodsIds: nil, excludedPaymentTypesIds: ["credit_card"], defaultPaymentMethodId: nil, maxAcceptedInstallment: nil, defaultInstallments: nil)
+        let settings = PaymentPreference()
+        settings.excludedPaymentTypeIds = ["credit_card"]
         let finalVault = MPFlowBuilder.startPaymentVaultViewController(1000, paymentPreference: settings, callback: { (paymentMethod, token, issuer, payerCost) in
             
         })

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/SimpleVaultViewController.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/SimpleVaultViewController.swift
@@ -166,7 +166,7 @@ class SimpleVaultViewController: UIViewController, UITableViewDataSource, UITabl
 
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         if indexPath.row == 0 {
-            let paymentMethodsViewController = MPStepBuilder.startPaymentMethodsStep(self.paymentPreference, callback: getSelectionCallbackPaymentMethod())
+            let paymentMethodsViewController = MPStepBuilder.startPaymentMethodsStep(withPreference: self.paymentPreference, callback: getSelectionCallbackPaymentMethod())
             
             if self.cards != nil {
                 if self.cards!.count > 0 {

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/StepsExamplesViewController.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/StepsExamplesViewController.swift
@@ -92,13 +92,18 @@ class StepsExamplesViewController: UIViewController, UITableViewDelegate, UITabl
     }
     
     public func startPaymentVault(){
-        let pv = MPFlowBuilder.startPaymentVaultViewController(1000 , callback: { (paymentMethod, token, issuer, payerCost) in
-            self.paymentMethod = paymentMethod
-            self.createdToken = token
-            self.selectedIssuer = issuer
-            self.installmentsSelected = payerCost
-        })
-        self.presentViewController(pv, animated: true, completion: {})
+        MercadoPagoContext.setPublicKey(ExamplesUtils.MERCHANT_PUBLIC_KEY_TEST)
+        MPServicesBuilder.searchPaymentMethods(200, excludedPaymentTypeIds: ["credit_card"], excludedPaymentMethodIds: ["rapipago"], success: { (paymentMethodSearch : PaymentMethodSearch) in
+                let pv = MPFlowBuilder.startPaymentVaultViewController(200, paymentMethodSearch: paymentMethodSearch, callback: { (paymentMethod, token, issuer, payerCost) in
+                    NSLog(paymentMethod._id)
+                })
+            
+            self.presentViewController(pv, animated: true, completion: {})
+
+            }) { (error) in
+                
+        }
+        
     }
     
     private func startCardFlow(){
@@ -130,7 +135,7 @@ class StepsExamplesViewController: UIViewController, UITableViewDelegate, UITabl
     }
     
     private func startPaymentMethods(){
-        let pms = MPStepBuilder.startPaymentMethodsStep(nil) { (paymentMethod) in
+        let pms = MPStepBuilder.startPaymentMethodsStep(withPreference: nil) { (paymentMethod) in
             self.paymentMethod = paymentMethod
             self.navigationController!.popViewControllerAnimated(true)
         }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/AppDelegate.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/AppDelegate.m
@@ -27,8 +27,8 @@
     [MercadoPagoContext setBaseURL: MERCHANT_MOCK_BASE_URL];
     [MercadoPagoContext setCustomerURI: MERCHANT_MOCK_GET_CUSTOMER_URI];
     [MercadoPagoContext setSiteID:@"MLB"];
-   [MercadoPagoContext setupPrimaryColor:[UIColor redColor] ];
-   [MercadoPagoContext setDarkTextColor];
+    [MercadoPagoContext setupPrimaryColor:[UIColor redColor] complementaryColor:nil];
+    [MercadoPagoContext setDarkTextColor];
     
     return YES;
 }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/SimpleVaultFormViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/SimpleVaultFormViewController.m
@@ -81,9 +81,11 @@ UILabel *identificationType;
                 Item *item = [[Item alloc] initWith_id:@"1" title:@"item title" quantity:1 unitPrice:amount];
                 MerchantPayment *merchantPayment = [[MerchantPayment alloc] initWithItems:[NSArray arrayWithObject:item] installments:installments cardIssuer:nil tokenId:token._id paymentMethod:paymentMethod campaignId:0];
                 [MerchantServer createPayment:merchantPayment success:^(Payment *payment) {
-                    UIViewController *congrats = [MPStepBuilder startPaymentCongratsStep:payment paymentMethod:paymentMethod callback:^(Payment *payment, NSString *congratsStatus) {
-                        [self.navigationController popToRootViewControllerAnimated:YES];
+                    
+                    UIViewController *congrats = [MPStepBuilder startPaymentCongratsStep:payment paymentMethod:paymentMethod callback:^(Payment * _Nonnull payment, enum CongratsState status) {
+                         [self.navigationController popToRootViewControllerAnimated:YES];
                     }];
+
                     [self.navigationController pushViewController:congrats animated:YES];
                 } failure:^(NSError *error) {
                     NSLog(@"Error ocurred : %@", error.description);
@@ -100,7 +102,8 @@ UILabel *identificationType;
                 Item *item = [[Item alloc] initWith_id:@"1" title:@"item title" quantity:1 unitPrice:amount];
                 MerchantPayment *merchantPayment = [[MerchantPayment alloc] initWithItems:[NSArray arrayWithObject:item] installments:installments cardIssuer:nil tokenId:token._id paymentMethod:customerCard.paymentMethod campaignId:0];
                 [MerchantServer createPayment:merchantPayment success:^(Payment *payment) {
-                    UIViewController *congrats = [MPStepBuilder startPaymentCongratsStep:payment paymentMethod:customerCard.paymentMethod callback:^(Payment *payment, NSString *congratsStatus) {
+
+                    UIViewController *congrats = [MPStepBuilder startPaymentCongratsStep:payment paymentMethod:customerCard.paymentMethod callback:^(Payment *payment, enum CongratsState congratsStatus) {
                         [self.navigationController popToRootViewControllerAnimated:YES];
                     }];
                     [self.navigationController pushViewController:congrats animated:YES];

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
@@ -63,6 +63,7 @@ int installmentsSelected = 1;
 }
 
 - (void)startPaymentVault {
+    
     UIViewController *paymentVaultVC = [MPFlowBuilder startPaymentVaultViewController:AMOUNT paymentPreference:nil callback:^(PaymentMethod *pm, Token *token, Issuer *issuer, PayerCost *payerCost) {
         currentToken = token;
         selectedIssuer = issuer;
@@ -75,7 +76,8 @@ int installmentsSelected = 1;
 }
 
 - (void)startCardFlow {
-    UIViewController *cf = [MPFlowBuilder startCardFlow:nil amount:AMOUNT paymentMethods:nil callback:^(PaymentMethod *pm, Token *token, Issuer *issuer, PayerCost *payerCost) {
+    
+    UINavigationController *cf = [MPFlowBuilder startCardFlow:nil amount:AMOUNT paymentMethods:nil token:nil callback:^(PaymentMethod *pm, Token * token, Issuer *issuer, PayerCost *payerCost) {
         currentToken = token;
         selectedIssuer = issuer;
         paymentMethod = pm;
@@ -83,6 +85,7 @@ int installmentsSelected = 1;
     } callbackCancel:^{
         [self dismissViewControllerAnimated:YES completion:^{}];
     }];
+
     [self presentViewController:cf animated:YES completion:^{}];
 
 }


### PR DESCRIPTION
- Métodos en PaymentPreference toJSON & fromJSON
- Método (deprecado) startPaymentMethod con supportedPaymentTypes (compatibilidad con SDK anterior)
- Valores default en cuotas en PaymentPreference (compatibilidad con objective-c)
- startPaymentResult agregado : el método retorna congrats o instrucciones según el estado de pago. F3 adaptado a nuevo step de PaymentResult.
- Enum de congratsStatus compatible con objective-c 

Se cierran #94 y #95 
