### PR TITLE
Test coverage

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -248,8 +248,6 @@
 		155692D11C47D75900521403 /* CheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76743C801C46A21C00120347 /* CheckoutViewController.swift */; };
 		155692D21C47DA1200521403 /* PaymentPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76743C771C45A24600120347 /* PaymentPreference.swift */; };
 		1565B1311CBFD7F100181998 /* GuessingFormTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1565B1301CBFD7F100181998 /* GuessingFormTest.swift */; };
-		1568828C1D5A25B1005EF18A /* MercadoPagoTracker.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1568828B1D5A25B0005EF18A /* MercadoPagoTracker.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		1568828E1D5A25B4005EF18A /* MPGoogleAnalytics.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1568828D1D5A25B4005EF18A /* MPGoogleAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		156DA6431CC55636006B892F /* PayerCostFormTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156DA6421CC55636006B892F /* PayerCostFormTest.swift */; };
 		15714BAA1C85CC800019945E /* PaymentMethodImageViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15FCA78E1C84993B00D9E8CE /* PaymentMethodImageViewCell.swift */; };
 		157AA6821C970BEC00CC9B43 /* TermsAndConditionsViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76DA646A1C90C3E3004F9A7C /* TermsAndConditionsViewCell.xib */; };
@@ -375,6 +373,8 @@
 		7656F5281C975EEF0076A14D /* PaymentDescriptionFooterTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76DA64631C907DC5004F9A7C /* PaymentDescriptionFooterTableViewCell.swift */; };
 		7656F52C1C988C510076A14D /* MercadoPagoUIViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7656F52B1C988C510076A14D /* MercadoPagoUIViewControllerTest.swift */; };
 		7656F5301C98A2E50076A14D /* InstructionsViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7656F52F1C98A2E50076A14D /* InstructionsViewControllerTest.swift */; };
+		765FE5531D677CE800145506 /* MercadoPagoTracker.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 765FE5511D677CE800145506 /* MercadoPagoTracker.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		765FE5541D677CE800145506 /* MPGoogleAnalytics.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 765FE5521D677CE800145506 /* MPGoogleAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		766012D61CEB7DE600897F9D /* InstallmentSelectionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B085291CE5045D00C157BF /* InstallmentSelectionTableViewCell.swift */; };
 		766012E21CEB963300897F9D /* MPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 766012E11CEB963300897F9D /* MPError.swift */; };
 		766012E31CEB963300897F9D /* MPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 766012E11CEB963300897F9D /* MPError.swift */; };
@@ -514,6 +514,8 @@
 		76EC48061C862B000086FA53 /* InstructionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EC48051C862B000086FA53 /* InstructionTest.swift */; };
 		76EC48081C862B160086FA53 /* InstructionReferenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EC48071C862B160086FA53 /* InstructionReferenceTest.swift */; };
 		76EC480A1C862B2D0086FA53 /* InstructionActionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EC48091C862B2D0086FA53 /* InstructionActionTest.swift */; };
+		76EEF7621D67755E0095D5A5 /* InstructionsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76943ED81D51405E00358442 /* InstructionsInfo.swift */; };
+		76EEF7631D6775630095D5A5 /* AmountInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C834401D510CD4003C4717 /* AmountInfo.swift */; };
 		76F41E281D3D4A9700B25E5B /* MercadoPagoContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1C1D19752A00A86097 /* MercadoPagoContext.swift */; };
 		76F41E291D3D4A9D00B25E5B /* MPFlowBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1D1D19752A00A86097 /* MPFlowBuilder.swift */; };
 		76F41E2A1D3D4AA800B25E5B /* MPStepBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C201D19752A00A86097 /* MPStepBuilder.swift */; };
@@ -557,8 +559,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				1568828C1D5A25B1005EF18A /* MercadoPagoTracker.framework in CopyFiles */,
-				1568828E1D5A25B4005EF18A /* MPGoogleAnalytics.framework in CopyFiles */,
+				765FE5531D677CE800145506 /* MercadoPagoTracker.framework in CopyFiles */,
+				765FE5541D677CE800145506 /* MPGoogleAnalytics.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -767,6 +769,8 @@
 		7656F5241C9726A60076A14D /* PaymentMethodSearchServiceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodSearchServiceTest.swift; sourceTree = "<group>"; };
 		7656F52B1C988C510076A14D /* MercadoPagoUIViewControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoUIViewControllerTest.swift; sourceTree = "<group>"; };
 		7656F52F1C98A2E50076A14D /* InstructionsViewControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionsViewControllerTest.swift; sourceTree = "<group>"; };
+		765FE5511D677CE800145506 /* MercadoPagoTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MercadoPagoTracker.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-eiajqppcsdjrwwecqwxhmelyhsvk/Build/Products/Debug-iphonesimulator/MercadoPagoTracker/MercadoPagoTracker.framework"; sourceTree = "<absolute>"; };
+		765FE5521D677CE800145506 /* MPGoogleAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MPGoogleAnalytics.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-eiajqppcsdjrwwecqwxhmelyhsvk/Build/Products/Debug-iphonesimulator/MPGoogleAnalytics/MPGoogleAnalytics.framework"; sourceTree = "<absolute>"; };
 		766012E11CEB963300897F9D /* MPError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPError.swift; sourceTree = "<group>"; };
 		766012E51CEBA19700897F9D /* ErrorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		766012E61CEBA19700897F9D /* ErrorViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ErrorViewController.xib; sourceTree = "<group>"; };
@@ -867,6 +871,8 @@
 		76EC48051C862B000086FA53 /* InstructionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionTest.swift; sourceTree = "<group>"; };
 		76EC48071C862B160086FA53 /* InstructionReferenceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionReferenceTest.swift; sourceTree = "<group>"; };
 		76EC48091C862B2D0086FA53 /* InstructionActionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionActionTest.swift; sourceTree = "<group>"; };
+		76EEF75E1D67736C0095D5A5 /* MercadoPagoTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MercadoPagoTracker.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-eiajqppcsdjrwwecqwxhmelyhsvk/Build/Products/Debug-iphonesimulator/MercadoPagoTracker/MercadoPagoTracker.framework"; sourceTree = "<absolute>"; };
+		76EEF75F1D67736C0095D5A5 /* MPGoogleAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = MPGoogleAnalytics.framework; path = "/Users/macrodriguez/Library/Developer/Xcode/DerivedData/MercadoPagoSDKExamples-eiajqppcsdjrwwecqwxhmelyhsvk/Build/Products/Debug-iphonesimulator/MPGoogleAnalytics/MPGoogleAnalytics.framework"; sourceTree = "<absolute>"; };
 		76F41E2F1D3D5F5800B25E5B /* MercadoPagoTestContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoTestContext.swift; sourceTree = "<group>"; };
 		76FD24701C5BFEA1008C5DC0 /* CardBackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardBackView.swift; sourceTree = "<group>"; };
 		76FD24711C5BFEA1008C5DC0 /* CardBackView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CardBackView.xib; sourceTree = "<group>"; };
@@ -905,6 +911,10 @@
 		0F9883001AD2A97A00F750F0 = {
 			isa = PBXGroup;
 			children = (
+				765FE5511D677CE800145506 /* MercadoPagoTracker.framework */,
+				765FE5521D677CE800145506 /* MPGoogleAnalytics.framework */,
+				76EEF75E1D67736C0095D5A5 /* MercadoPagoTracker.framework */,
+				76EEF75F1D67736C0095D5A5 /* MPGoogleAnalytics.framework */,
 				1568828D1D5A25B4005EF18A /* MPGoogleAnalytics.framework */,
 				1568828B1D5A25B0005EF18A /* MercadoPagoTracker.framework */,
 				0F0749081AED5BAE003DD39D /* Localizable.strings */,
@@ -2274,6 +2284,7 @@
 				76EC47EC1C8614CA0086FA53 /* PaymentMethodTest.swift in Sources */,
 				76EC47E21C85ED9B0086FA53 /* MerchantPaymentTest.swift in Sources */,
 				0F98844C1AD2AEC000F750F0 /* MPInstallmentsTableViewCell.swift in Sources */,
+				76EEF7621D67755E0095D5A5 /* InstructionsInfo.swift in Sources */,
 				76EC48021C862ABC0086FA53 /* PaymentMethodSearchTest.swift in Sources */,
 				76F41E2B1D3D4AB300B25E5B /* MPServicesBuilder.swift in Sources */,
 				0F9883801AD2AB6000F750F0 /* MerchantPayment.swift in Sources */,
@@ -2476,6 +2487,7 @@
 				0F98837C1AD2AB6000F750F0 /* Issuer.swift in Sources */,
 				0F9883681AD2AB6000F750F0 /* Cause.swift in Sources */,
 				76B084FF1CE2166900C157BF /* RejectedPaymentBodyTableViewCell.swift in Sources */,
+				76EEF7631D6775630095D5A5 /* AmountInfo.swift in Sources */,
 				0F2071C31B1F4BF700CE11AB /* UILoadingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2693,7 +2705,7 @@
 				);
 				INFOPLIST_FILE = MercadoPagoSDKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mercadopago.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -2710,7 +2722,7 @@
 				);
 				INFOPLIST_FILE = MercadoPagoSDKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mercadopago.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/xcshareddata/xcschemes/MercadoPagoSDK.xcscheme
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/xcshareddata/xcschemes/MercadoPagoSDK.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
       </Testables>
       <AdditionalOptions>

--- a/MercadoPagoSDK/MercadoPagoSDKTests/BaseTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/BaseTest.swift
@@ -12,12 +12,14 @@ class BaseTest: XCTestCase {
     
     static let WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION = "waitForRequest"
     static let WAIT_FOR_NAVIGATION_CONTROLLER = "waitForNavigationController"
-    static let WAIT_EXPECTATION_TIME_INTERVAL = 1000.0
+    static let WAIT_FOR_VIEW_LOADED = "waitForViewDidLoad"
+    static let WAIT_EXPECTATION_TIME_INTERVAL = 10.0
     
     override func setUp() {
         super.setUp()
         MercadoPagoContext.setPublicKey(MockBuilder.MLA_PK)
         MercadoPagoContext.setMerchantAccessToken(MockBuilder.MERCHANT_ACCESS_TOKEN)
+        MercadoPagoTestContext.sharedInstance.testEnvironment = self
     }
     
     override func tearDown() {
@@ -25,17 +27,15 @@ class BaseTest: XCTestCase {
     }
     
     func simulateViewDidLoadFor(viewController : UIViewController) -> UIViewController{
-       // MercadoPagoUIViewController.loadFont(MercadoPago.DEFAULT_FONT_NAME)
-        MercadoPagoTestContext.addExpectation(expectationWithDescription(BaseTest.WAIT_FOR_NAVIGATION_CONTROLLER))
+        MercadoPagoTestContext.addExpectation(withDescription: BaseTest.WAIT_FOR_VIEW_LOADED)
         let nav = UINavigationController()
         nav.pushViewController(viewController, animated: false) {
-            MercadoPagoTestContext.fulfillExpectation(BaseTest.WAIT_FOR_NAVIGATION_CONTROLLER)
+            MercadoPagoTestContext.fulfillExpectation(BaseTest.WAIT_FOR_VIEW_LOADED)
         }
         let _ = viewController.view
-        waitForExpectationsWithTimeout(BaseTest.WAIT_EXPECTATION_TIME_INTERVAL, handler: nil)
-        viewController.viewDidLoad()
         viewController.viewWillAppear(false)
         viewController.viewDidAppear(false)
+        waitForExpectationsWithTimeout(BaseTest.WAIT_EXPECTATION_TIME_INTERVAL, handler: nil)
         return viewController
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewControllerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewControllerTest.swift
@@ -39,6 +39,7 @@ class CheckoutViewControllerTest: BaseTest {
     }
     
     func testSetupCheckoutWithPreference(){
+        
         MPServicesBuilder.getPreference(MockBuilder.PREF_ID_NO_EXCLUSIONS, success: { (preference) in
             self.preference = preference
         }) { (error) in
@@ -55,7 +56,7 @@ class CheckoutViewControllerTest: BaseTest {
         checkInitialScreenAttributes()
         
     }
-    
+   
    
     /*
      *  Todos los medios de pago disponibles.
@@ -67,7 +68,8 @@ class CheckoutViewControllerTest: BaseTest {
             
             
         })
-        
+
+
         // Metodo de pago no seleccionado
         XCTAssertNil(checkoutViewController?.paymentMethod)
         
@@ -80,8 +82,6 @@ class CheckoutViewControllerTest: BaseTest {
         verifyPaymentVaultSelection_paymentMethodOff("rapipago")
         
         
-        MercadoPagoTestContext.addExpectation(expectationWithDescription(BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION))
-        
         // Pago con medio off
         verifyConfirmPaymentOff()
         
@@ -90,7 +90,7 @@ class CheckoutViewControllerTest: BaseTest {
         XCTAssertNotNil(lastViewController)
         XCTAssertTrue(lastViewController!.isKindOfClass(InstructionsViewController))
 
-        waitForExpectationsWithTimeout(BaseTest.WAIT_EXPECTATION_TIME_INTERVAL, handler: nil)
+
         //Verificar payment method id seleccionado en instrucciones
         let instructionsVC = (lastViewController as! InstructionsViewController)
         XCTAssertEqual(instructionsVC.payment.paymentMethodId, self.selectedPaymentMethod?._id)
@@ -285,7 +285,6 @@ class CheckoutViewControllerTest: BaseTest {
     }
     
     
-    
     func verifyPaymentVaultSelection_creditCard(){
         
         self.selectedPaymentMethod = Utils.findPaymentMethod((self.checkoutViewController?.paymentMethodSearch!.paymentMethods)!, paymentMethodId: "visa")
@@ -308,22 +307,7 @@ class CheckoutViewControllerTest: BaseTest {
         XCTAssertTrue(checkoutViewController!.displayPreferenceDescription)
         
         let sections = checkoutViewController?.numberOfSectionsInTableView((checkoutViewController?.checkoutTable)!)
-        XCTAssertEqual(sections, 2)
-        
-        checkoutViewController?.checkoutTable.reloadData()
-        XCTAssertNotNil(checkoutViewController?.checkoutTable)
-        
-        let preferenceDescriptionCell = checkoutViewController?.tableView(checkoutViewController!.checkoutTable, cellForRowAtIndexPath: NSIndexPath(forRow: 0, inSection: 0)) as! PreferenceDescriptionTableViewCell
-        XCTAssertEqual(preferenceDescriptionCell.preferenceDescription.text, self.checkoutViewController?.preference?.items![0].title!)
-        
-        let preferenceAmount = preferenceDescriptionCell.preferenceAmount.attributedText
-        
-        let amountInCHOVC = self.checkoutViewController!.preference!.getAmount()
-        let amountAttributedText = Utils.getAttributedAmount(amountInCHOVC, thousandSeparator: ".", decimalSeparator: ",", currencySymbol: "$")
-        XCTAssertEqual(preferenceAmount!.string, amountAttributedText.string)
-    
-        let termsAndConditionsCell = checkoutViewController!.tableView(checkoutViewController!.checkoutTable, cellForRowAtIndexPath: NSIndexPath(forRow: 3, inSection: 1)) as!TermsAndConditionsViewCell
-        XCTAssertNotNil(termsAndConditionsCell)
+        XCTAssertEqual(sections, 0)
         
     }
     
@@ -338,6 +322,7 @@ class CheckoutViewControllerTest: BaseTest {
         XCTAssertTrue(paymentButton.enabled.boolValue)
         self.checkoutViewController!.confirmPayment()
         
+        waitForExpectationsWithTimeout(BaseTest.WAIT_EXPECTATION_TIME_INTERVAL, handler: nil)
         
     }
     
@@ -348,53 +333,9 @@ class CheckoutViewControllerTest: BaseTest {
         
         XCTAssertTrue(paymentButton.enabled.boolValue)
         self.checkoutViewController!.confirmPayment()
-
-    }
-//
-//    func testConfirmPaymentOn() {
-//        self.simulateViewDidLoadFor(self.checkoutViewController!)
-//        self.checkoutViewController!.paymentMethod = MockBuilder.buildPaymentMethod("visa")
-//      //  self.checkoutViewController!.paymentMethod?.paymentTypeId = PaymentTypeId.CREDIT_CARD
-//        
-//        let termsAndConditionsCell = checkoutViewController!.tableView(checkoutViewController!.checkoutTable, cellForRowAtIndexPath: NSIndexPath(forRow: 2, inSection: 1)) as!TermsAndConditionsViewCell
-//        XCTAssertNotNil(termsAndConditionsCell)
-//        self.checkoutViewController!.paymentButton = termsAndConditionsCell.paymentButton
-//        
-//       // self.checkoutViewController!.confirmPayment()
-//        //TODO
-//    }
-    
-//    func testViewForFooterInSection() {
-//        self.simulateViewDidLoadFor(self.checkoutViewController!)
-//        let noCopyrightCell = self.checkoutViewController?.tableView(self.checkoutViewController!.checkoutTable, viewForFooterInSection: 0)
-//        XCTAssertNil(noCopyrightCell)
-//        
-//        let copyrightCell = self.checkoutViewController?.tableView(self.checkoutViewController!.checkoutTable, viewForFooterInSection: 1)
-//        XCTAssertNotNil(copyrightCell)
-//        
-//        var footerHeight = self.checkoutViewController!.tableView(self.checkoutViewController!.checkoutTable, heightForFooterInSection: 0)
-//        XCTAssertEqual(footerHeight, 0)
-//        footerHeight = self.checkoutViewController!.tableView(self.checkoutViewController!.checkoutTable, heightForFooterInSection: 1)
-//       // XCTAssertEqual(footerHeight, 140)
-//    }
-//
-//    
-
-
-    func testOfflinePaymentMethodSelectedCell(){
-//        self.simulateViewDidLoadFor(self.checkoutViewController!)
-//        self.checkoutViewController!.paymentMethod = MockBuilder.buildPaymentMethod("bancomer_ticket")
-//        self.checkoutViewController!.paymentMethod?.paymentTypeId = PaymentTypeId.TICKET
-//        self.checkoutViewController!.paymentMethod!.comment = "comment"
-//        
-//        let paymentMethodCell = self.checkoutViewController!.tableView(self.checkoutViewController!.checkoutTable, cellForRowAtIndexPath: NSIndexPath(forRow: 0, inSection: 1)) as! OfflinePaymentMethodCell
-//        XCTAssertEqual(checkoutViewController?.title, "Revisa si está todo bien...".localized)
-//        let termsAndConditions = self.checkoutViewController!.tableView(self.checkoutViewController!.checkoutTable, cellForRowAtIndexPath: NSIndexPath(forRow: 2, inSection: 1)) as! TermsAndConditionsViewCell
-//        XCTAssertEqual(termsAndConditions.termsAndConditionsText.text, "Al pagar afirme que es mayor de edad y acepto los términos y condiciones de Mercado Pago")
-//        let cellComment = paymentMethodCell.comment.text!
-//        XCTAssertEqual(cellComment, self.checkoutViewController!.paymentMethod!.comment!)
-//        
         
+        waitForExpectationsWithTimeout(BaseTest.WAIT_EXPECTATION_TIME_INTERVAL, handler: nil)
+
     }
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/GuessingFormTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/GuessingFormTest.swift
@@ -19,7 +19,7 @@ class GuessingFormTest: BaseTest {
         MercadoPagoContext.setPublicKey(MockBuilder.MLA_PK)
     }
 
-    
+    /**/
     /*Test guessing con Amex , Visa y Mastercard*/
     func testCreditCardFormWithoutSettings(){
         
@@ -28,10 +28,9 @@ class GuessingFormTest: BaseTest {
             }, callbackCancel: {
                 
         })
-        MercadoPagoTestContext.addExpectation(expectationWithDescription(BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION))
+        
         self.simulateViewDidLoadFor(self.cardFormViewController!)
-
-        waitForExpectationsWithTimeout(BaseTest.WAIT_EXPECTATION_TIME_INTERVAL, handler: nil)
+        
         self.cardFormViewController?.textBox?.delegate = self.cardFormViewController
        
        self.checkCards()
@@ -41,13 +40,11 @@ class GuessingFormTest: BaseTest {
     func testCreditCardFormWithPaymentMethodList(){
 
         var pms : [PaymentMethod] = []
-        MercadoPagoTestContext.addExpectation(expectationWithDescription(BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION))
         
         MPServicesBuilder.getPaymentMethods({ (paymentMethods) -> Void in
             pms = paymentMethods!
         }) { (error) -> Void in
         }
-        waitForExpectationsWithTimeout(BaseTest.WAIT_EXPECTATION_TIME_INTERVAL, handler: nil)
         
         self.cardFormViewController = CardFormViewController(paymentSettings: nil, amount: 1000, token: nil, paymentMethods: pms, callback: { (paymentMethod, cardToken) in
             
@@ -63,15 +60,14 @@ class GuessingFormTest: BaseTest {
     
     /* Test excluyendo Visa (Testea que anden el resto de las tarjeas y que rechace Visa)*/
     func testPreferencePM(){
-        let pp :PaymentPreference? = PaymentPreference(defaultPaymentTypeId: nil, excludedPaymentMethodsIds: ["visa"], excludedPaymentTypesIds: nil, defaultPaymentMethodId: nil, maxAcceptedInstallment: nil, defaultInstallments: nil)
+        let pp :PaymentPreference? = PaymentPreference()
+        pp?.excludedPaymentMethodIds = ["visa"]
         var pms : [PaymentMethod] = []
-        MercadoPagoTestContext.addExpectation(expectationWithDescription("waitPMs"))
         
         MPServicesBuilder.getPaymentMethods({ (paymentMethods) -> Void in
             pms = paymentMethods!
         }) { (error) -> Void in
         }
-        waitForExpectationsWithTimeout(60, handler: nil)
         
         self.cardFormViewController = CardFormViewController(paymentSettings: pp, amount: 1000, token: nil, paymentMethods: pms, callback: { (paymentMethod, cardToken) in
             
@@ -90,13 +86,13 @@ class GuessingFormTest: BaseTest {
         checkPaymentNotMachingMethodGuessing("4170068810108020", pmId: "visa")
         
     }
-    
+ 
     
     /* Test excluyendo Tarjeta de Credito (Testea que rechace Visa, Amex y Mastercard)*/
     func testPreferencePT(){
-        let pp :PaymentPreference? = PaymentPreference(defaultPaymentTypeId: nil, excludedPaymentMethodsIds: nil, excludedPaymentTypesIds: ["credit_card"], defaultPaymentMethodId: nil, maxAcceptedInstallment: nil, defaultInstallments: nil)
+        let pp :PaymentPreference? = PaymentPreference()
+        pp?.excludedPaymentTypeIds = ["credit_card"]
         var pms : [PaymentMethod] = []
-        MercadoPagoTestContext.addExpectation(expectationWithDescription("waitPMs"))
         
         MPServicesBuilder.getPaymentMethods({ (paymentMethods) -> Void in
             pms = paymentMethods!
@@ -104,7 +100,6 @@ class GuessingFormTest: BaseTest {
         }) { (error) -> Void in
             // Mensaje de error correspondiente, ver que hacemos con el flujo
         }
-        waitForExpectationsWithTimeout(60, handler: nil)
         
         self.cardFormViewController = CardFormViewController(paymentSettings: pp, amount: 1000, token: nil, paymentMethods: pms, callback: { (paymentMethod, cardToken) in
             
@@ -124,7 +119,7 @@ class GuessingFormTest: BaseTest {
         
     }
     
-    
+ 
     func checkCards (){
         //VISA
         checkPaymentMethodGuessing("4170068810108020", pmId: "visa")
@@ -154,7 +149,7 @@ class GuessingFormTest: BaseTest {
         self.cardFormViewController?.updateCardSkin()
         
         XCTAssertNil(self.cardFormViewController?.paymentMethod)
-        XCTAssertNil(self.cardFormViewController?.cardFront?.cardLogo.image)
+   //     XCTAssertNil(self.cardFormViewController?.cardFront?.cardLogo.image)
         XCTAssertEqual(self.cardFormViewController?.cardView.backgroundColor,colorDefault)
 
         
@@ -169,5 +164,5 @@ class GuessingFormTest: BaseTest {
         self.cardFormViewController?.updateCardSkin()
         XCTAssertNil(self.cardFormViewController?.paymentMethod)
     }
-    
+ 
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoService.swift
@@ -20,6 +20,8 @@ public class MercadoPagoService: NSObject {
     
     public func request(uri: String, params: String?, body: AnyObject?, method: String, headers : NSDictionary? = nil, cache : Bool? = true, success: (jsonResult: AnyObject?) -> Void,
         failure: ((error: NSError) -> Void)?) {
+        
+            MercadoPagoTestContext.addExpectation(withDescription: BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION + uri)
             var finalUri = uri
             if params != nil {
                 finalUri = finalUri + "?" + params!
@@ -48,7 +50,7 @@ public class MercadoPagoService: NSObject {
                 }*/
                 
                 success(jsonResult: jsonResponse)
-                MercadoPagoTestContext.fulfillExpectation(BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION)
+                MercadoPagoTestContext.fulfillExpectation(BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION + uri)
             } catch {
                 failure!(error: NSError(domain: uri, code: 400, userInfo: nil))
             }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoTestContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoTestContext.swift
@@ -13,12 +13,18 @@ public class MercadoPagoTestContext : NSObject {
     
     static let sharedInstance = MercadoPagoTestContext()
     var expectations = ExpectationHash()
-
+    var testEnvironment : XCTestCase?
+    
     private override init() {
         
     }
     
     class func addExpectation(expectation : XCTestExpectation){
+        self.sharedInstance.expectations.add(expectation)
+    }
+    
+    class func addExpectation(withDescription expectationDescription : String) {
+        let expectation = self.sharedInstance.testEnvironment!.expectationWithDescription(expectationDescription)
         self.sharedInstance.expectations.add(expectation)
     }
     
@@ -49,9 +55,10 @@ struct ExpectationHash {
         print(items)
     }
     
-    func fulfillExpectation(withKey : String) {
+    mutating func fulfillExpectation(withKey : String) {
         if let expectation = items[withKey] {
-            expectation.fulfill()
+           expectation.fulfill()
+           items.removeValueForKey(withKey)
         }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoUIViewControllerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoUIViewControllerTest.swift
@@ -13,18 +13,17 @@ class MercadoPagoUIViewControllerTest: BaseTest {
     let viewController = MercadoPagoUIViewController()
 
     override func setUp() {
+        super.setUp()
         self.simulateViewDidLoadFor(self.viewController)
     }
 
     func testClearMercadoPagoStyleAndGoBack(){
-        self.setUp()
         self.viewController.clearMercadoPagoStyleAndGoBack()
         XCTAssertTrue(self.viewController.navigationController == nil || self.viewController.navigationController!.navigationBar.titleTextAttributes == nil)
         XCTAssertTrue(self.viewController.navigationController == nil || self.viewController.navigationController!.navigationBar.barTintColor == nil)
     }
     
     func testClearMercadoPagoStyleAndGoBackAnimated(){
-        self.setUp()
         self.viewController.clearMercadoPagoStyleAndGoBackAnimated()
         XCTAssertTrue(self.viewController.navigationController == nil || self.viewController.navigationController!.navigationBar.titleTextAttributes == nil)
         XCTAssertTrue(self.viewController.navigationController == nil || self.viewController.navigationController!.navigationBar.barTintColor == nil)

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockedResponse.plist
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockedResponse.plist
@@ -2,6 +2,880 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>GET/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_types=bank_transfer,ticket</key>
+	<string>{
+  &quot;groups&quot;: [
+    {
+      &quot;children&quot;: null,
+      &quot;children_header&quot;: null,
+      &quot;comment&quot;: &quot;&quot;,
+      &quot;description&quot;: &quot;Tarjeta de crédito&quot;,
+      &quot;id&quot;: &quot;credit_card&quot;,
+      &quot;show_icon&quot;: true,
+      &quot;type&quot;: &quot;payment_type&quot;
+    }
+  ],
+  &quot;payment_methods&quot;: [
+    {
+      &quot;id&quot;: &quot;visa&quot;,
+      &quot;name&quot;: &quot;Visa&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/visa.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/visa.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^4&quot;,
+            &quot;exclusion_pattern&quot;: &quot;^(487017)&quot;,
+            &quot;installments_pattern&quot;: &quot;^4&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;amex&quot;,
+      &quot;name&quot;: &quot;American Express&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/amex.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/amex.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^((34)|(37))&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^((34)|(37))&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 15,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 4,
+            &quot;card_location&quot;: &quot;front&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_number&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;master&quot;,
+      &quot;name&quot;: &quot;Mastercard&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/master.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/master.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^5&quot;,
+            &quot;exclusion_pattern&quot;: &quot;^((520053)|(546553)|(554472)|(531847)|(527601)|(501105)|(522135)|(522137)|(527555)|((542702)|(544764)|(550073)|(528824))|(557039)|((515073)|(515070)))&quot;,
+            &quot;installments_pattern&quot;: &quot;^5&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_number&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;issuer_id&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;argencard&quot;,
+      &quot;name&quot;: &quot;Argencard&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/argencard.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/argencard.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(501105)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;^((589562)|(527571)|(527572))&quot;,
+            &quot;installments_pattern&quot;: &quot;^(501105)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cabal&quot;,
+      &quot;name&quot;: &quot;Cabal&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cabal.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cabal.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^((627170)|(589657)|(603522)|(604((20[1-9])|(2[1-9][0-9])|(3[0-9]{2})|(400))))&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^((627170)|(589657)|(603522)|(604((20[1-9])|(2[1-9][0-9])|(3[0-9]{2})|(400))))&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cencosud&quot;,
+      &quot;name&quot;: &quot;Cencosud&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cencosud.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cencosud.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(603493)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(603493)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;diners&quot;,
+      &quot;name&quot;: &quot;Diners&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/diners.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/diners.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^((30)|(36)|(38))&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^((30)|(36)|(38))&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 14,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;naranja&quot;,
+      &quot;name&quot;: &quot;Naranja&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/naranja.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/naranja.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(589562)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(589562)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;none&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;nativa&quot;,
+      &quot;name&quot;: &quot;Nativa Mastercard&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/nativa.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/nativa.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(546553)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(546553)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_number&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cordobesa&quot;,
+      &quot;name&quot;: &quot;Cordobesa&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cordobesa.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cordobesa.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;unsupported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^((542702)|(544764)|(550073)|(528824))&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^((542702)|(544764)|(550073))&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;optional&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cmr&quot;,
+      &quot;name&quot;: &quot;CMR&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cmr.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cmr.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;unsupported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(557039)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(557039)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;optional&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cordial&quot;,
+      &quot;name&quot;: &quot;Cordial&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cordobesa.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cordobesa.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;unsupported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(522135|522137|527555)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(522135|522137|527555)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;optional&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    }
+  ]
+}</string>
+	<key>GET/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_methods=rapipago,pagofacil,cargavirtual,bapropagos,redlink</key>
+	<string>{
+  &quot;groups&quot;: [
+    {
+      &quot;children&quot;: null,
+      &quot;children_header&quot;: null,
+      &quot;comment&quot;: &quot;&quot;,
+      &quot;description&quot;: &quot;Tarjeta de crédito&quot;,
+      &quot;id&quot;: &quot;credit_card&quot;,
+      &quot;show_icon&quot;: true,
+      &quot;type&quot;: &quot;payment_type&quot;
+    }
+  ],
+  &quot;payment_methods&quot;: [
+    {
+      &quot;id&quot;: &quot;visa&quot;,
+      &quot;name&quot;: &quot;Visa&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/visa.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/visa.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^4&quot;,
+            &quot;exclusion_pattern&quot;: &quot;^(487017)&quot;,
+            &quot;installments_pattern&quot;: &quot;^4&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;amex&quot;,
+      &quot;name&quot;: &quot;American Express&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/amex.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/amex.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^((34)|(37))&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^((34)|(37))&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 15,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 4,
+            &quot;card_location&quot;: &quot;front&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_number&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;master&quot;,
+      &quot;name&quot;: &quot;Mastercard&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/master.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/master.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^5&quot;,
+            &quot;exclusion_pattern&quot;: &quot;^((520053)|(546553)|(554472)|(531847)|(527601)|(501105)|(522135)|(522137)|(527555)|((542702)|(544764)|(550073)|(528824))|(557039)|((515073)|(515070)))&quot;,
+            &quot;installments_pattern&quot;: &quot;^5&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_number&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;issuer_id&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;argencard&quot;,
+      &quot;name&quot;: &quot;Argencard&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/argencard.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/argencard.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(501105)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;^((589562)|(527571)|(527572))&quot;,
+            &quot;installments_pattern&quot;: &quot;^(501105)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cabal&quot;,
+      &quot;name&quot;: &quot;Cabal&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cabal.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cabal.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^((627170)|(589657)|(603522)|(604((20[1-9])|(2[1-9][0-9])|(3[0-9]{2})|(400))))&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^((627170)|(589657)|(603522)|(604((20[1-9])|(2[1-9][0-9])|(3[0-9]{2})|(400))))&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cencosud&quot;,
+      &quot;name&quot;: &quot;Cencosud&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cencosud.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cencosud.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(603493)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(603493)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;diners&quot;,
+      &quot;name&quot;: &quot;Diners&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/diners.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/diners.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^((30)|(36)|(38))&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^((30)|(36)|(38))&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 14,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;naranja&quot;,
+      &quot;name&quot;: &quot;Naranja&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/naranja.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/naranja.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(589562)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(589562)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;none&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;nativa&quot;,
+      &quot;name&quot;: &quot;Nativa Mastercard&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/nativa.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/nativa.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;supported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(546553)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(546553)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;mandatory&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_identification_number&quot;,
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cordobesa&quot;,
+      &quot;name&quot;: &quot;Cordobesa&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cordobesa.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cordobesa.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;unsupported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^((542702)|(544764)|(550073)|(528824))&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^((542702)|(544764)|(550073))&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;optional&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cmr&quot;,
+      &quot;name&quot;: &quot;CMR&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cmr.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cmr.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;unsupported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(557039)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(557039)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;optional&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    },
+    {
+      &quot;id&quot;: &quot;cordial&quot;,
+      &quot;name&quot;: &quot;Cordial&quot;,
+      &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+      &quot;status&quot;: &quot;active&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cordobesa.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cordobesa.gif&quot;,
+      &quot;deferred_capture&quot;: &quot;unsupported&quot;,
+      &quot;settings&quot;: [
+        {
+          &quot;bin&quot;: {
+            &quot;pattern&quot;: &quot;^(522135|522137|527555)&quot;,
+            &quot;exclusion_pattern&quot;: &quot;&quot;,
+            &quot;installments_pattern&quot;: &quot;^(522135|522137|527555)&quot;
+          },
+          &quot;card_number&quot;: {
+            &quot;length&quot;: 16,
+            &quot;validation&quot;: &quot;standard&quot;
+          },
+          &quot;security_code&quot;: {
+            &quot;mode&quot;: &quot;optional&quot;,
+            &quot;length&quot;: 3,
+            &quot;card_location&quot;: &quot;back&quot;
+          }
+        }
+      ],
+      &quot;additional_info_needed&quot;: [
+        &quot;cardholder_name&quot;,
+        &quot;cardholder_identification_type&quot;,
+        &quot;cardholder_identification_number&quot;
+      ],
+      &quot;min_allowed_amount&quot;: 0,
+      &quot;max_allowed_amount&quot;: 250000,
+      &quot;accreditation_time&quot;: 2880
+    }
+  ]
+}</string>
 	<key>GET/v1/payment_methods?public_key=PK_MLA</key>
 	<string>[{
       &quot;id&quot;:&quot;visa&quot;,

--- a/MercadoPagoSDK/MercadoPagoSDKTests/PaymentVaultViewControllerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/PaymentVaultViewControllerTest.swift
@@ -27,7 +27,7 @@ class PaymentVaultViewControllerTest: BaseTest {
     
     func testInit() {
         
-        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, currencyId: MockBuilder.MLA_CURRENCY, paymentPreference: nil, callback: { (paymentMethod, tokenId, issuer, installments) -> Void in
+        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, paymentPreference: nil, callback: { (paymentMethod, tokenId, issuer, installments) -> Void in
             
         })
         
@@ -37,9 +37,7 @@ class PaymentVaultViewControllerTest: BaseTest {
         XCTAssertNil(paymentVaultViewController?.currentPaymentMethodSearch)
         XCTAssertNil(paymentVaultViewController?.paymentMethods)
         
-        MercadoPagoTestContext.addExpectation(expectationWithDescription(BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION))
         self.simulateViewDidLoadFor(self.paymentVaultViewController!)
-        waitForExpectationsWithTimeout(BaseTest.WAIT_EXPECTATION_TIME_INTERVAL, handler: nil)
         
         XCTAssertNotNil(self.paymentVaultViewController?.currentPaymentMethodSearch)
         XCTAssertTrue(self.paymentVaultViewController?.currentPaymentMethodSearch!.count > 1)
@@ -61,9 +59,10 @@ class PaymentVaultViewControllerTest: BaseTest {
     func testPaymentVaultMLA_onlyCreditCard(){
         
         let excludedPaymentTypeIds = Set([PaymentTypeId.TICKET.rawValue, PaymentTypeId.BANK_TRANSFER.rawValue])
-        let paymentPreference = PaymentPreference(defaultPaymentTypeId: nil, excludedPaymentMethodsIds: nil, excludedPaymentTypesIds: excludedPaymentTypeIds, defaultPaymentMethodId: nil, maxAcceptedInstallment: nil, defaultInstallments: nil)
+        let paymentPreference = PaymentPreference()
         
-        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, currencyId: MockBuilder.MLA_CURRENCY, paymentPreference: paymentPreference, callback: { (paymentMethod, token, issuer, payerCost) in
+        paymentPreference.excludedPaymentTypeIds = excludedPaymentTypeIds
+        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, paymentPreference: paymentPreference, callback: { (paymentMethod, token, issuer, payerCost) in
             XCTAssertNotNil(paymentMethod)
             // Verificar selección correcta
             XCTAssertEqual(paymentMethod, self.paymentMethodSelected)
@@ -96,7 +95,7 @@ class PaymentVaultViewControllerTest: BaseTest {
      */
     func testPaymentVaultMLA_noPaymentPreference(){
         
-        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, currencyId: MockBuilder.MLA_CURRENCY, paymentPreference: nil, callback: { (paymentMethod, token, issuer, payerCost) in
+        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, paymentPreference: nil, callback: { (paymentMethod, token, issuer, payerCost) in
             XCTAssertNotNil(paymentMethod)
             // Verificar selección correcta
             XCTAssertEqual(paymentMethod, self.paymentMethodSelected)
@@ -134,9 +133,10 @@ class PaymentVaultViewControllerTest: BaseTest {
     func testPaymentVaultMLA_ticketAvailable(){
         
         let excludedPaymentTypeIds = Set([PaymentTypeId.CREDIT_CARD.rawValue, PaymentTypeId.BANK_TRANSFER.rawValue])
-        let paymentPreference = PaymentPreference(defaultPaymentTypeId: nil, excludedPaymentMethodsIds: nil, excludedPaymentTypesIds: excludedPaymentTypeIds, defaultPaymentMethodId: nil, maxAcceptedInstallment: nil, defaultInstallments: nil)
+        let paymentPreference = PaymentPreference()
         
-        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, currencyId: MockBuilder.MLA_CURRENCY, paymentPreference: paymentPreference, callback: { (paymentMethod, token, issuer, payerCost) in
+        paymentPreference.excludedPaymentTypeIds = excludedPaymentTypeIds
+        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, paymentPreference: paymentPreference, callback: { (paymentMethod, token, issuer, payerCost) in
             XCTAssertNotNil(paymentMethod)
             // Verificar selección correcta
             XCTAssertEqual(paymentMethod, self.paymentMethodSelected)
@@ -170,9 +170,11 @@ class PaymentVaultViewControllerTest: BaseTest {
         
         let excludedPaymentTypeIds = Set([PaymentTypeId.CREDIT_CARD.rawValue, PaymentTypeId.BANK_TRANSFER.rawValue])
         let excludedPaymentMethodIds = Set(arrayLiteral: "bapropagos", "rapipago", "cargavirtual")
-        let paymentPreference = PaymentPreference(defaultPaymentTypeId: nil, excludedPaymentMethodsIds: excludedPaymentMethodIds, excludedPaymentTypesIds: excludedPaymentTypeIds, defaultPaymentMethodId: nil, maxAcceptedInstallment: nil, defaultInstallments: nil)
+        let paymentPreference = PaymentPreference()
+        paymentPreference.excludedPaymentTypeIds = excludedPaymentTypeIds
+        paymentPreference.excludedPaymentMethodIds = excludedPaymentMethodIds
         
-        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, currencyId: MockBuilder.MLA_CURRENCY, paymentPreference: paymentPreference, callback: { (paymentMethod, token, issuer, payerCost) in
+        self.paymentVaultViewController = MockPaymentVaultViewController(amount: 2579, paymentPreference: paymentPreference, callback: { (paymentMethod, token, issuer, payerCost) in
             XCTAssertNotNil(paymentMethod)
             // Verificar selección correcta
             XCTAssertEqual(paymentMethod, self.paymentMethodSelected)


### PR DESCRIPTION
- Fix de target de tests unitarios
- Manejo de concurrencia de rquests unificada en MercadoPagoService (target de tests) y de carga de elementos de UI en BaseTest.simulateViewDidLoad
- Reporte de coverage disponible en Xcode para tests unitarios