### PR TITLE
Fix Rejected congrats title

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/RejectedPaymentHeaderTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/RejectedPaymentHeaderTableViewCell.swift
@@ -36,7 +36,7 @@ class RejectedPaymentHeaderTableViewCell: UITableViewCell, CongratsFillmentDeleg
             title = "Uy, no pudimos procesar el pago".localized
         }
         
-        let titleWithParams = (title.localized as NSString).replacingOccurrences(of: "%0", with: "\(paymentMethod.name)")
+        let titleWithParams = (title.localized as NSString).replacingOccurrences(of: "%0", with: "\(paymentMethod.name!)")
         self.title.text = titleWithParams
         
         


### PR DESCRIPTION
PaymentMethod.name se mostraba como Optional("name") en título de congrats para pagos rechazados.