### PR TITLE
Subdirectory added. Tests scheme shared.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ osx_image: xcode8.1
 xcode_project: MercadoPagoSDK/MercadoPagoSDK.xcodeproj
 xcode_scheme: MercadoPagoSDK
 
+before_script:
+- cd MercadoPagoSDK
+
 script:
 # tests not working yet
 - xcodebuild  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 

--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/xcshareddata/xcschemes/MercadoPagoSDKTests.xcscheme
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/xcshareddata/xcschemes/MercadoPagoSDKTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0F9883141AD2A97A00F750F0"
+               BuildableName = "MercadoPagoSDKTests.xctest"
+               BlueprintName = "MercadoPagoSDKTests"
+               ReferencedContainer = "container:MercadoPagoSDK.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Fix #281

##  Cambios introducidos : 
- Se verifica subdirectory de MercadoPagoSDK con proyecto xcode (en vez de raíz de repositorio de px-ios)
- Scheme de tests se hace público para acceso de Travis
