### PR TITLE
Default pm in groups

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -198,7 +198,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     internal func loadGroupsAndStartPaymentVault(_ animated : Bool = true){
         
         if self.viewModel.paymentMethodSearch == nil {
-            MPServicesBuilder.searchPaymentMethods(self.viewModel.preference!.getAmount(), excludedPaymentTypeIds: self.viewModel.preference?.getExcludedPaymentTypesIds(), excludedPaymentMethodIds: self.viewModel.preference?.getExcludedPaymentMethodsIds(), success: { (paymentMethodSearch) in
+            MPServicesBuilder.searchPaymentMethods(self.viewModel.preference!.getAmount(), defaultPaymenMethodId: self.viewModel.preference!.getDefaultPaymentMethodId(), excludedPaymentTypeIds: self.viewModel.preference?.getExcludedPaymentTypesIds(), excludedPaymentMethodIds: self.viewModel.preference?.getExcludedPaymentMethodsIds(), success: { (paymentMethodSearch) in
                 self.viewModel.paymentMethodSearch = paymentMethodSearch
                 
                 self.startPaymentVault()

--- a/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
@@ -253,11 +253,11 @@ open class MPServicesBuilder : NSObject {
     }
     
     
-    open class func searchPaymentMethods(_ amount : Double, excludedPaymentTypeIds : Set<String>?, excludedPaymentMethodIds : Set<String>?, success: @escaping (PaymentMethodSearch) -> Void, failure: ((_ error: NSError) -> Void)?) {
+    open class func searchPaymentMethods(_ amount : Double, defaultPaymenMethodId : String?, excludedPaymentTypeIds : Set<String>?, excludedPaymentMethodIds : Set<String>?, success: @escaping (PaymentMethodSearch) -> Void, failure: ((_ error: NSError) -> Void)?) {
         MercadoPagoContext.initFlavor1()
         MPTracker.trackEvent(MercadoPagoContext.sharedInstance, action: "GET_PAYMENT_METHOD_SEARCH", result: nil)
         let paymentMethodSearchService = PaymentMethodSearchService()
-        paymentMethodSearchService.getPaymentMethods(amount, excludedPaymentTypeIds: excludedPaymentTypeIds, excludedPaymentMethodIds: excludedPaymentMethodIds, success: success, failure: failure!)
+        paymentMethodSearchService.getPaymentMethods(amount, defaultPaymenMethodId : defaultPaymenMethodId, excludedPaymentTypeIds: excludedPaymentTypeIds, excludedPaymentMethodIds: excludedPaymentMethodIds, success: success, failure: failure!)
         
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearch.plist
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearch.plist
@@ -147,7 +147,7 @@
 		<key>image_name</key>
 		<string>pagoEfvoIconoBancomer</string>
 	</dict>
-	<key>serfin_telecomm</key>
+	<key>banamex_telecomm</key>
 	<dict>
 		<key>image_name</key>
 		<string>pagoEfvoIconoTelecomm</string>

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearch.plist
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearch.plist
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>prepaid_card</key>
+	<dict>
+		<key>image_name</key>
+		<string>mediosIconoTarjeta</string>
+	</dict>
+	<key>debit_card</key>
+	<dict>
+		<key>image_name</key>
+		<string>mediosIconoTarjeta</string>
+	</dict>
 	<key>bank_transfer</key>
 	<dict>
 		<key>image_name</key>

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearch.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearch.swift
@@ -13,6 +13,7 @@ open class PaymentMethodSearch: Equatable {
     var paymentMethods : [PaymentMethod]!
     var customerPaymentMethods : [CardInformation]?
     var cards : [Card]?
+    var defaultOption : PaymentMethodSearchItem?
     
     open class func fromJSON(_ json : NSDictionary) -> PaymentMethodSearch {
         let pmSearch = PaymentMethodSearch()
@@ -69,7 +70,10 @@ open class PaymentMethodSearch: Equatable {
             pmSearch.customerPaymentMethods = customerPaymentMethods
         }
 
-
+        if let defaultPaymentMethodIdJson = json["default_option"] as? NSDictionary {
+            let defaultPaymentMethodOption = PaymentMethodSearchItem.fromJSON(defaultPaymentMethodIdJson)
+            pmSearch.defaultOption = defaultPaymentMethodOption
+        }
         
         return pmSearch
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchService.swift
@@ -36,7 +36,7 @@ open class PaymentMethodSearchService: MercadoPagoService {
         super.init(baseURL: MercadoPago.MP_API_BASE_URL)
     }
     
-    open func getPaymentMethods(_ amount : Double, customerEmail : String? = nil, customerId : String? = nil, excludedPaymentTypeIds : Set<String>?, excludedPaymentMethodIds : Set<String>?, success: @escaping (_ paymentMethodSearch: PaymentMethodSearch) -> Void, failure: @escaping ((_ error: NSError) -> Void)) {
+    open func getPaymentMethods(_ amount : Double, customerEmail : String? = nil, customerId : String? = nil, defaultPaymenMethodId : String?, excludedPaymentTypeIds : Set<String>?, excludedPaymentMethodIds : Set<String>?, success: @escaping (_ paymentMethodSearch: PaymentMethodSearch) -> Void, failure: @escaping ((_ error: NSError) -> Void)) {
         var params = "public_key=" + MercadoPagoContext.publicKey() + "&amount=" + String(amount)
         
         if excludedPaymentTypeIds != nil && excludedPaymentTypeIds?.count > 0 {
@@ -47,6 +47,10 @@ open class PaymentMethodSearchService: MercadoPagoService {
         if excludedPaymentMethodIds != nil && excludedPaymentMethodIds!.count > 0 {
             let excludedPaymentMethodsParams = excludedPaymentMethodIds!.joined(separator: ",")
             params = params + "&excluded_payment_methods=" + excludedPaymentMethodsParams.trimSpaces()
+        }
+        
+        if let defaultPaymenMethodId = defaultPaymenMethodId {
+            params = params + "&default_payment_method=" + defaultPaymenMethodId.trimSpaces()
         }
         
         if customerEmail != nil && customerEmail!.characters.count > 0 {
@@ -79,7 +83,7 @@ open class PaymentMethodSearchService: MercadoPagoService {
             }
             
             },  failure: { (error) -> Void in
-                failure(NSError(domain: "mercadopago.sdk.PaymentMethodSearchService.getPaymentMethods", code: error.code, userInfo: [NSLocalizedDescriptionKey: "Hubo un error".localized, NSLocalizedFailureReasonErrorKey : "Verifique su conexión a ineternet e intente nuevamente".localized]))
+                failure(NSError(domain: "mercadopago.sdk.PaymentMethodSearchService.getPaymentMethods", code: error.code, userInfo: [NSLocalizedDescriptionKey: "Hubo un error".localized, NSLocalizedFailureReasonErrorKey : "Verifique su conexión a internet e intente nuevamente".localized]))
         })
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentService.swift
@@ -66,7 +66,7 @@ open class PaymentService : MercadoPagoService {
                 }
             }
             }, failure: { (error) in
-                failure(NSError(domain: "mercadopago.sdk.paymentService.getInstallments", code: error.code, userInfo: [NSLocalizedDescriptionKey: "Hubo un error".localized, NSLocalizedFailureReasonErrorKey : "Verifique su conexión a ineternet e intente nuevamente".localized]))
+                failure(NSError(domain: "mercadopago.sdk.paymentService.getInstallments", code: error.code, userInfo: [NSLocalizedDescriptionKey: "Hubo un error".localized, NSLocalizedFailureReasonErrorKey : "Verifique su conexión a internet e intente nuevamente".localized]))
 
         })
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PreferenceService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PreferenceService.swift
@@ -32,7 +32,7 @@ open class PreferenceService: MercadoPagoService {
                 }
             }
             }, failure : { (error) in
-                failure(NSError(domain: "mercadopago.sdk.PreferenceService.getPreference", code: error.code, userInfo: [NSLocalizedDescriptionKey: "Hubo un error".localized, NSLocalizedFailureReasonErrorKey : "Verifique su conexión a ineternet e intente nuevamente".localized]))
+                failure(NSError(domain: "mercadopago.sdk.PreferenceService.getPreference", code: error.code, userInfo: [NSLocalizedDescriptionKey: "Hubo un error".localized, NSLocalizedFailureReasonErrorKey : "Verifique su conexión a internet e intente nuevamente".localized]))
         })
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
@@ -122,3 +122,4 @@
 "Cancelar Pago"="Cancelar pagamento";
 
 "Términos y Condiciones"="Termos e Condições";
+"Verifique su conexión a internet e intente nuevamente"="Sem conexão";


### PR DESCRIPTION
Fix #167 #236 #322

##  Cambios introducidos : 
- Se utiliza parámetro de default option de payment method para ir a grupos. Se autoselecciona en caso de que grupos retorne un nodo válido como default
- Se corrige nombre de asset para Telecomm
- Se muestras los assets para tarjeta de débito y prepaga
- Se corrige typo en mensaje de error cuando no hay conexión a Internet

Revisión
[X] Todos los textos se encuentran localizables
[X] No se introducen warnings al proyecto

Testeo
[X] Testeado en BETA con emulador
[X] Testeado en BETA con dispositivo
[] Test unitarios OK
[] Test funcionales OK
[NA] Documentación actualizada

