### PR TITLE
Fix llenar tarjeta guardada en pantalla de cuotas

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CardAdditionalStep.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardAdditionalStep.swift
@@ -89,9 +89,8 @@ open class CardAdditionalStep: MercadoPagoUIScrollViewController, UITableViewDel
         fatalError("init(coder:) has not been implemented")
     }
     
-    public init(token : CardInformationForm?, amount: Double?, paymentPreference: PaymentPreference?,installment: Installment?, timer: CountdownTimer?, callback: ((_ payerCost: NSObject?)->Void)? ){
-        let cardInformation: CardInformation = token as! CardInformation
-        self.viewModel = CardAdditionalStepViewModel(paymentMethod: [cardInformation.getPaymentMethod()], issuer: cardInformation.getIssuer(), token: token, amount: amount, paymentPreference: paymentPreference, installment:installment, callback: callback)
+    public init(cardInformation : CardInformation, amount: Double?, paymentPreference: PaymentPreference?,installment: Installment?, timer: CountdownTimer?, callback: ((_ payerCost: NSObject?)->Void)? ){
+        self.viewModel = CardAdditionalStepViewModel(paymentMethod: [cardInformation.getPaymentMethod()], issuer: cardInformation.getIssuer(), token: cardInformation, amount: amount, paymentPreference: paymentPreference, installment:installment, callback: callback)
         self.viewModel.cardInformation = cardInformation
         
         super.init(nibName: "CardAdditionalStep", bundle: self.bundle)

--- a/MercadoPagoSDK/MercadoPagoSDK/MPStepBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPStepBuilder.swift
@@ -201,7 +201,7 @@ open class MPStepBuilder : NSObject {
                                        callbackCancel : ((Void) -> Void)? = nil) -> CardAdditionalStep {
         
         MercadoPagoContext.initFlavor2()
-        return CardAdditionalStep(token: cardInformation, amount: amount, paymentPreference: paymentPreference, installment: installment, timer: timer, callback: callback)
+        return CardAdditionalStep(cardInformation: cardInformation, amount: amount, paymentPreference: paymentPreference, installment: installment, timer: timer, callback: callback)
     }
     
     open class func startIdentificationForm(


### PR DESCRIPTION
Fix #228

## Cambios introducidos : 
- Cambio 1
Se cargan los últimos 4 números de la tarjeta en CardAdditional Step con una tarjeta guardada.
- Cambio 2

[X] Testeado en BETA con emulador
[] Testeado en BETA con dispositivo
[] Test unitarios OK
[] Test funcionales OK
[] Documentación actualizada

