### PR TITLE
Remove env urls for v1 services

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/GatewayService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/GatewayService.swift
@@ -10,11 +10,11 @@ import Foundation
 
 public class GatewayService : MercadoPagoService {
     
-    public func getToken(url : String = MercadoPago.MP_ENVIROMENT + "/card_tokens", method : String = "POST", public_key : String, savedCardToken : SavedCardToken, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+    public func getToken(url : String = "/v1/card_tokens", method : String = "POST", public_key : String, savedCardToken : SavedCardToken, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
         self.request(url, params: "public_key=" + public_key, body: savedCardToken.toJSONString(), method: method, success: success, failure: failure)
     }
     
-    public func getToken(url : String = MercadoPago.MP_ENVIROMENT + "/card_tokens", method : String = "POST", public_key : String, cardToken : CardToken, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+    public func getToken(url : String = "/v1/card_tokens", method : String = "POST", public_key : String, cardToken : CardToken, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
         self.request(url, params: "public_key=" + public_key, body: cardToken.toJSONString(), method: method, success: success, failure: failure)
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/GatewayService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/GatewayService.swift
@@ -10,11 +10,11 @@ import Foundation
 
 public class GatewayService : MercadoPagoService {
     
-    public func getToken(url : String = "/v1/card_tokens", method : String = "POST", public_key : String, savedCardToken : SavedCardToken, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+    public func getToken(url : String = MercadoPago.MP_OP_ENVIROMENT + "/card_tokens", method : String = "POST", public_key : String, savedCardToken : SavedCardToken, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
         self.request(url, params: "public_key=" + public_key, body: savedCardToken.toJSONString(), method: method, success: success, failure: failure)
     }
     
-    public func getToken(url : String = "/v1/card_tokens", method : String = "POST", public_key : String, cardToken : CardToken, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+    public func getToken(url : String = MercadoPago.MP_OP_ENVIROMENT + "/card_tokens", method : String = "POST", public_key : String, cardToken : CardToken, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
         self.request(url, params: "public_key=" + public_key, body: cardToken.toJSONString(), method: method, success: success, failure: failure)
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/Installment.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Installment.swift
@@ -54,7 +54,7 @@ public class Installment : NSObject {
     
     public func numberOfPayerCostToShow(maxNumberOfInstallments : Int? = nil) -> Int{
         var count = 0
-        if (maxNumberOfInstallments == 0){
+        if (maxNumberOfInstallments == 0 || maxNumberOfInstallments == nil){
             return self.payerCosts!.count
         }
         for pc in payerCosts! {

--- a/MercadoPagoSDK/MercadoPagoSDK/InstructionsService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/InstructionsService.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class InstructionsService: MercadoPagoService {
 
-    public let MP_INSTRUCTIONS_URI = MercadoPago.MP_ENVIROMENT + "/checkout/payments/${payment_id}/results"
+    public let MP_INSTRUCTIONS_URI = MercadoPago.MP_ENVIROMENT + "/payments/${payment_id}/results"
     
     public init(){
         super.init(baseURL: MercadoPago.MP_API_BASE_URL)

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPago.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPago.swift
@@ -59,13 +59,13 @@ public class MercadoPago : NSObject, UIAlertViewDelegate {
     let BIN_LENGTH : Int = 6
     
     
-    static var MP_TEST_ENV = "/beta/checkout"
-    static let MP_PROD_ENV = "/v1/checkout"
-    static let MP_ENVIROMENT = MP_PROD_ENV
+    static var MP_TEST_ENV = "/beta"
+    static let MP_PROD_ENV = "/v1"
+    static let MP_ENVIROMENT = MP_PROD_ENV  + "/checkout"
     
     static let MP_API_BASE_URL : String = "https://api.mercadopago.com"
     static let MP_CUSTOMER_URI = "/customers?preference_id="
-    static let MP_PAYMENTS_URI = MP_ENVIROMENT + "/checkout/payments"
+    static let MP_PAYMENTS_URI = MP_ENVIROMENT + "/payments"
     
     public var privateKey : String?
     public var pk : String!

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPago.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPago.swift
@@ -63,6 +63,8 @@ public class MercadoPago : NSObject, UIAlertViewDelegate {
     static let MP_PROD_ENV = "/v1"
     static let MP_ENVIROMENT = MP_PROD_ENV  + "/checkout"
     
+    static let MP_OP_ENVIROMENT = "/v1"
+    
     static let MP_API_BASE_URL : String = "https://api.mercadopago.com"
     static let MP_CUSTOMER_URI = "/customers?preference_id="
     static let MP_PAYMENTS_URI = MP_ENVIROMENT + "/payments"

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPago.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPago.swift
@@ -59,8 +59,8 @@ public class MercadoPago : NSObject, UIAlertViewDelegate {
     let BIN_LENGTH : Int = 6
     
     
-    static var MP_TEST_ENV = "/beta"
-    static let MP_PROD_ENV = "/v1"
+    static var MP_TEST_ENV = "/beta/checkout"
+    static let MP_PROD_ENV = "/v1/checkout"
     static let MP_ENVIROMENT = MP_PROD_ENV
     
     static let MP_API_BASE_URL : String = "https://api.mercadopago.com"

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchService.swift
@@ -19,10 +19,6 @@ public class PaymentMethodSearchService: MercadoPagoService {
     public func getPaymentMethods(amount : Double, excludedPaymentTypeIds : Set<String>?, excludedPaymentMethodIds : Set<String>?, success: (paymentMethodSearch: PaymentMethodSearch) -> Void, failure: ((error: NSError) -> Void)) {
         var params = "public_key=" + MercadoPagoContext.publicKey() + "&amount=" + String(amount)
         
-        if accessToken != nil && accessToken?.characters.count > 0 {
-            params = params + "&access_token=" + accessToken!
-        }
-        
         if excludedPaymentTypeIds != nil && excludedPaymentTypeIds?.count > 0 {
             let excludedPaymentTypesParams = excludedPaymentTypeIds!.map({$0}).joinWithSeparator(",")
             params = params + "&excluded_payment_types=" + String(excludedPaymentTypesParams).trimSpaces()

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchService.swift
@@ -18,7 +18,11 @@ public class PaymentMethodSearchService: MercadoPagoService {
     
     public func getPaymentMethods(amount : Double, excludedPaymentTypeIds : Set<String>?, excludedPaymentMethodIds : Set<String>?, success: (paymentMethodSearch: PaymentMethodSearch) -> Void, failure: ((error: NSError) -> Void)) {
         var params = "public_key=" + MercadoPagoContext.publicKey() + "&amount=" + String(amount)
-        params = params + "&access_token=" + "TEST-3655020329214032-122910-7f125ed5eecbaaa3d04f0c56953c95b6__LD_LC__-170206767"
+        
+        if accessToken != nil && accessToken?.characters.count > 0 {
+            params = params + "&access_token=" + accessToken!
+        }
+        
         if excludedPaymentTypeIds != nil && excludedPaymentTypeIds?.count > 0 {
             let excludedPaymentTypesParams = excludedPaymentTypeIds!.map({$0}).joinWithSeparator(",")
             params = params + "&excluded_payment_types=" + String(excludedPaymentTypesParams).trimSpaces()

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentService.swift
@@ -10,11 +10,11 @@ import Foundation
 
 public class PaymentService : MercadoPagoService {
     
-    public func getPaymentMethods(method: String = "GET", uri : String = MercadoPago.MP_ENVIROMENT + "/payment_methods", public_key : String, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+    public func getPaymentMethods(method: String = "GET", uri : String = "/v1/payment_methods", public_key : String, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
         self.request(uri, params: "public_key=" + public_key, body: nil, method: method, success: success, failure: failure)
     }
 
-    public func getInstallments(method: String = "GET", uri : String = MercadoPago.MP_ENVIROMENT + "/payment_methods/installments", public_key : String, bin : String?, amount: Double, issuer_id: NSNumber?, payment_method_id: String, success: ([Installment]) -> Void, failure: ((error: NSError) -> Void)) {
+    public func getInstallments(method: String = "GET", uri : String = "/v1/payment_methods/installments", public_key : String, bin : String?, amount: Double, issuer_id: NSNumber?, payment_method_id: String, success: ([Installment]) -> Void, failure: ((error: NSError) -> Void)) {
         var params : String = "public_key=" + public_key
         if(bin != nil){
                     params = params + "&bin=" + bin!

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentService.swift
@@ -10,11 +10,11 @@ import Foundation
 
 public class PaymentService : MercadoPagoService {
     
-    public func getPaymentMethods(method: String = "GET", uri : String = "/v1/payment_methods", public_key : String, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+    public func getPaymentMethods(method: String = "GET", uri : String = MercadoPago.MP_OP_ENVIROMENT + "/payment_methods", public_key : String, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
         self.request(uri, params: "public_key=" + public_key, body: nil, method: method, success: success, failure: failure)
     }
 
-    public func getInstallments(method: String = "GET", uri : String = "/v1/payment_methods/installments", public_key : String, bin : String?, amount: Double, issuer_id: NSNumber?, payment_method_id: String, success: ([Installment]) -> Void, failure: ((error: NSError) -> Void)) {
+    public func getInstallments(method: String = "GET", uri : String = MercadoPago.MP_OP_ENVIROMENT + "/payment_methods/installments", public_key : String, bin : String?, amount: Double, issuer_id: NSNumber?, payment_method_id: String, success: ([Installment]) -> Void, failure: ((error: NSError) -> Void)) {
         var params : String = "public_key=" + public_key
         if(bin != nil){
                     params = params + "&bin=" + bin!
@@ -51,7 +51,7 @@ public class PaymentService : MercadoPagoService {
         })
     }
     
-    public func getIssuers(method: String = "GET", uri : String = "/v1/payment_methods/card_issuers", public_key : String, payment_method_id: String, bin: String? = nil, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+    public func getIssuers(method: String = "GET", uri : String = MercadoPago.MP_OP_ENVIROMENT + "/payment_methods/card_issuers", public_key : String, payment_method_id: String, bin: String? = nil, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
         if(bin != nil){
             self.request(uri, params: "public_key=" + public_key + "&payment_method_id=" + payment_method_id + "&bin=" + bin!, body: nil, method: method, success: success, failure: failure)
         }else{

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentService.swift
@@ -51,7 +51,7 @@ public class PaymentService : MercadoPagoService {
         })
     }
     
-    public func getIssuers(method: String = "GET", uri : String = MercadoPago.MP_ENVIROMENT + "/payment_methods/card_issuers", public_key : String, payment_method_id: String, bin: String? = nil, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+    public func getIssuers(method: String = "GET", uri : String = "/v1/payment_methods/card_issuers", public_key : String, payment_method_id: String, bin: String? = nil, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
         if(bin != nil){
             self.request(uri, params: "public_key=" + public_key + "&payment_method_id=" + payment_method_id + "&bin=" + bin!, body: nil, method: method, success: success, failure: failure)
         }else{

--- a/MercadoPagoSDK/MercadoPagoSDK/PreferenceService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PreferenceService.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class PreferenceService: MercadoPagoService {
     
-    private var MP_PREFERENCE_URI = MercadoPago.MP_ENVIROMENT + "/checkout/preferences/"
+    private var MP_PREFERENCE_URI = MercadoPago.MP_ENVIROMENT + "/preferences/"
     
     init(){
         super.init(baseURL: MercadoPago.MP_API_BASE_URL)

--- a/MercadoPagoSDK/MercadoPagoSDK/PromosService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PromosService.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class PromosService : MercadoPagoService {
 	
-	public func getPromos(url : String = MercadoPago.MP_ENVIROMENT + "/payment_methods/deals", method : String = "GET", public_key: String, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+	public func getPromos(url : String = "/v1/payment_methods/deals", method : String = "GET", public_key: String, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
 		self.request(url, params: "public_key=" + public_key, body: nil, method: method, success: success, failure: failure)
 	}
     

--- a/MercadoPagoSDK/MercadoPagoSDK/PromosService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PromosService.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class PromosService : MercadoPagoService {
 	
-	public func getPromos(url : String = "/v1/payment_methods/deals", method : String = "GET", public_key: String, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
+	public func getPromos(url : String = MercadoPago.MP_OP_ENVIROMENT + "/payment_methods/deals", method : String = "GET", public_key: String, success: (jsonResult: AnyObject?) -> Void, failure: ((error: NSError) -> Void)?) {
 		self.request(url, params: "public_key=" + public_key, body: nil, method: method, success: success, failure: failure)
 	}
     


### PR DESCRIPTION
Aquellos servicios que se comunican con backend (fury) deberían poder ser seteados a BETA o PROD.
La creación de tokens, cuotas disponibles, medios de pagos disponibles y bancos son servicios provistos por OP, por lo que no se testean en distintos ambientes.