### PR TITLE
Fix dots for CCs in front and back card view. Instructions header space in amount.

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CardFrontView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardFrontView.swift
@@ -33,16 +33,8 @@ import UIKit
         let nib = UINib(nibName: "CardFrontView", bundle: bundle)
         let view = nib.instantiate(withOwner: self, options: nil)[0] as! UIView
         view.frame = bounds
- //       view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+
         self.addSubview(view);
-        /*
-        cardNumber.adjustsFontSizeToFitWidth = true
-        cardNumber.numberOfLines = 0
-        cardName.adjustsFontSizeToFitWidth = true
-        cardName.numberOfLines = 0
-        cardExpirationDate.adjustsFontSizeToFitWidth = true
-        cardExpirationDate.numberOfLines = 0
-        */
         
         cardNumber.numberOfLines = 0
         cardName.numberOfLines = 0

--- a/MercadoPagoSDK/MercadoPagoSDK/HeaderCongratsTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/HeaderCongratsTableViewCell.swift
@@ -31,13 +31,12 @@ class HeaderCongratsTableViewCell: UITableViewCell {
                 titleWithParams = ("Debes autorizar ante %p el pago de %t a MercadoPago".localized as NSString).replacingOccurrences(of: "%p", with: "\(paymentMethodName)")
             }
             let currency = MercadoPagoContext.getCurrency()
-            let currencySymbol = currency.getCurrencySymbolOrDefault() ?? "$"
+            let currencySymbol = currency.getCurrencySymbolOrDefault()
             let thousandSeparator = String(currency.getThousandsSeparatorOrDefault()) ?? "."
             let decimalSeparator = String(currency.getDecimalSeparatorOrDefault()) ?? "."
             
             let amountFromDouble = String(payment.transactionAmount).replacingOccurrences(of: ".", with: decimalSeparator)
-            let amountStr = Utils.getAmountFormatted(amountFromDouble, thousandSeparator: thousandSeparator, decimalSeparator: decimalSeparator)
-            let centsStr = Utils.getCentsFormatted(String(payment.transactionAmount), decimalSeparator: decimalSeparator)
+            
             let amountRange = titleWithParams.range(of: "%t")
             
             if amountRange != nil {
@@ -51,10 +50,9 @@ class HeaderCongratsTableViewCell: UITableViewCell {
             
         } else if payment.status == "pending"{
             icon.image = MercadoPago.getImage("iconoPagoOffline")
-            //title.text = instruction?.title
             
             let currency = MercadoPagoContext.getCurrency()
-            let currencySymbol = currency.getCurrencySymbolOrDefault() ?? "$"
+            let currencySymbol = currency.getCurrencySymbolOrDefault()
             let thousandSeparator = String(currency.getThousandsSeparatorOrDefault()) ?? "."
             let decimalSeparator = String(currency.getDecimalSeparatorOrDefault()) ?? "."
             

--- a/MercadoPagoSDK/MercadoPagoSDK/SecrurityCodeViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecrurityCodeViewController.swift
@@ -19,6 +19,7 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
     var textMaskFormater : TextMaskFormater!
     var cardFront : CardFrontView!
     var cardBack : CardBackView!
+    var ccvLabelEmpty : Bool = true
     
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -44,6 +45,7 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
         securityCodeTextField.keyboardType = UIKeyboardType.numberPad
         securityCodeTextField.addTarget(self, action: #selector(SecrurityCodeViewController.editingChanged(_:)), for: UIControlEvents.editingChanged)
         securityCodeTextField.delegate = self
+        completeCvvLabel()
     }
 
     override open func didReceiveMemoryWarning() {
@@ -70,6 +72,7 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         securityCodeTextField.becomeFirstResponder()
+        
        
     }
     open override func viewDidDisappear(_ animated: Bool) {
@@ -113,6 +116,7 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
                 cardFront.cardName.text = ""
                 cardFront.cardExpirationDate.text = ""
                 cardFront.cardNumber.alpha = 0.8
+                cardFront.cardCVV.alpha = 0.8
                 cardFront.cardNumber.textColor =  fontColor
                 cardFront.layer.cornerRadius = 11
             }
@@ -139,8 +143,11 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
     
     open func editingChanged(_ textField:UITextField){
         hideErrorMessage()
-       securityCodeLabel.text = textField.text
+        securityCodeLabel.text = textField.text
+        self.ccvLabelEmpty = (textField.text != nil && textField.text!.characters.count == 0)
         securityCodeLabel.textColor  = UIColor.black
+        completeCvvLabel()
+        
     }
     
     open func showErrorMessage(){
@@ -148,6 +155,30 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
     }
     open func hideErrorMessage(){
         self.errorLabel.alpha = 0
+    }
+
+    func completeCvvLabel(){
+        if (self.ccvLabelEmpty) {
+            securityCodeLabel!.text = ""
+        }
+        
+        while (addCvvDot() != false){
+            
+        }
+        securityCodeLabel.textColor = UIColor.black
+    }
+    
+    func addCvvDot() -> Bool {
+        
+        let label = self.securityCodeLabel
+        //Check for max length including the spacers we added
+        if label?.text?.characters.count == self.viewModel.secCodeLenght() {
+            return false
+        }
+        
+        label?.text?.append("•")
+        return true
+        
     }
 
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/String+Additions.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/String+Additions.swift
@@ -10,6 +10,8 @@ import Foundation
 
 extension String {
 	
+    static let NON_BREAKING_LINE_SPACE = "\u{00a0}"
+    
 	var localized: String {
 		var bundle : Bundle? = MercadoPago.getBundle()
 		if bundle == nil {
@@ -68,3 +70,4 @@ extension String {
         return stringTrimmed
     }
 }
+

--- a/MercadoPagoSDK/MercadoPagoSDK/TermsAndConditionsViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/TermsAndConditionsViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class TermsAndConditionsViewCell: UITableViewCell, UITextViewDelegate {
 
-    private static let ROW_HEIGHT = CGFloat(40)
+    private static let ROW_HEIGHT = CGFloat(44)
     
     @IBOutlet weak var termsAndConditionsText: MPTextView!
     

--- a/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
@@ -76,10 +76,11 @@ class Utils {
         let smallAttributes : [String:AnyObject] = [NSFontAttributeName : UIFont(name: MercadoPago.DEFAULT_FONT_NAME, size: 10) ?? UIFont.systemFont(ofSize: 10),NSForegroundColorAttributeName: color, NSBaselineOffsetAttributeName : baselineOffset as AnyObject]
 
 
-        let attributedSymbol = NSMutableAttributedString(string: currencySymbol + " ", attributes: normalAttributes)
+        let attributedSymbol = NSMutableAttributedString(string: currencySymbol, attributes: normalAttributes)
         let attributedAmount = NSMutableAttributedString(string: amount, attributes: normalAttributes)
         let attributedCents = NSAttributedString(string: cents, attributes: smallAttributes)
-        let space = NSAttributedString(string: " ", attributes: smallAttributes)
+        let space = NSAttributedString(string: String.NON_BREAKING_LINE_SPACE, attributes: smallAttributes)
+        attributedSymbol.append(space)
         attributedSymbol.append(attributedAmount)
         attributedSymbol.append(space)
         attributedSymbol.append(attributedCents)


### PR DESCRIPTION
Fix #259 & #248 

## Cambios introducidos : 
- Mostrar dots en CVV label para customer cards
- Se fixea el bug de no mostrar animación de CVV para amex
- Se elimina espacio en amount para evitar el salto de linea 

[X] Testeado en BETA con emulador
[] Testeado en BETA con dispositivo
[] Test unitarios OK
[] Test funcionales OK
[NA] Documentación actualizada

