### PR TITLE
Card Manager in CardFormVC

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CardFormViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardFormViewController.swift
@@ -32,15 +32,7 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
 
     var editingLabel : UILabel?
     
-    var paymentMethods : [PaymentMethod]?
-    var paymentMethod : PaymentMethod?
-    var customerCard : CardInformation?
-    var token : Token?
-    var cardToken : CardToken?
-    var paymentSettings : PaymentPreference?
     var callback : (( paymentMethod: PaymentMethod,cardtoken: CardToken?) -> Void)?
-    var amount : Double?
-    
     
     var textMaskFormater = TextMaskFormater(mask: "XXXX XXXX XXXX XXXX")
     var textEditMaskFormater = TextMaskFormater(mask: "XXXX XXXX XXXX XXXX", completeEmptySpaces :false)
@@ -53,6 +45,7 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
     var doneNext : UIBarButtonItem?
     var donePrev : UIBarButtonItem?
     
+    var cardFormManager : CardViewModelManager?
     
     override public var screenName : String { get { return "CARD_NUMBER" } }
     
@@ -94,15 +87,8 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
 
     public init(paymentSettings : PaymentPreference?, amount:Double!, token: Token? = nil, cardInformation : CardInformation? = nil, paymentMethods : [PaymentMethod]? = nil,  callback : ((paymentMethod: PaymentMethod, cardToken: CardToken?) -> Void), callbackCancel : (Void -> Void)? = nil) {
         super.init(nibName: "CardFormViewController", bundle: MercadoPago.getBundle())
-        self.paymentSettings = paymentSettings
-        self.token = token
-        self.paymentMethods = paymentMethods
-        self.callback = callback
-        self.amount = amount
+        self.cardFormManager = CardViewModelManager(amount: amount, paymentMethods: paymentMethods, customerCard: cardInformation, token: token, paymentSettings: paymentSettings)
         self.callbackCancel = callbackCancel
-        self.paymentMethod = cardInformation?.getPaymentMethod()
-        self.customerCard = cardInformation
-        
     }
     
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
@@ -132,14 +118,14 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
         textBox.placeholder = "Número de tarjeta".localized
         textBox.becomeFirstResponder()
 
-        if paymentMethod != nil {
+        if self.cardFormManager!.paymentMethod != nil {
             self.updateCardSkin()
         }
         
-        if self.customerCard != nil {
+        if self.cardFormManager!.customerCard != nil {
             let textMaskFormaterAux = TextMaskFormater(mask: "XXXX XXXX XXXX XXXX", completeEmptySpaces: true)
-            self.cardNumberLabel?.text = textMaskFormaterAux.textMasked(self.customerCard?.getCardBin(), remasked: false)
-            self.cardNumberLabel?.text = textMaskFormaterAux.textMasked(self.customerCard?.getCardBin(), remasked: false)
+            self.cardNumberLabel?.text = textMaskFormaterAux.textMasked(self.cardFormManager!.customerCard?.getCardBin(), remasked: false)
+            self.cardNumberLabel?.text = textMaskFormaterAux.textMasked(self.cardFormManager!.customerCard?.getCardBin(), remasked: false)
             
             let textMaskFormaterAuxSec = TextMaskFormater(mask: "XXXX XXXX XXXX XXXX", completeEmptySpaces: true, leftToRight: false)
          //   textMaskFormaterAuxSec.textMasked(self.)
@@ -151,17 +137,13 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
        
     }
     
-    public func setPMs(pms : [PaymentMethod]){
-        self.paymentMethods = pms
-    }
-  
     override public func viewDidLoad() {
         super.viewDidLoad()
 
 
-        if (self.paymentMethods == nil){
+        if (self.cardFormManager!.paymentMethods == nil){
             MPServicesBuilder.getPaymentMethods({ (paymentMethods) -> Void in
-                self.setPMs(paymentMethods!)
+                self.cardFormManager?.paymentMethods = paymentMethods
                 }) { (error) -> Void in
                     // Mensaje de error correspondiente, ver que hacemos con el flujo
             }
@@ -342,11 +324,11 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
                 return true
             }
             if(((textEditMaskFormater.textUnmasked(textField.text).characters.count) == 6) && (string.characters.count > 0)){
-                if (paymentMethod == nil){
+                if (cardFormManager!.paymentMethod == nil){
                     return false
                 }
             }else{
-                if ((textEditMaskFormater.textUnmasked(textField.text).characters.count) == paymentMethod?.cardNumberLenght()){
+                if ((textEditMaskFormater.textUnmasked(textField.text).characters.count) == cardFormManager!.paymentMethod?.cardNumberLenght()){
                     return false
                 }
                 
@@ -410,32 +392,6 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
 
     }
     
-    
-    func validInputCVV(text : String) -> Bool{
-        if( text.characters.count > self.cvvLenght() ){
-            return false
-        }
-        let num = Int(text)
-        return (num != nil)
-    }
-    
-    func cvvLenght() -> Int{
-        var lenght : Int
-        
-        if customerCard != nil {
-            lenght = (self.customerCard?.getCardSecurityCode().length)!
-        } else {
-            if ((paymentMethod?.settings == nil)||(paymentMethod?.settings.count == 0)){
-                lenght = 3 // Default
-            }else{
-                lenght = (paymentMethod?.settings[0].securityCode.length)!
-            }
-        }
-        return lenght
-    }
-    
-    
-
 
     func setupInputAccessoryView() {
         inputButtons = UINavigationBar(frame: CGRectMake(0, 0, UIScreen.mainScreen().bounds.size.width, 44))
@@ -454,7 +410,7 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
         doneNext?.setTitlePositionAdjustment(UIOffset(horizontal: -UIScreen.mainScreen().bounds.size.width / 8, vertical: 0), forBarMetrics: UIBarMetrics.Default)
         navItem!.rightBarButtonItem = doneNext
         navItem!.leftBarButtonItem = donePrev
-        if self.customerCard != nil {
+        if self.cardFormManager!.customerCard != nil {
             navItem!.leftBarButtonItem?.enabled = false
         }
         inputButtons!.pushNavigationItem(navItem!, animated: false)
@@ -498,7 +454,7 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
             prepareNameLabelForEdit()
             
         case cvvLabel! :
-              if (self.paymentMethod!.secCodeInBack()){
+              if (self.cardFormManager!.paymentMethod!.secCodeInBack()){
                 UIView.transitionFromView(self.cardBack!, toView: self.cardFront!, duration: 1, options: UIViewAnimationOptions.TransitionFlipFromRight, completion: { (completion) -> Void in
                 })
             }
@@ -515,8 +471,8 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
             
         case cardNumberLabel! :
             if (checkCardNumber() == false){
-                if (paymentMethod != nil){
-                        showErrorMessage((cardToken?.validateCardNumber(paymentMethod!)?.userInfo["cardNumber"] as? String)!)
+                if (cardFormManager!.paymentMethod != nil){
+                    showErrorMessage((cardFormManager!.cardToken?.validateCardNumber(cardFormManager!.paymentMethod!)?.userInfo["cardNumber"] as? String)!)
                 }else{
                     if (cardNumberLabel?.text?.characters.count == 0){
                         showErrorMessage("Ingresa el número de la tarjeta de crédito".localized)
@@ -540,14 +496,14 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
             
         case expirationDateLabel! :
             
-            if (paymentMethod != nil){
-                if (!(paymentMethod?.isSecurityCodeRequired(getBIN()!))!){
+            if (cardFormManager!.paymentMethod != nil){
+                if (!(cardFormManager!.paymentMethod?.isSecurityCodeRequired(getBIN()!))!){
                     self.confirmPaymentMethod()
                     return
                 }
             }
             if (checkExpirationDateCard() == false){
-                showErrorMessage((cardToken?.validateExpiryDate()?.userInfo["expiryDate"] as? String)!)
+                showErrorMessage((cardFormManager!.cardToken?.validateExpiryDate()?.userInfo["expiryDate"] as? String)!)
 
                 return
             }
@@ -560,7 +516,7 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
         case cvvLabel! :
             if (checkCVV() == false){
                 
-                showErrorMessage(("Ingresa los %1$s números del código de seguridad".localized as NSString).stringByReplacingOccurrencesOfString("%1$s", withString: ((paymentMethod?.secCodeLenght())! as NSNumber).stringValue))
+                showErrorMessage(("Ingresa los %1$s números del código de seguridad".localized as NSString).stringByReplacingOccurrencesOfString("%1$s", withString: ((cardFormManager!.paymentMethod?.secCodeLenght())! as NSNumber).stringValue))
                    return
             }
             self.confirmPaymentMethod()
@@ -588,10 +544,10 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
     }
     
     func matchedPaymentMethod () -> PaymentMethod? {
-        if paymentMethod != nil {
-            return self.paymentMethod
+        if cardFormManager!.paymentMethod != nil {
+            return self.cardFormManager!.paymentMethod
         }
-        if(paymentMethods == nil){
+        if(cardFormManager!.paymentMethods == nil){
             return nil
         }
         if(getBIN() == nil){
@@ -599,9 +555,9 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
         }
         
         
-        for (_, value) in paymentMethods!.enumerate() {
+        for (_, value) in cardFormManager!.paymentMethods!.enumerate() {
             
-            if (value.conformsPaymentPreferences(self.paymentSettings)){
+            if (value.conformsPaymentPreferences(self.cardFormManager!.paymentSettings)){
                 if (value.conformsToBIN(getBIN()!)){
                     return value.cloneWithBIN(getBIN()!)
                 }
@@ -630,25 +586,25 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
         textEditMaskFormater = textMaskFormaterAux
         textEditMaskFormater = textEditMaskFormaterAux
         cardFront?.cardCVV.alpha = 0
-        paymentMethod = nil
+        cardFormManager!.paymentMethod = nil
         self.updateLabelsFontColors()
         
     }
     
     func updateCardSkin(){
        
-        if (textEditMaskFormater.textUnmasked(textBox.text).characters.count==6 || customerCard != nil){
+        if (textEditMaskFormater.textUnmasked(textBox.text).characters.count==6 || cardFormManager!.customerCard != nil){
             let pmMatched = self.matchedPaymentMethod()
             
-            paymentMethod = pmMatched
-            if(paymentMethod != nil){
+            cardFormManager!.paymentMethod = pmMatched
+            if(cardFormManager!.paymentMethod != nil){
                 UIView.animateWithDuration(0.7, animations: { () -> Void in
-               self.cardFront?.cardLogo.image =  MercadoPago.getImageFor(self.paymentMethod!)
-                    self.cardView.backgroundColor = MercadoPago.getColorFor(self.paymentMethod!)
+               self.cardFront?.cardLogo.image =  MercadoPago.getImageFor(self.cardFormManager!.paymentMethod!)
+                    self.cardView.backgroundColor = MercadoPago.getColorFor(self.cardFormManager!.paymentMethod!)
                     self.cardFront?.cardLogo.alpha = 1
                 })
-                let labelMask = (paymentMethod?.getLabelMask() != nil) ? paymentMethod?.getLabelMask() : "XXXX XXXX XXXX XXXX"
-                let editTextMask = (paymentMethod?.getEditTextMask() != nil) ? paymentMethod?.getEditTextMask() : "XXXX XXXX XXXX XXXX"
+                let labelMask = (cardFormManager!.paymentMethod?.getLabelMask() != nil) ? cardFormManager!.paymentMethod?.getLabelMask() : "XXXX XXXX XXXX XXXX"
+                let editTextMask = (cardFormManager!.paymentMethod?.getEditTextMask() != nil) ? cardFormManager!.paymentMethod?.getEditTextMask() : "XXXX XXXX XXXX XXXX"
                 let textMaskFormaterAux = TextMaskFormater(mask: labelMask)
                 let textEditMaskFormaterAux = TextMaskFormater(mask:editTextMask, completeEmptySpaces :false)
                 cardNumberLabel?.text = textMaskFormaterAux.textMasked(textMaskFormater.textUnmasked(cardNumberLabel!.text))
@@ -667,7 +623,7 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
             self.clearCardSkin()
         }
         
-        if((paymentMethod != nil)&&(!paymentMethod!.secCodeInBack())){
+        if((cardFormManager!.paymentMethod != nil)&&(!cardFormManager!.paymentMethod!.secCodeInBack())){
             cvvLabel = cardFront?.cardCVV
             cardBack?.cardCVV.text = ""
             cardFront?.cardCVV.alpha = 1
@@ -687,8 +643,8 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
         if(getBIN() == nil){
             return false
         }
-        if(paymentMethod != nil){
-            return paymentMethod!.isAmex()
+        if(cardFormManager!.paymentMethod != nil){
+            return cardFormManager!.paymentMethod!.isAmex()
         }else{
             return false
         }
@@ -697,14 +653,14 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
     
     
     func delightedLabels(){
-        if (self.paymentMethod == nil){
+        if (self.cardFormManager!.paymentMethod == nil){
             cardNumberLabel?.textColor = MPLabel.defaultColorText
             nameLabel?.textColor = MPLabel.defaultColorText
             expirationDateLabel?.textColor = MPLabel.defaultColorText
         }else{
-            cardNumberLabel?.textColor = MercadoPago.getFontColorFor(self.paymentMethod!)
-            nameLabel?.textColor = MercadoPago.getFontColorFor(self.paymentMethod!)
-            expirationDateLabel?.textColor = MercadoPago.getFontColorFor(self.paymentMethod!)
+            cardNumberLabel?.textColor = MercadoPago.getFontColorFor(self.cardFormManager!.paymentMethod!)
+            nameLabel?.textColor = MercadoPago.getFontColorFor(self.cardFormManager!.paymentMethod!)
+            expirationDateLabel?.textColor = MercadoPago.getFontColorFor(self.cardFormManager!.paymentMethod!)
             
         }
         cvvLabel?.textColor = MPLabel.defaultColorText
@@ -718,10 +674,10 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
     
     func lightEditingLabel(){
         if (editingLabel != cvvLabel){
-            if (paymentMethod == nil){
+            if (cardFormManager!.paymentMethod == nil){
                 editingLabel?.textColor = MPLabel.highlightedColorText
             }else{
-                editingLabel?.textColor =  MercadoPago.getEditingFontColorFor(self.paymentMethod!)
+                editingLabel?.textColor =  MercadoPago.getEditingFontColorFor(self.cardFormManager!.paymentMethod!)
             }
 
         }
@@ -745,22 +701,22 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
         let name = nameLabelEmpty ? "" : nameLabel?.text
         
         
-        self.cardToken = CardToken(cardNumber: number, expirationMonth: month, expirationYear: year, securityCode: secCode, cardholderName: name!, docType: "", docNumber: "")
+        self.cardFormManager!.cardToken = CardToken(cardNumber: number, expirationMonth: month, expirationYear: year, securityCode: secCode, cardholderName: name!, docType: "", docNumber: "")
         
     }
     
     private func createSavedCardToken() -> CardToken {
-        let securityCode = self.customerCard!.isSecurityCodeRequired() ? self.cvvLabel?.text : nil
-        return  SavedCardToken(card: customerCard!, securityCode: securityCode, securityCodeRequired: self.customerCard!.isSecurityCodeRequired())
+        let securityCode = self.cardFormManager!.customerCard!.isSecurityCodeRequired() ? self.cvvLabel?.text : nil
+        return  SavedCardToken(card: cardFormManager!.customerCard!, securityCode: securityCode, securityCodeRequired: self.cardFormManager!.customerCard!.isSecurityCodeRequired())
     }
     
     func checkCardNumber() -> Bool{
         
-        if(self.paymentMethod == nil){
+        if(self.cardFormManager!.paymentMethod == nil){
             return false
         }
         tokenHidratate()
-        let errorMethod = self.cardToken!.validateCardNumber(paymentMethod!)
+        let errorMethod = self.cardFormManager!.cardToken!.validateCardNumber(cardFormManager!.paymentMethod!)
         if((errorMethod) != nil){
             return false
         }
@@ -768,14 +724,14 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
     }
     func checkCardName() -> Bool{
         tokenHidratate()
-        if ( cardToken!.validateCardholderName() != nil ){
+        if ( cardFormManager!.cardToken!.validateCardholderName() != nil ){
             return false
         }
         return true
     }
     func checkExpirationDateCard() -> Bool{
          tokenHidratate()
-        let errorMethod = cardToken!.validateExpiryDate()
+        let errorMethod = cardFormManager!.cardToken!.validateExpiryDate()
         if((errorMethod) != nil){
             return false
         }
@@ -783,10 +739,10 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
     }
     func checkCVV() -> Bool{
          tokenHidratate()
-        if (cvvLabel?.text?.stringByReplacingOccurrencesOfString("•", withString: "").characters.count < paymentMethod?.secCodeLenght()){
+        if (cvvLabel?.text?.stringByReplacingOccurrencesOfString("•", withString: "").characters.count < cardFormManager!.paymentMethod?.secCodeLenght()){
             return false
         }
-        let errorMethod = cardToken!.validateSecurityCode()
+        let errorMethod = cardFormManager!.cardToken!.validateSecurityCode()
         if((errorMethod) != nil){
             return false
         }
@@ -795,16 +751,16 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
     
     func makeToken(){
         
-        if customerCard != nil {
-            cardToken = createSavedCardToken()
-            if !cardToken!.validate() {
+        if cardFormManager!.customerCard != nil {
+            cardFormManager!.cardToken = createSavedCardToken()
+            if !cardFormManager!.cardToken!.validate() {
                 markErrorLabel(cvvLabel!)
             }
         } else {
             tokenHidratate()
             
-            if (paymentMethod != nil){
-                let errorMethod = cardToken!.validateCardNumber(paymentMethod!)
+            if (cardFormManager!.paymentMethod != nil){
+                let errorMethod = cardFormManager!.cardToken!.validateCardNumber(cardFormManager!.paymentMethod!)
                 if((errorMethod) != nil){
                     markErrorLabel(cardNumberLabel!)
                     return
@@ -815,18 +771,18 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
                 return
             }
             
-            let errorDate = cardToken!.validateExpiryDate()
+            let errorDate = cardFormManager!.cardToken!.validateExpiryDate()
             if((errorDate) != nil){
                 markErrorLabel(expirationDateLabel!)
                 return
             }
-            let errorName = cardToken!.validateCardholderName()
+            let errorName = cardFormManager!.cardToken!.validateCardholderName()
             if((errorName) != nil){
                 markErrorLabel(nameLabel!)
                 return
             }
-            if(paymentMethod!.isSecurityCodeRequired(getBIN()!)){
-                let errorCVV = cardToken!.validateSecurityCode()
+            if(cardFormManager!.paymentMethod!.isSecurityCodeRequired(getBIN()!)){
+                let errorCVV = cardFormManager!.cardToken!.validateSecurityCode()
                 if((errorCVV) != nil){
                     markErrorLabel(cvvLabel!)
                     UIView.transitionFromView(self.cardBack!, toView: self.cardFront!, duration: 1, options: UIViewAnimationOptions.TransitionFlipFromLeft, completion: nil)
@@ -835,7 +791,7 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
             }
         }
         
-        self.callback!(paymentMethod: self.paymentMethod!, cardtoken: self.cardToken!)
+        self.callback!(paymentMethod: self.cardFormManager!.paymentMethod!, cardtoken: self.cardFormManager!.cardToken!)
     }
     
     
@@ -895,12 +851,12 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
     
     
     func hidratateWithToken(){
-        if ( self.token == nil ){
+        if ( self.cardFormManager!.token == nil ){
             return
         }
-        self.nameLabel?.text = self.token?.cardHolder?.name
-        self.cardNumberLabel?.text = self.token?.getMaskNumber()
-        self.expirationDateLabel?.text = self.token?.getExpirationDateFormated()
+        self.nameLabel?.text = self.cardFormManager!.token?.cardHolder?.name
+        self.cardNumberLabel?.text = self.cardFormManager!.token?.getMaskNumber()
+        self.expirationDateLabel?.text = self.cardFormManager!.token?.getExpirationDateFormated()
     }
 
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/CardFormViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardFormViewController.swift
@@ -339,7 +339,7 @@ public class CardFormViewController: MercadoPagoUIViewController , UITextFieldDe
        
         case expirationDateLabel! : return validInputDate(textField, shouldChangeCharactersInRange: range, replacementString: string)
         
-        case cvvLabel! : return self.cardFormManager!.validInputCVV(textField.text! + string)
+        case cvvLabel! : return self.cardFormManager!.isValidInputCVV(textField.text! + string)
         default : return false
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/CardViewModelManager.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardViewModelManager.swift
@@ -80,7 +80,7 @@ class CardViewModelManager: NSObject {
     }
     
     /*TODO : VER QUE ONDA, PORQUE DOS VALID CVV?? **/
-    func validInputCVV(text : String) -> Bool{
+    func isValidInputCVV(text : String) -> Bool{
         if( text.characters.count > self.cvvLenght() ){
             return false
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/CardViewModelManager.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardViewModelManager.swift
@@ -22,6 +22,9 @@ class CardViewModelManager: NSObject {
     let textMaskFormater = TextMaskFormater(mask: "XXXX XXXX XXXX XXXX")
     let textEditMaskFormater = TextMaskFormater(mask: "XXXX XXXX XXXX XXXX", completeEmptySpaces :false)
     
+    var cvvEmpty: Bool = true
+    var cardholderNameEmpty: Bool = true
+    
     init(amount : Double, paymentMethods : [PaymentMethod]?, paymentMethod : PaymentMethod? = nil, customerCard : CardInformation? = nil, token : Token? = nil, paymentSettings : PaymentPreference?){
         self.amount = amount
         self.paymentMethods = paymentMethods
@@ -46,7 +49,37 @@ class CardViewModelManager: NSObject {
         }
         return lenght
     }
+ 
+    func getLabelTextColor() -> UIColor {
+        return (self.paymentMethod == nil) ? MPLabel.defaultColorText : MercadoPago.getFontColorFor(self.paymentMethod!)!
+    }
+
+    func getEditingLabelColor() -> UIColor {
+        return (self.paymentMethod == nil) ? MPLabel.highlightedColorText : MercadoPago.getEditingFontColorFor(self.paymentMethod!)!
+    }
     
+    func getExpirationMonthFromLabel(expirationDateLabel : MPLabel)->Int {
+        return Utils.getExpirationMonthFromLabelText(expirationDateLabel.text!)
+    }
+
+    func getExpirationYearFromLabel(expirationDateLabel : MPLabel)->Int {
+        return Utils.getExpirationYearFromLabelText(expirationDateLabel.text!)
+    }
+    
+    func getBIN(cardNumber : String) -> String?{
+        var trimmedNumber = cardNumber.stringByReplacingOccurrencesOfString(" ", withString: "")
+        trimmedNumber = trimmedNumber.stringByReplacingOccurrencesOfString(String(textMaskFormater.emptyMaskElement), withString: "")
+        
+        
+        if (trimmedNumber.characters.count < 6){
+            return nil
+        }else{
+            let bin = trimmedNumber.substringToIndex((trimmedNumber.startIndex.advancedBy(6)))
+            return bin
+        }
+    }
+    
+    /*TODO : VER QUE ONDA, PORQUE DOS VALID CVV?? **/
     func validInputCVV(text : String) -> Bool{
         if( text.characters.count > self.cvvLenght() ){
             return false
@@ -54,8 +87,109 @@ class CardViewModelManager: NSObject {
         let num = Int(text)
         return (num != nil)
     }
- 
+    
+    func validateCardNumber(cardNumberLabel : UILabel, expirationDateLabel : MPLabel, cvvLabel : UILabel, cardholderNameLabel : MPLabel) -> Bool{
+        
+        if(self.paymentMethod == nil){
+            return false
+        }
+        
+        self.tokenHidratate(cardNumberLabel.text!, expirationDate: expirationDateLabel.text!, cvv: cvvLabel.text!, cardholderName: cardholderNameLabel.text!)
+        
+        let errorMethod = self.cardToken!.validateCardNumber(self.paymentMethod!)
+        if((errorMethod) != nil){
+            return false
+        }
+        return true
+    }
+    
+    func validateCardholderName(cardNumberLabel : UILabel, expirationDateLabel : MPLabel, cvvLabel : UILabel, cardholderNameLabel : MPLabel) -> Bool{
+        
+        self.tokenHidratate(cardNumberLabel.text!, expirationDate: expirationDateLabel.text!, cvv: cvvLabel.text!, cardholderName: cardholderNameLabel.text!)
+        
+        if ( self.cardToken!.validateCardholderName() != nil ){
+            return false
+        }
+        return true
+    }
+    
+    func validateCvv(cardNumberLabel : UILabel, expirationDateLabel : MPLabel, cvvLabel : UILabel, cardholderNameLabel : MPLabel) -> Bool{
+        
+        self.tokenHidratate(cardNumberLabel.text!, expirationDate: expirationDateLabel.text!, cvv: cvvLabel.text!, cardholderName: cardholderNameLabel.text!)
+        
+        if (cvvLabel.text!.stringByReplacingOccurrencesOfString("•", withString: "").characters.count < self.paymentMethod?.secCodeLenght()){
+            return false
+        }
+        let errorMethod = self.cardToken!.validateSecurityCode()
+        if((errorMethod) != nil){
+            return false
+        }
+        return true
+    }
+    
+    func validateExpirationDate(cardNumberLabel : UILabel, expirationDateLabel : MPLabel, cvvLabel : UILabel, cardholderNameLabel : MPLabel) -> Bool{
+        
+        self.tokenHidratate(cardNumberLabel.text!, expirationDate: expirationDateLabel.text!, cvv: cvvLabel.text!, cardholderName: cardholderNameLabel.text!)
+        let errorMethod = self.cardToken!.validateExpiryDate()
+        if((errorMethod) != nil){
+            return false
+        }
+        return true
+    }
+    
+    /*TODO : deberia validarse esto acá???*/
+    func isAmexCard(cardNumber : String) -> Bool{
+        if(self.getBIN(cardNumber) == nil){
+            return false
+        }
+        if(self.paymentMethod != nil){
+            return self.paymentMethod!.isAmex()
+        }else{
+            return false
+        }
+    }
+    
+    func matchedPaymentMethod (cardNumber : String) -> PaymentMethod? {
+        if self.paymentMethod != nil {
+            return self.paymentMethod
+        }
+        if(self.paymentMethods == nil){
+            return nil
+        }
+        if(getBIN(cardNumber) == nil){
+            return nil
+        }
+        
+        
+        for (_, value) in self.paymentMethods!.enumerate() {
+            
+            if (value.conformsPaymentPreferences(self.paymentSettings)){
+                if (value.conformsToBIN(getBIN(cardNumber)!)){
+                    return value.cloneWithBIN(getBIN(cardNumber)!)
+                }
+            }
+            
+        }
+        return nil
+    }
+    
+    
+    func tokenHidratate(cardNumber : String, expirationDate : String, cvv : String, cardholderName : String) {
+        let number = cardNumber
+        let year = Utils.getExpirationYearFromLabelText(expirationDate)
+        let month = Utils.getExpirationMonthFromLabelText(expirationDate)
+        let secCode = cvvEmpty ? "" :cvv
+        let name = cardholderNameEmpty ? "" : cardholderName
+        
+        self.cardToken = CardToken(cardNumber: number, expirationMonth: month, expirationYear: year, securityCode: secCode, cardholderName: name, docType: "", docNumber: "")
+    }
+    
+    func buildSavedCardToken(cvv : String) -> CardToken {
+        let securityCode = self.customerCard!.isSecurityCodeRequired() ? cvv : ""
+        self.cardToken = SavedCardToken(card: self.customerCard!, securityCode: securityCode, securityCodeRequired: self.customerCard!.isSecurityCodeRequired())
+        return self.cardToken!
+    }
 
-
-
+    
+    
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/CardViewModelManager.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardViewModelManager.swift
@@ -1,0 +1,61 @@
+//
+//  CardViewModelManager.swift
+//  MercadoPagoSDK
+//
+//  Created by Maria cristina rodriguez on 9/8/16.
+//  Copyright © 2016 MercadoPago. All rights reserved.
+//
+
+import UIKit
+
+class CardViewModelManager: NSObject {
+
+    
+    var paymentMethods : [PaymentMethod]?
+    var paymentMethod : PaymentMethod?
+    var customerCard : CardInformation?
+    var token : Token?
+    var cardToken : CardToken?
+    var paymentSettings : PaymentPreference?
+    var amount : Double?
+    
+    let textMaskFormater = TextMaskFormater(mask: "XXXX XXXX XXXX XXXX")
+    let textEditMaskFormater = TextMaskFormater(mask: "XXXX XXXX XXXX XXXX", completeEmptySpaces :false)
+    
+    init(amount : Double, paymentMethods : [PaymentMethod]?, paymentMethod : PaymentMethod? = nil, customerCard : CardInformation? = nil, token : Token? = nil, paymentSettings : PaymentPreference?){
+        self.amount = amount
+        self.paymentMethods = paymentMethods
+        self.paymentMethod = paymentMethod
+        self.customerCard = customerCard
+        self.token = token
+        self.paymentSettings = paymentSettings
+    }
+    
+    
+    func cvvLenght() -> Int{
+        var lenght : Int
+        
+        if self.customerCard != nil {
+            lenght = (self.customerCard?.getCardSecurityCode().length)!
+        } else {
+            if ((paymentMethod?.settings == nil)||(paymentMethod?.settings.count == 0)){
+                lenght = 3 // Default
+            }else{
+                lenght = (paymentMethod?.settings[0].securityCode.length)!
+            }
+        }
+        return lenght
+    }
+    
+    func validInputCVV(text : String) -> Bool{
+        if( text.characters.count > self.cvvLenght() ){
+            return false
+        }
+        let num = Int(text)
+        return (num != nil)
+    }
+ 
+
+
+
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
@@ -219,5 +219,29 @@ class Utils {
         }
         return title
     }
+    
+    public static func getExpirationYearFromLabelText(mmyy : String) -> Int {
+        let stringMMYY = mmyy.stringByReplacingOccurrencesOfString("/", withString: "")
+        let validInt = Int(stringMMYY)
+        if(validInt == nil){
+            return 0
+        }
+        let floatMMYY = Float( validInt! / 100 )
+        let mm : Int = Int(floor(floatMMYY))
+        let yy = Int(stringMMYY)! - (mm*100)
+        return yy
+        
+    }
+    
+    public static func getExpirationMonthFromLabelText(mmyy : String) -> Int {
+        let stringMMYY = mmyy.stringByReplacingOccurrencesOfString("/", withString: "")
+        let validInt = Int(stringMMYY)
+        if(validInt == nil){
+            return 0
+        }
+        let floatMMYY = Float( validInt! / 100 )
+        let mm : Int = Int(floor(floatMMYY))
+        return mm
+    }
 
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
@@ -1,0 +1,140 @@
+//
+//  CardViewModelManagerTest.swift
+//  MercadoPagoSDK
+//
+//  Created by Maria cristina rodriguez on 9/8/16.
+//  Copyright © 2016 MercadoPago. All rights reserved.
+//
+
+import XCTest
+
+class CardViewModelManagerTest: BaseTest {
+
+    var cardFormManager : CardViewModelManager?
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testCvvLengthDefaultValue() {
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
+        
+        let cvvLengthDefault = self.cardFormManager?.cvvLenght()
+        XCTAssertEqual(cvvLengthDefault, 3)
+    }
+    
+    func testCvvLengthCustomerCardLength () {
+        let customerCard = MockBuilder.buildCard()
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: customerCard, token: nil, paymentSettings: nil)
+        
+        let cvvLengthFromCustomerCard = self.cardFormManager?.cvvLenght()
+        XCTAssertEqual(cvvLengthFromCustomerCard, customerCard.getCardSecurityCode().length)
+    }
+    
+    func testCvvLengthPaymentMethodSettingLength() {
+        let paymentMethod = MockBuilder.buildPaymentMethod("amex")
+        let setting = Setting()
+        setting.securityCode = SecurityCode()
+        setting.securityCode.length = 4
+        setting.securityCode.cardLocation = "front"
+        paymentMethod.settings = [setting]
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: paymentMethod, customerCard: nil, token: nil, paymentSettings: nil)
+        
+        let cvvLengthFromPaymentMethodSetting = self.cardFormManager?.cvvLenght()
+        XCTAssertEqual(cvvLengthFromPaymentMethodSetting, paymentMethod.secCodeLenght())
+    }
+    
+    func testGetLabelTextColorDefaultColor() {
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
+        
+        let color = self.cardFormManager?.getLabelTextColor()
+        XCTAssertEqual(color, MPLabel.defaultColorText)
+    }
+    
+    func testGetLabelTextColorPaymentMethodColor() {
+        let paymentMethod = MockBuilder.buildPaymentMethod("visa")
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: paymentMethod, customerCard: nil, token: nil, paymentSettings: nil)
+        
+        let color = self.cardFormManager?.getLabelTextColor()
+        let expectedColor = MercadoPago.getEditingFontColorFor(paymentMethod)
+        XCTAssertEqual(color, expectedColor)
+    }
+    
+    func testGetEditingLabelColorDefaultColor() {
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
+        
+        let color = self.cardFormManager?.getLabelTextColor()
+        XCTAssertEqual(color, MPLabel.highlightedColorText)
+    }
+    
+    func testGetEditingLabelColorPaymentMethodColor() {
+        let paymentMethod = MockBuilder.buildPaymentMethod("master")
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: paymentMethod, customerCard: nil, token: nil, paymentSettings: nil)
+        
+        let color = self.cardFormManager?.getLabelTextColor()
+        let expectedColor = MercadoPago.getEditingFontColorFor(paymentMethod)
+        XCTAssertEqual(color, expectedColor)
+    }
+    
+    func testGetExpirationDateFromLabel(){
+        let label = MPLabel()
+        label.text = "11/22"
+        
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
+        
+        let year = self.cardFormManager?.getExpirationYearFromLabel(label)
+        XCTAssertEqual(year, 22)
+        
+        let month = self.cardFormManager?.getExpirationMonthFromLabel(label)
+        XCTAssertEqual(month, 11)
+        
+    }
+    
+    func testGetBIN(){
+        let cardNumber = "12345677777777"
+        
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
+        
+        let bin = self.cardFormManager?.getBIN(cardNumber)
+        XCTAssertEqual(bin, "123456")
+    }
+    
+    func testIsAmex(){
+        
+        let amexCardNumber = "371180111111111"
+        let amexPaymentMethod = MockBuilder.buildPaymentMethod("amex")
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: amexPaymentMethod, customerCard: nil, token: nil, paymentSettings: nil)
+        var isAmex = self.cardFormManager!.isAmexCard(amexCardNumber)
+        XCTAssertTrue(isAmex)
+        
+        let masterCardNumber = "503175111111111"
+        let masterPaymentMethod = MockBuilder.buildPaymentMethod("master")
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: masterPaymentMethod, customerCard: nil, token: nil, paymentSettings: nil)
+        isAmex = self.cardFormManager!.isAmexCard(masterCardNumber)
+        XCTAssertFalse(isAmex)
+        
+        isAmex = self.cardFormManager!.isAmexCard("")
+        XCTAssertFalse(isAmex)
+    }
+    
+    func testMatchedPaymentMethod(){
+        let defaultPaymentMethod = MockBuilder.buildPaymentMethod("master")
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: defaultPaymentMethod, customerCard: nil, token: nil, paymentSettings: nil)
+        
+        let paymentMethodFound = self.cardFormManager?.matchedPaymentMethod("XXXX")
+        XCTAssertEqual(defaultPaymentMethod, paymentMethodFound)
+        
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
+        let noPaymentMethodFound = self.cardFormManager?.matchedPaymentMethod("XXXX")
+        XCTAssertNil(noPaymentMethodFound)
+        
+     
+        
+        
+
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
@@ -131,10 +131,42 @@ class CardViewModelManagerTest: BaseTest {
         self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
         let noPaymentMethodFound = self.cardFormManager?.matchedPaymentMethod("XXXX")
         XCTAssertNil(noPaymentMethodFound)
-        
-     
-        
-        
 
+    }
+    
+    func testTokenHidratate(){
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
+        self.cardFormManager?.cvvEmpty = false
+        self.cardFormManager?.cardholderNameEmpty = false
+        self.cardFormManager?.tokenHidratate("cardNumber", expirationDate: "11/22", cvv: "123", cardholderName: "cardholdername")
+        
+        XCTAssertEqual(self.cardFormManager?.cardToken?.cardNumber, "cardNumber")
+        XCTAssertEqual(self.cardFormManager?.cardToken?.expirationMonth, 11)
+        XCTAssertEqual(self.cardFormManager?.cardToken?.expirationYear, 2022)
+        XCTAssertEqual(self.cardFormManager?.cardToken?.securityCode, "123")
+        XCTAssertEqual(self.cardFormManager?.cardToken?.cardholder?.name, "cardholdername")
+    }
+    
+    func testBuildSavedCardToken(){
+        let customerCard = MockBuilder.buildCard()
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: customerCard, token: nil, paymentSettings: nil)
+        self.cardFormManager?.buildSavedCardToken("cvv")
+        
+        let savedCardToken = self.cardFormManager!.cardToken as! SavedCardToken
+        let savedCardtokenCardId = savedCardToken.cardId
+        //XCTAssertEqual(savedCardtokenCardId, customerCard.idCard)
+        XCTAssertEqual(savedCardToken.securityCode, "cvv")
+        XCTAssertEqual(savedCardToken.securityCodeRequired, customerCard.isSecurityCodeRequired())
+    }
+    
+    func testIsValidInputCVV() {
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
+        //TODO : acá hay casos locos
+        XCTAssertFalse(self.cardFormManager!.isValidInputCVV(""))
+        XCTAssertTrue(self.cardFormManager!.isValidInputCVV("123"))
+    }
+    
+    func testValidateCardNumber(){
+        
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/GuessingFormTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/GuessingFormTest.swift
@@ -170,8 +170,6 @@ class GuessingFormTest: BaseTest {
         
         self.checkOnlyPaymentMethodGuessing(MockBuilder.AMEX_TEST_CARD_NUMBER, pmId: "amex")
         
-        // Focus on cvv
-        XCTAssertEqual(self.cardFormViewController?.editingLabel, self.cardFormViewController?.cvvLabel)
         
         // Cvv displays on the front
         XCTAssertEqual(self.cardFormViewController?.cvvLabel, self.cardFormViewController?.cardFront?.cardCVV)
@@ -197,7 +195,7 @@ class GuessingFormTest: BaseTest {
         self.cardFormViewController?.updateCardSkin()
         
         
-        XCTAssertNil(self.cardFormViewController?.paymentMethod)
+        XCTAssertNil(self.cardFormViewController?.cardFormManager!.paymentMethod)
    //     XCTAssertNil(self.cardFormViewController?.cardFront?.cardLogo.image)
      //   XCTAssertTrue(self.cardFormViewController?.cardView.backgroundColor == colorDefault!)
         
@@ -210,7 +208,7 @@ class GuessingFormTest: BaseTest {
         self.cardFormViewController?.cardNumberLabel?.text = binNumber
         self.cardFormViewController?.numberLabelEmpty = false
         self.cardFormViewController?.updateCardSkin()
-        XCTAssertNil(self.cardFormViewController?.paymentMethod)
+        XCTAssertNil(self.cardFormViewController?.cardFormManager!.paymentMethod)
     }
     
     func checkOnlyPaymentMethodGuessing(number: String, pmId: String){
@@ -225,11 +223,11 @@ class GuessingFormTest: BaseTest {
         self.cardFormViewController?.numberLabelEmpty = false
         self.cardFormViewController?.updateCardSkin()
         
-        XCTAssertNotNil(self.cardFormViewController?.paymentMethod)
-        let cardLogo = MercadoPago.getImageFor(self.cardFormViewController!.paymentMethod!)
+        XCTAssertNotNil(self.cardFormViewController?.cardFormManager!.paymentMethod)
+        let cardLogo = MercadoPago.getImageFor(self.cardFormViewController!.cardFormManager!.paymentMethod!)
         XCTAssertEqual(self.cardFormViewController?.cardFront?.cardLogo.image, cardLogo)
-        XCTAssertEqual(self.cardFormViewController?.cardView.backgroundColor,MercadoPago.getColorFor((self.cardFormViewController?.paymentMethod)!))
-        XCTAssertEqual(self.cardFormViewController?.paymentMethod?._id, pmId)
+        XCTAssertEqual(self.cardFormViewController?.cardView.backgroundColor,MercadoPago.getColorFor((self.cardFormViewController?.cardFormManager!.paymentMethod)!))
+        XCTAssertEqual(self.cardFormViewController?.cardFormManager!.paymentMethod?._id, pmId)
         
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockBuilder.swift
@@ -127,6 +127,10 @@ public class MockBuilder: NSObject {
         card.expirationMonth = 11
         card.expirationYear = 22
         card.cardHolder = buildCardholder()
+        card.securityCode = SecurityCode()
+        card.securityCode?.cardLocation = "cardLocation"
+        card.securityCode?.mode = "mandatory"
+        card.securityCode?.length = 3
         return card
     }
         


### PR DESCRIPTION
- Creación de CardViewModelManager
- Se movieron los objetos de modelo de CardFormViewController al CardViewModelManager
- Se movió lógica simple de negocio (como ya estaba en el VC) a CardViewModelManager
- Se movieron métodos de parseo de fecha a Utils
- Pasos siguientes: remover la lógica de negocios que aún queda. Utilizar CardViewModelManager en MPStepBuilder y MPFlowBuilder