### PR TITLE
Fix Payment JSONSerialization bug.

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Card.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Card.swift
@@ -78,6 +78,8 @@ open class Card : NSObject, CardInformation {
         let lastFourDigits : Any = self.lastFourDigits == nil ? JSONHandler.null : self.lastFourDigits!
         let paymentMethod : Any = self.paymentMethod == nil ? JSONHandler.null : self.paymentMethod!.toJSON()
         let issuer : Any = self.issuer == nil ? JSONHandler.null : self.issuer!.toJSONString()
+        let securityCode : Any = self.securityCode == nil ? JSONHandler.null : self.securityCode
+        
         let obj:[String:Any] = [
             "cardHolder" : cardHolder,
             "customer_id": customer_id,
@@ -90,7 +92,8 @@ open class Card : NSObject, CardInformation {
             "lastFourDigits" : lastFourDigits,
             "paymentMethod" : paymentMethod,
             "issuer" : issuer,
-            "securityCode" : securityCode  ]
+            "securityCode" : securityCode
+        ]
         return obj
     }
     

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -25,11 +25,11 @@
 }
 
 - (IBAction)checkoutFlow:(id)sender {
-
-    UINavigationController *choFlow = [MPFlowBuilder startCheckoutViewController:PREF_ID_NO_EXCLUSIONS callback:^(Payment *payment) {
-        
-    } callbackCancel:nil];
     
+    UINavigationController *choFlow = [MPFlowBuilder startCheckoutViewController:PREF_ID_NO_EXCLUSIONS callback:^(Payment *payment) {
+                NSString *mppayment = [payment toJSONString];
+                printf("%s", mppayment);
+    } callbackCancel:nil];
     [self presentViewController:choFlow animated:YES completion:^{}];
 }
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
@@ -75,7 +75,10 @@ int installmentsSelected = 1;
 
 }
 
+
+
 - (void)startCardFlow {
+    /*
     UINavigationController *cf = [MPFlowBuilder startCardFlow:nil amount:AMOUNT cardInformation:nil paymentMethods:nil token:nil callback:^(PaymentMethod * pm, Token * token, Issuer * issuer, PayerCost * payercost) {
         currentToken = token;
         selectedIssuer = issuer;
@@ -86,12 +89,12 @@ int installmentsSelected = 1;
     }];
     
     [self presentViewController:cf animated:YES completion:^{}];
-
+*/
 }
 
 -(void)startCardForm {
     
-    
+    /*
     UINavigationController *cf = [MPStepBuilder startCreditCardForm:nil amount:1000 cardInformation:nil paymentMethods:nil token:nil callback:^(PaymentMethod *pm, Token *token, Issuer *issuer) {
         currentToken = token;
         selectedIssuer = issuer;
@@ -103,7 +106,7 @@ int installmentsSelected = 1;
    
     
     [self presentViewController:cf animated:YES completion:^{}];
-    
+    */
 }
 
 - (void)startPaymentMethods {


### PR DESCRIPTION
- Fix Card.toJSON() validations
- Add securityCode nil validation to avoid Crash with parsing JSON to String.
- Replace nil with  NSNull for JSONSerialization purpose.
- Add    "NSString *mppayment = [payment toJSONString];" in CHO Test