### PR TITLE
One section in payment vault

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -386,6 +386,8 @@
 		76151B971C74CD8C007DF0E3 /* InstructionsTwoLabelsViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76151B941C74CD8C007DF0E3 /* InstructionsTwoLabelsViewCell.xib */; };
 		76151B981C74CD8C007DF0E3 /* InstructionsTwoLabelsViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76151B941C74CD8C007DF0E3 /* InstructionsTwoLabelsViewCell.xib */; };
 		7619E93B1DF05E2900CEFAC1 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E93A1DF05E2900CEFAC1 /* Array+Extension.swift */; };
+		7619E9451DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */; };
+		7619E9461DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */; };
 		761B893A1C625C130015D0BE /* MercadoPagoUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B89391C625C130015D0BE /* MercadoPagoUIViewController.swift */; };
 		761B893B1C625C130015D0BE /* MercadoPagoUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B89391C625C130015D0BE /* MercadoPagoUIViewController.swift */; };
 		761B89421C637DBD0015D0BE /* PurchaseDetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B89401C637DBD0015D0BE /* PurchaseDetailTableViewCell.swift */; };
@@ -863,6 +865,7 @@
 		76151B931C74CD8C007DF0E3 /* InstructionsTwoLabelsViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionsTwoLabelsViewCell.swift; sourceTree = "<group>"; };
 		76151B941C74CD8C007DF0E3 /* InstructionsTwoLabelsViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InstructionsTwoLabelsViewCell.xib; sourceTree = "<group>"; };
 		7619E93A1DF05E2900CEFAC1 /* Array+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
+		7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentOptionDrawable.swift; sourceTree = "<group>"; };
 		761B89391C625C130015D0BE /* MercadoPagoUIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoUIViewController.swift; sourceTree = "<group>"; };
 		761B89401C637DBD0015D0BE /* PurchaseDetailTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseDetailTableViewCell.swift; sourceTree = "<group>"; };
 		761B89411C637DBD0015D0BE /* PurchaseDetailTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PurchaseDetailTableViewCell.xib; sourceTree = "<group>"; };
@@ -1133,6 +1136,7 @@
 				0F98834F1AD2AB6000F750F0 /* PaymentMethodRow.swift */,
 				766012E11CEB963300897F9D /* MPError.swift */,
 				4BAA56211DB6B13B00501061 /* CardInfo.swift */,
+				7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -2484,6 +2488,7 @@
 				76FD24791C5BFEA1008C5DC0 /* CardBackView.swift in Sources */,
 				76128AC11DD10BA600D3B3CD /* MercadoPagoUIScrollViewController.swift in Sources */,
 				0F98838B1AD2AB6000F750F0 /* PaymentMethodRow.swift in Sources */,
+				7619E9451DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift in Sources */,
 				0F98836F1AD2AB6000F750F0 /* Discount.swift in Sources */,
 				76EEF75D1D674BA80095D5A5 /* CardInformation.swift in Sources */,
 				0F9883321AD2AB3C00F750F0 /* MerchantServer.swift in Sources */,
@@ -2664,6 +2669,7 @@
 				0F9883721AD2AB6000F750F0 /* FeesDetail.swift in Sources */,
 				76F41E281D3D4A9700B25E5B /* MercadoPagoContext.swift in Sources */,
 				76445ADC1CC93998008EE68E /* ViewUtils.swift in Sources */,
+				7619E9461DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift in Sources */,
 				76B0850A1CE258BA00C157BF /* CongratsFillmentDelegate.swift in Sources */,
 				7656F5301C98A2E50076A14D /* InstructionsViewControllerTest.swift in Sources */,
 				76EC47DA1C85E8D20086FA53 /* IdentificationTest.swift in Sources */,

--- a/MercadoPagoSDK/MercadoPagoSDK/Card.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Card.swift
@@ -156,6 +156,21 @@ open class Card : NSObject, CardInformation {
     public func isIssuerRequired() -> Bool {
         return self.issuer == nil
     }
+    
+    /** PaymentOptionDrawable implementation */
+    
+    public func getTitle() -> String {
+        return getCardDescription()
+    }
+    
+    public func getSubtitle() -> String? {
+        return nil
+    }
+    
+    public func getImageDescription() -> String {
+        return self.getPaymentMethodId()
+    }
+
 }
 
 

--- a/MercadoPagoSDK/MercadoPagoSDK/CardInformation.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardInformation.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @objc
-public protocol CardInformation : CardInformationForm {
+public protocol CardInformation : CardInformationForm, PaymentOptionDrawable {
     
     func isSecurityCodeRequired() -> Bool
     

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -561,7 +561,7 @@ open class CheckoutViewModel {
         let paymentMethodSearchItemSelected : PaymentMethodSearchItem
         if paymentTypeIdEnum != nil && paymentTypeIdEnum == PaymentTypeId.ACCOUNT_MONEY {
             paymentMethodSearchItemSelected = PaymentMethodSearchItem()
-            paymentMethodSearchItemSelected.description = "Dinero en cuenta"
+            paymentMethodSearchItemSelected._description = "Dinero en cuenta"
         } else {
             paymentMethodSearchItemSelected = Utils.findPaymentMethodSearchItemInGroups(self.paymentMethodSearch!, paymentMethodId: self.paymentMethod!._id, paymentTypeId: paymentTypeIdEnum)!
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/CustomerPaymentMethod.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CustomerPaymentMethod.swift
@@ -116,6 +116,20 @@ open class CustomerPaymentMethod: NSObject, CardInformation {
     public func isIssuerRequired() -> Bool {
         return false
     }
+    
+    /** PaymentOptionDrawable implementation */
+    
+    public func getTitle() -> String {
+        return getCardDescription()
+    }
+    
+    public func getSubtitle() -> String? {
+        return nil
+    }
+    
+    public func getImageDescription() -> String {
+        return self.getPaymentMethodId()
+    }
 
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPago.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPago.swift
@@ -324,6 +324,18 @@ import UIKit
         
     }
     
+    open class func getImageForPaymentMethod(withDescription : String) -> UIImage?{
+        let path = MercadoPago.getBundle()!.path(forResource: "PaymentMethodSearch", ofType: "plist")
+        let dictPM = NSDictionary(contentsOfFile: path!)
+        
+        guard let itemSelected = dictPM?.value(forKey: withDescription) as? NSDictionary else {
+            return nil
+        }
+        
+        return MercadoPago.getImage(itemSelected.object(forKey: "image_name") as! String?)
+        
+    }
+    
     open class func getImageFor(cardInformation : CardInformation) -> UIImage?{
         let path = MercadoPago.getBundle()!.path(forResource: "PaymentMethodSearch", ofType: "plist")
         let dictPM = NSDictionary(contentsOfFile: path!)

--- a/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodWithDescriptionCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodWithDescriptionCell.swift
@@ -27,7 +27,7 @@ class OfflinePaymentMethodWithDescriptionCell: UITableViewCell {
     
     
     func fillRowWith(_ paymentMethodSearchItem : PaymentMethodSearchItem) -> UITableViewCell {
-        self.paymentDescription.text = paymentMethodSearchItem.description
+        self.paymentDescription.text = paymentMethodSearchItem._description
         self.paymentIcon.image = MercadoPago.getImage(paymentMethodSearchItem.idPaymentMethodSearchItem)
         return self
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchItem.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchItem.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-open class PaymentMethodSearchItem : Equatable {
+open class PaymentMethodSearchItem : Equatable, PaymentOptionDrawable {
     
     open var idPaymentMethodSearchItem : String!
     open var type : PaymentMethodSearchItemType!
-    open var description : String!
+    open var _description : String!
     open var comment : String?
     open var childrenHeader : String?
     open var children : [PaymentMethodSearchItem] = []
@@ -28,7 +28,7 @@ open class PaymentMethodSearchItem : Equatable {
             pmSearchItem.type = PaymentMethodSearchItemType(rawValue:type)
         }
         if let description = JSONHandler.attemptParseToString(json["description"]){
-            pmSearchItem.description = description
+            pmSearchItem._description = description
         }
         if let comment = JSONHandler.attemptParseToString(json["comment"]){
             pmSearchItem.comment = comment
@@ -69,6 +69,21 @@ open class PaymentMethodSearchItem : Equatable {
         return self.type == PaymentMethodSearchItemType.PAYMENT_TYPE
     }
     
+    /*
+     * PaymentOptionDrawable implementation
+     */
+    
+    public func getTitle() -> String {
+        return self._description
+    }
+    
+    public func getSubtitle() -> String? {
+        return self.comment
+    }
+    
+    public func getImageDescription() -> String{
+        return self.idPaymentMethodSearchItem
+    }
 }
 
 public enum PaymentMethodSearchItemType : String {
@@ -81,7 +96,7 @@ public func ==(obj1: PaymentMethodSearchItem, obj2: PaymentMethodSearchItem) -> 
     let areEqual =
     obj1.idPaymentMethodSearchItem == obj2.idPaymentMethodSearchItem &&
     obj1.type == obj2.type &&
-    obj1.description == obj2.description &&
+    obj1._description == obj2._description &&
     obj1.comment == obj2.comment &&
     obj1.childrenHeader == obj2.childrenHeader &&
     obj1.children == obj2.children &&

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentOptionDrawable.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentOptionDrawable.swift
@@ -1,0 +1,19 @@
+//
+//  PaymentOptionDrawable.swift
+//  MercadoPagoSDK
+//
+//  Created by Maria cristina rodriguez on 12/2/16.
+//  Copyright © 2016 MercadoPago. All rights reserved.
+//
+
+import UIKit
+
+@objc
+public protocol PaymentOptionDrawable {
+
+    func getImageDescription() -> String
+    
+    func getTitle() -> String
+    
+    func getSubtitle() -> String?
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentSearchCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentSearchCell.swift
@@ -35,7 +35,7 @@ class PaymentSearchCell: UITableViewCell {
     }
     
     func fillRowWithPayment(_ paymentSearchItem : PaymentMethodSearchItem, iconImage: UIImage, tintColor : Bool){
-        self.paymentTitle.text = paymentSearchItem.description
+        self.paymentTitle.text = paymentSearchItem._description
         if tintColor {
             let tintedImage = iconImage.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
             self.paymentIcon.image = tintedImage

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentSearchCollectionViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentSearchCollectionViewCell.swift
@@ -43,23 +43,16 @@ class PaymentSearchCollectionViewCell: UICollectionViewCell {
     func totalHeight() -> CGFloat {
         return titleSearch.requiredHeight() + subtitleSearch.requiredHeight() + 112
     }
-    public func fillCell(searchItem : PaymentMethodSearchItem){
-        let image = MercadoPago.getImageFor(searchItem: searchItem)
-        self.fillCell(image: image, title: searchItem.description, subtitle: searchItem.comment)
+    
+    func fillCell(drawablePaymentOption : PaymentOptionDrawable) {
+        let image = MercadoPago.getImageForPaymentMethod(withDescription: drawablePaymentOption.getImageDescription())
+        self.fillCell(image: image, title: drawablePaymentOption.getTitle(), subtitle: drawablePaymentOption.getSubtitle())
     }
     
-    public func fillCell(cardInformation : CardInformation){
-        let image = MercadoPago.getImageFor(cardInformation: cardInformation)
-        self.fillCell(image: image, title: cardInformation.getCardDescription(), subtitle: nil)
-    }
-
-    static func totalHeight(searchItem : CardInformation ) -> CGFloat {
-        return PaymentSearchCollectionViewCell.totalHeight(title: searchItem.getCardDescription(), subtitle: "")
+    static func totalHeight(drawablePaymentOption : PaymentOptionDrawable) -> CGFloat {
+        return PaymentSearchCollectionViewCell.totalHeight(title: drawablePaymentOption.getTitle(), subtitle: drawablePaymentOption.getSubtitle())
     }
     
-    static func totalHeight(searchItem : PaymentMethodSearchItem ) -> CGFloat {
-        return PaymentSearchCollectionViewCell.totalHeight(title: searchItem.description, subtitle: searchItem.comment)
-    }
     static func totalHeight(title: String?, subtitle:String?) -> CGFloat {
         let screenSize: CGRect = UIScreen.main.bounds
         let screenWidth = screenSize.width
@@ -74,7 +67,7 @@ class PaymentSearchCollectionViewCell: UICollectionViewCell {
         subtitleLabel.text = subtitle
         let altura1 = titleLabel.requiredHeight()
         let altura2 = subtitleLabel.requiredHeight()
-    return altura1 + altura2 + 112
+        return altura1 + altura2 + 112
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
@@ -237,8 +237,9 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
             } else {
                 self.collectionSearch.delegate = self
                 self.collectionSearch.dataSource = self
-                self.loadingGroups = false
+                
                 self.collectionSearch.reloadData()
+                self.loadingGroups = false
             }
         }
     }


### PR DESCRIPTION
Fix #330 

##  Cambios introducidos : 
- Se cargan todos los elementos tanto de medios de pago del customer como los medios de grupos en una única sección en F2

Revisión
[NA] Todos los textos se encuentran localizables
[X] No se introducen warnings al proyecto

Testeo
[X] Testeado en BETA con emulador
[] Testeado en BETA con dispositivo
[] Test unitarios OK
[] Test funcionales OK
[] Documentación actualizada

