### PR TITLE
Fix Promociones

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -598,6 +598,7 @@
 		76D936421CDA5BE000238CB0 /* PreferenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D936401CDA56A900238CB0 /* PreferenceService.swift */; };
 		76DA64601C8F50C2004F9A7C /* MPServicesBuilderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76DA645F1C8F50C2004F9A7C /* MPServicesBuilderTest.swift */; };
 		76DA646C1C90C3E3004F9A7C /* TermsAndConditionsViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76DA646A1C90C3E3004F9A7C /* TermsAndConditionsViewCell.xib */; };
+		76E43C7E1E1BE80300E7ADBA /* PromoViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E43C7D1E1BE80300E7ADBA /* PromoViewControllerTest.swift */; };
 		76E92F831C6D1F69000D0393 /* PaymentTitleAndCommentViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E92F811C6D1F69000D0393 /* PaymentTitleAndCommentViewCell.swift */; };
 		76E92F841C6D1F69000D0393 /* PaymentTitleAndCommentViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E92F811C6D1F69000D0393 /* PaymentTitleAndCommentViewCell.swift */; };
 		76E92F851C6D1F69000D0393 /* PaymentTitleAndCommentViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76E92F821C6D1F69000D0393 /* PaymentTitleAndCommentViewCell.xib */; };
@@ -1019,6 +1020,7 @@
 		76DA64611C8F5D8B004F9A7C /* MercadoPagoService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoService.swift; sourceTree = "<group>"; };
 		76DA64691C90C3E3004F9A7C /* TermsAndConditionsViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsViewCell.swift; sourceTree = "<group>"; };
 		76DA646A1C90C3E3004F9A7C /* TermsAndConditionsViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TermsAndConditionsViewCell.xib; sourceTree = "<group>"; };
+		76E43C7D1E1BE80300E7ADBA /* PromoViewControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromoViewControllerTest.swift; sourceTree = "<group>"; };
 		76E92F811C6D1F69000D0393 /* PaymentTitleAndCommentViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentTitleAndCommentViewCell.swift; sourceTree = "<group>"; };
 		76E92F821C6D1F69000D0393 /* PaymentTitleAndCommentViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PaymentTitleAndCommentViewCell.xib; sourceTree = "<group>"; };
 		76EA639F1C9B3B9700808E11 /* InstructionsServiceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionsServiceTest.swift; sourceTree = "<group>"; };
@@ -1920,7 +1922,6 @@
 				76EC47F91C862A030086FA53 /* SettingTest.swift */,
 				76EC47FB1C862A160086FA53 /* TokenTest.swift */,
 				76EC47FD1C862A600086FA53 /* TransactionDetailsTest.swift */,
-				769EC3511E11938F0054E940 /* MPPaymentTest.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -1946,6 +1947,7 @@
 		767254651C7CB28B00EB5EBA /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				76E43C7C1E1BE7EB00E7ADBA /* Promos */,
 				7652F4401D78ADF2006022AF /* Congrats */,
 				1565B12F1CBFD7B200181998 /* GuessingForm */,
 				7656F52E1C98A2B90076A14D /* Instructions */,
@@ -2063,6 +2065,14 @@
 				76D00A001CA2CA3E00F52BC6 /* UtilsTest.swift */,
 			);
 			name = Util;
+			sourceTree = "<group>";
+		};
+		76E43C7C1E1BE7EB00E7ADBA /* Promos */ = {
+			isa = PBXGroup;
+			children = (
+				76E43C7D1E1BE80300E7ADBA /* PromoViewControllerTest.swift */,
+			);
+			name = Promos;
 			sourceTree = "<group>";
 		};
 		76FD246F1C5BFE45008C5DC0 /* GuessingForm */ = {
@@ -2766,10 +2776,10 @@
 				0F98838A1AD2AB6000F750F0 /* PaymentMethod.swift in Sources */,
 				156DA6431CC55636006B892F /* PayerCostFormTest.swift in Sources */,
 				0F9883721AD2AB6000F750F0 /* FeesDetail.swift in Sources */,
+				76E43C7E1E1BE80300E7ADBA /* PromoViewControllerTest.swift in Sources */,
 				76F41E281D3D4A9700B25E5B /* MercadoPagoContext.swift in Sources */,
 				7622E3361DF5F0A300490C4E /* InstructionsSubtitleTableViewCell.swift in Sources */,
 				76445ADC1CC93998008EE68E /* ViewUtils.swift in Sources */,
-				769EC3521E11938F0054E940 /* MPPaymentTest.swift in Sources */,
 				7619E9461DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift in Sources */,
 				76B0850A1CE258BA00C157BF /* CongratsFillmentDelegate.swift in Sources */,
 				7656F5301C98A2E50076A14D /* InstructionsViewControllerTest.swift in Sources */,

--- a/MercadoPagoSDK/MercadoPagoSDK/CardFormViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardFormViewController.swift
@@ -81,12 +81,6 @@ open class CardFormViewController: MercadoPagoUIViewController , UITextFieldDele
                 self.navigationController?.navigationBar.isTranslucent = false
                 self.cardBackground.backgroundColor =  MercadoPagoContext.getComplementaryColor()
                 
-                if self.timer == nil && cardFormManager.showBankDeals(){
-                    let promocionesButton : UIBarButtonItem = UIBarButtonItem(title: "Ver promociones".localized, style: UIBarButtonItemStyle.plain, target: self, action: #selector(CardFormViewController.verPromociones))
-                    promocionesButton.tintColor = UIColor.systemFontColor()
-                    self.navigationItem.rightBarButtonItem = promocionesButton
-                }
-                
                 
                 displayBackButton()
             }
@@ -124,6 +118,16 @@ open class CardFormViewController: MercadoPagoUIViewController , UITextFieldDele
     open override func viewDidAppear(_ animated: Bool) {
         
         super.viewDidAppear(animated)
+        
+        if self.navigationController != nil {
+            if self.timer == nil && cardFormManager.showBankDeals(){
+                let promocionesButton : UIBarButtonItem = UIBarButtonItem(title: "Ver promociones".localized, style: UIBarButtonItemStyle.plain, target: self, action: #selector(CardFormViewController.verPromociones))
+                promocionesButton.tintColor = UIColor.systemFontColor()
+                self.navigationItem.rightBarButtonItem = promocionesButton
+            }
+        }
+
+        
         self.showNavBar()
         
         textBox.placeholder = "Número de tarjeta".localized
@@ -156,13 +160,12 @@ open class CardFormViewController: MercadoPagoUIViewController , UITextFieldDele
                 
 
                 self.cardFormManager.paymentMethods = paymentMethods
-                
-                self.updateCardSkin()
-                
-                
+                self.getPromos()
             }) { (error) -> Void in
                 // Mensaje de error correspondiente, ver que hacemos con el flujo
             }
+        } else {
+            self.getPromos()
         }
         
         
@@ -209,6 +212,18 @@ open class CardFormViewController: MercadoPagoUIViewController , UITextFieldDele
         
     }
     
+    private func getPromos(){
+        MPServicesBuilder.getPromos({(promos : [Promo]?) -> Void in
+            self.cardFormManager.promos = promos
+            self.updateCardSkin()
+        }, failure: { (error: NSError) in
+            // Si no se pudieron obtener promociones se ignora tal caso
+            CardFormViewController.showBankDeals = false
+            self.updateCardSkin()
+        })
+
+    }
+    
     func getCardWidth() -> CGFloat {
         let widthTotal = UIScreen.main.bounds.size.width * 0.70
         if widthTotal < 512 {
@@ -246,7 +261,7 @@ open class CardFormViewController: MercadoPagoUIViewController , UITextFieldDele
     
     
     open func verPromociones(){
-        self.navigationController?.present(UINavigationController(rootViewController: MPStepBuilder.startPromosStep()), animated: true, completion: {})
+        self.navigationController?.present(UINavigationController(rootViewController: MPStepBuilder.startPromosStep(promos : self.cardFormManager.promos)), animated: true, completion: {})
     }
     
     

--- a/MercadoPagoSDK/MercadoPagoSDK/CardViewModelManager.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardViewModelManager.swift
@@ -36,6 +36,8 @@ class CardViewModelManager: NSObject {
     var cvvEmpty: Bool = true
     var cardholderNameEmpty: Bool = true
     
+    var promos : [Promo]?
+    
     init(amount : Double, paymentMethods : [PaymentMethod]?, paymentMethod : [PaymentMethod]? = nil, customerCard : CardInformation? = nil, token : Token? = nil, paymentSettings : PaymentPreference?){
         self.amount = amount
         self.paymentMethods = paymentMethods
@@ -229,11 +231,8 @@ class CardViewModelManager: NSObject {
             return true
         }
     }
+    
     func showBankDeals() -> Bool{
-        if MercadoPagoContext.getSite() == MercadoPagoContext.Site.MLA.rawValue{
-            return CardFormViewController.showBankDeals
-        } else {
-            return false
-        }
+        return !Array.isNullOrEmpty(self.promos) && CardFormViewController.showBankDeals
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/MPStepBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPStepBuilder.swift
@@ -100,10 +100,10 @@ open class MPStepBuilder : NSObject {
         })
     }
     
-    open class func startPromosStep(
+    open class func startPromosStep(promos : [Promo]? = nil,
         _ callback : ((Void) -> (Void))? = nil) -> PromoViewController {
         MercadoPagoContext.initFlavor2()
-        return PromoViewController(callback : callback)
+        return PromoViewController(promos : promos, callback : callback)
     }
     
     fileprivate class func verifyPaymentMethods(paymentMethods: [PaymentMethod], cardToken: CardToken, amount: Double, timer: CountdownTimer?, cardInformation: CardInformation?, callback: @escaping ((_ paymentMethod: PaymentMethod, _ token: Token? ,  _ issuer: Issuer?) -> Void), ccf: MercadoPagoUIViewController, callbackCancel: ((Void) -> Void)?) -> Bool{

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoUIViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoUIViewController.swift
@@ -100,7 +100,9 @@ open class MercadoPagoUIViewController: UIViewController, UIGestureRecognizerDel
             
             
             if self.navigationController != nil {
-                self.navigationController!.navigationBar.titleTextAttributes = titleDict as? [String : AnyObject]
+                if titleDict.count > 0 {
+                    self.navigationController!.navigationBar.titleTextAttributes = titleDict as? [String : AnyObject]
+                }
                 self.navigationItem.hidesBackButton = true
                 self.navigationController!.interactivePopGestureRecognizer?.delegate = self
                 self.navigationController?.navigationBar.tintColor = navBarTextColor

--- a/MercadoPagoSDK/MercadoPagoSDK/PromoViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PromoViewController.swift
@@ -25,12 +25,13 @@ open class PromoViewController: MercadoPagoUIViewController, UITableViewDataSour
 		super.init(coder: aDecoder)
 	}
 	
-	public init(callback : ((Void) -> (Void))? = nil) {
+	public init(promos : [Promo]? = nil,callback : ((Void) -> (Void))? = nil) {
 		super.init(nibName: "PromoViewController", bundle: self.bundle)
 		self.publicKey = MercadoPagoContext.publicKey()
         self.callback = callback
+        self.promos = promos
 	}
-	
+    
 	override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
 		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 	}
@@ -38,9 +39,6 @@ open class PromoViewController: MercadoPagoUIViewController, UITableViewDataSour
     override open func viewDidLoad() {
         super.viewDidLoad()
 		self.title = "Promociones".localized
-	//	self.navigationItem.hidesBackButton = true
-
-	//	self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Cerrar", style: UIBarButtonItemStyle.Plain, target: self, action: Selector(PromoViewController.back))
 		
 		self.tableView.register(UINib(nibName: "PromoTableViewCell", bundle: self.bundle), forCellReuseIdentifier: "PromoTableViewCell")
 		self.tableView.register(UINib(nibName: "PromosTyCTableViewCell", bundle: self.bundle), forCellReuseIdentifier: "PromosTyCTableViewCell")
@@ -51,27 +49,31 @@ open class PromoViewController: MercadoPagoUIViewController, UITableViewDataSour
 		self.tableView.delegate = self
 		self.tableView.dataSource = self
 		
-		self.loadingView = UILoadingView(frame: MercadoPago.screenBoundsFixedToPortraitOrientation(), text: ("Cargando...".localized as NSString) as String)
+	/*	self.loadingView = UILoadingView(frame: MercadoPago.screenBoundsFixedToPortraitOrientation(), text: ("Cargando...".localized as NSString) as String)
         
 		self.view.addSubview(self.loadingView)
-		
+	*/
         if self.callback == nil {
             self.callback = {
                 self.dismiss(animated: true, completion: {})
             }
         }
-		var mercadoPago : MercadoPago
-		mercadoPago = MercadoPago(keyType: MercadoPago.PUBLIC_KEY, key: self.publicKey)
-		mercadoPago.getPromos({ (promos) -> Void in
-			self.promos = promos
-			self.tableView.reloadData()
-			self.loadingView.removeFromSuperview()
-		}, failure: { (error) -> Void in
-			if error.code == MercadoPago.ERROR_API_CODE {
-				self.tableView.reloadData()
-				self.loadingView.removeFromSuperview()
-			}
-		})
+        
+        if Array.isNullOrEmpty(self.promos) {
+            MPServicesBuilder.getPromos({(promos : [Promo]?) in
+                self.promos = promos
+                self.tableView.reloadData()
+                self.loadingView.removeFromSuperview()
+            }, failure: { (error: NSError) in
+                if error.code == MercadoPago.ERROR_API_CODE {
+                    self.tableView.reloadData()
+                    self.loadingView.removeFromSuperview()
+                }
+            })
+        } else {
+            self.tableView.reloadData()
+            //self.loadingView.removeFromSuperview()
+        }
 		
     }
 	

--- a/MercadoPagoSDK/MercadoPagoSDK/PromoViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PromoViewController.swift
@@ -39,7 +39,7 @@ open class PromoViewController: MercadoPagoUIViewController, UITableViewDataSour
         super.viewDidLoad()
         self.title = "Promociones".localized
         if self.navigationController != nil {
-            self.navigationController!.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.px_white()]
+            self.navigationController!.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.systemFontColor()]
         }
         
         

--- a/MercadoPagoSDK/MercadoPagoSDK/PromoViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PromoViewController.swift
@@ -14,7 +14,6 @@ open class PromoViewController: MercadoPagoUIViewController, UITableViewDataSour
 	var publicKey : String?
 	override open var screenName : String { get { return "BANK_DEALS" } }
 	@IBOutlet weak fileprivate var tableView : UITableView!
-	var loadingView : UILoadingView!
 	
 	var promos : [Promo]!
 	
@@ -38,8 +37,12 @@ open class PromoViewController: MercadoPagoUIViewController, UITableViewDataSour
 	
     override open func viewDidLoad() {
         super.viewDidLoad()
-		self.title = "Promociones".localized
-		
+        self.title = "Promociones".localized
+        if self.navigationController != nil {
+            self.navigationController!.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.px_white()]
+        }
+        
+        
 		self.tableView.register(UINib(nibName: "PromoTableViewCell", bundle: self.bundle), forCellReuseIdentifier: "PromoTableViewCell")
 		self.tableView.register(UINib(nibName: "PromosTyCTableViewCell", bundle: self.bundle), forCellReuseIdentifier: "PromosTyCTableViewCell")
 		self.tableView.register(UINib(nibName: "PromoEmptyTableViewCell", bundle: self.bundle), forCellReuseIdentifier: "PromoEmptyTableViewCell")
@@ -49,10 +52,7 @@ open class PromoViewController: MercadoPagoUIViewController, UITableViewDataSour
 		self.tableView.delegate = self
 		self.tableView.dataSource = self
 		
-	/*	self.loadingView = UILoadingView(frame: MercadoPago.screenBoundsFixedToPortraitOrientation(), text: ("Cargando...".localized as NSString) as String)
-        
-		self.view.addSubview(self.loadingView)
-	*/
+        self.showLoading()
         if self.callback == nil {
             self.callback = {
                 self.dismiss(animated: true, completion: {})
@@ -63,16 +63,16 @@ open class PromoViewController: MercadoPagoUIViewController, UITableViewDataSour
             MPServicesBuilder.getPromos({(promos : [Promo]?) in
                 self.promos = promos
                 self.tableView.reloadData()
-                self.loadingView.removeFromSuperview()
+                self.hideLoading()
             }, failure: { (error: NSError) in
                 if error.code == MercadoPago.ERROR_API_CODE {
                     self.tableView.reloadData()
-                    self.loadingView.removeFromSuperview()
+                    self.hideLoading()
                 }
             })
         } else {
             self.tableView.reloadData()
-            //self.loadingView.removeFromSuperview()
+            self.hideLoading()
         }
 		
     }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
@@ -84,6 +84,12 @@ class CardViewModelManagerTest: BaseTest {
         XCTAssertEqual(MercadoPago.getFontColorFor(expectedPaymentMethod), self.cardFormManager!.getLabelTextColor())
     }
     
+    func testShowBankDeals(){
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentSettings: nil)
+        let result = self.cardFormManager!.showBankDeals()
+        XCTAssertTrue(result)
+    }
+    
     func testGetEditingLabelColorDefaultColor() {
         self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: nil, token: nil, paymentSettings: nil)
         

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
@@ -83,11 +83,39 @@ class CardViewModelManagerTest: BaseTest {
         let expectedPaymentMethod = MockBuilder.buildPaymentMethod("master")
         XCTAssertEqual(MercadoPago.getFontColorFor(expectedPaymentMethod), self.cardFormManager!.getLabelTextColor())
     }
-    
-    func testShowBankDeals(){
+   
+    /*
+     *
+     * showBankDeals() tests for no promos loaded, promos loaded and custom setting in CardFormVC
+     *
+     */
+    func testShowBankDeals_noPromosLoaded(){
         self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentSettings: nil)
         let result = self.cardFormManager!.showBankDeals()
+        XCTAssertNil(self.cardFormManager!.promos)
+        XCTAssertFalse(result)
+    }
+    
+    func testShowBankDeals_promosLoaded(){
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentSettings: nil)
+        self.cardFormManager!.promos = [MockBuilder.buildPromo()]
+        let result = self.cardFormManager!.showBankDeals()
         XCTAssertTrue(result)
+    }
+    
+    func testShowBankDeals_promosLoadedIsEmpty(){
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentSettings: nil)
+        self.cardFormManager!.promos = []
+        let result = self.cardFormManager!.showBankDeals()
+        XCTAssertFalse(result)
+    }
+    
+    func testShowBankDeals_promosLoadedHidePromosByUser(){
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentSettings: nil)
+        self.cardFormManager!.promos = [MockBuilder.buildPromo()]
+        CardFormViewController.showBankDeals = false
+        let result = self.cardFormManager!.showBankDeals()
+        XCTAssertFalse(result)
     }
     
     func testGetEditingLabelColorDefaultColor() {

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoService.swift
@@ -20,7 +20,7 @@ open class MercadoPagoService: NSObject {
         failure: ((_ error: NSError) -> Void)?) {
         
         /*
-        MercadoPagoTestContext.addExpectation(withDescription: BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION + uri)
+        MercadoPagoTestContext.addExpectation(withDescription: BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION + uri)*/
         var finalUri = uri
         if params != nil {
             finalUri = finalUri + "?" + params!
@@ -28,7 +28,7 @@ open class MercadoPagoService: NSObject {
         
        if method == "POST" {
             let bodyData = (body as! String).data(using: String.Encoding.utf8)
-            let bodyParams = JSON(data: bodyData!)
+         /*   let bodyParams = JSON(data: bodyData!)
             
             if let public_key = (bodyParams["public_key"].asString) {
                 finalUri = finalUri + "?public_key=" + public_key
@@ -37,20 +37,20 @@ open class MercadoPagoService: NSObject {
             if let paymentMethodId = bodyParams["payment_method_id"].asString {
                 finalUri = finalUri + "&payment_method_id=" + paymentMethodId
             }
-            
+           */
         }
         
         do {
             let jsonResponse = try MockManager.getMockResponseFor(finalUri, method: method)
-            /* if (jsonResponse != nil && jsonResponse!["error"] != nil){
-             failure!(error: NSError(domain: uri, code: 400, userInfo: nil))
-             return
-             }*/
+            if (jsonResponse != nil && jsonResponse!["error"] != nil){
+                failure!(NSError(domain: uri, code: 400, userInfo: nil))
+                return
+            }
             
             success(jsonResponse)
-            MercadoPagoTestContext.fulfillExpectation(BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION + uri)
+            //MercadoPagoTestContext.fulfillExpectation(BaseTest.WAIT_FOR_REQUEST_EXPECTATION_DESCRIPTION + uri)
         } catch {
             failure!(NSError(domain: uri, code: 400, userInfo: nil))
-        }*/
+        }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockedResponse.plist
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockedResponse.plist
@@ -2,6 +2,1021 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>GET/v1/payment_methods/installments?public_key=PK_MLA&amp;amount=1.00&amp;payment_method_id=amex</key>
+	<string>[
+  {
+    &quot;payment_method_id&quot;: &quot;amex&quot;,
+    &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;303&quot;,
+      &quot;is_default&quot;: null,
+      &quot;name&quot;: &quot;Banco Patagonia&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/303.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/303.gif&quot;
+    },
+    &quot;payer_costs&quot;: [
+      {
+        &quot;installments&quot;: 1,
+        &quot;installment_rate&quot;: 0,
+        &quot;discount_rate&quot;: 0,
+        &quot;labels&quot;: [
+        ],
+        &quot;min_allowed_amount&quot;: 0,
+        &quot;max_allowed_amount&quot;: 250000,
+        &quot;recommended_message&quot;: &quot;1 cuota de $ 1,00 ($ 1,00)&quot;,
+        &quot;installment_amount&quot;: 1,
+        &quot;total_amount&quot;: 1
+      }
+    ]
+  },
+  {
+    &quot;payment_method_id&quot;: &quot;amex&quot;,
+    &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;326&quot;,
+      &quot;is_default&quot;: null,
+      &quot;name&quot;: &quot;HSBC&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/326.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/326.gif&quot;
+    },
+    &quot;payer_costs&quot;: [
+      {
+        &quot;installments&quot;: 1,
+        &quot;installment_rate&quot;: 0,
+        &quot;discount_rate&quot;: 0,
+        &quot;labels&quot;: [
+        ],
+        &quot;min_allowed_amount&quot;: 0,
+        &quot;max_allowed_amount&quot;: 250000,
+        &quot;recommended_message&quot;: &quot;1 cuota de $ 1,00 ($ 1,00)&quot;,
+        &quot;installment_amount&quot;: 1,
+        &quot;total_amount&quot;: 1
+      }
+    ]
+  },
+  {
+    &quot;payment_method_id&quot;: &quot;amex&quot;,
+    &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;279&quot;,
+      &quot;is_default&quot;: null,
+      &quot;name&quot;: &quot;Banco Galicia&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/279.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/279.gif&quot;
+    },
+    &quot;payer_costs&quot;: [
+      {
+        &quot;installments&quot;: 1,
+        &quot;installment_rate&quot;: 0,
+        &quot;discount_rate&quot;: 0,
+        &quot;labels&quot;: [
+        ],
+        &quot;min_allowed_amount&quot;: 0,
+        &quot;max_allowed_amount&quot;: 250000,
+        &quot;recommended_message&quot;: &quot;1 cuota de $ 1,00 ($ 1,00)&quot;,
+        &quot;installment_amount&quot;: 1,
+        &quot;total_amount&quot;: 1
+      }
+    ]
+  },
+  {
+    &quot;payment_method_id&quot;: &quot;amex&quot;,
+    &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;297&quot;,
+      &quot;is_default&quot;: null,
+      &quot;name&quot;: &quot;Macro&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/297.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/297.gif&quot;
+    },
+    &quot;payer_costs&quot;: [
+      {
+        &quot;installments&quot;: 1,
+        &quot;installment_rate&quot;: 0,
+        &quot;discount_rate&quot;: 0,
+        &quot;labels&quot;: [
+        ],
+        &quot;min_allowed_amount&quot;: 0,
+        &quot;max_allowed_amount&quot;: 250000,
+        &quot;recommended_message&quot;: &quot;1 cuota de $ 1,00 ($ 1,00)&quot;,
+        &quot;installment_amount&quot;: 1,
+        &quot;total_amount&quot;: 1
+      }
+    ]
+  },
+  {
+    &quot;payment_method_id&quot;: &quot;amex&quot;,
+    &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;1041&quot;,
+      &quot;is_default&quot;: null,
+      &quot;name&quot;: &quot;Emitida por American Express&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1041.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1041.gif&quot;
+    },
+    &quot;payer_costs&quot;: [
+      {
+        &quot;installments&quot;: 1,
+        &quot;installment_rate&quot;: 0,
+        &quot;discount_rate&quot;: 0,
+        &quot;labels&quot;: [
+        ],
+        &quot;min_allowed_amount&quot;: 0,
+        &quot;max_allowed_amount&quot;: 250000,
+        &quot;recommended_message&quot;: &quot;1 cuota de $ 1,00 ($ 1,00)&quot;,
+        &quot;installment_amount&quot;: 1,
+        &quot;total_amount&quot;: 1
+      }
+    ]
+  },
+  {
+    &quot;payment_method_id&quot;: &quot;amex&quot;,
+    &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;310&quot;,
+      &quot;is_default&quot;: null,
+      &quot;name&quot;: &quot;Banco Santander Rio S.A.&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/310.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/310.gif&quot;
+    },
+    &quot;payer_costs&quot;: [
+      {
+        &quot;installments&quot;: 1,
+        &quot;installment_rate&quot;: 0,
+        &quot;discount_rate&quot;: 0,
+        &quot;labels&quot;: [
+        ],
+        &quot;min_allowed_amount&quot;: 0,
+        &quot;max_allowed_amount&quot;: 250000,
+        &quot;recommended_message&quot;: &quot;1 cuota de $ 1,00 ($ 1,00)&quot;,
+        &quot;installment_amount&quot;: 1,
+        &quot;total_amount&quot;: 1
+      }
+    ]
+  },
+  {
+    &quot;payment_method_id&quot;: &quot;amex&quot;,
+    &quot;payment_type_id&quot;: &quot;credit_card&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;2&quot;,
+      &quot;is_default&quot;: null,
+      &quot;name&quot;: &quot;American Express&quot;,
+      &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/amex.gif&quot;,
+      &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/amex.gif&quot;
+    },
+    &quot;payer_costs&quot;: [
+      {
+        &quot;installments&quot;: 1,
+        &quot;installment_rate&quot;: 0,
+        &quot;discount_rate&quot;: 0,
+        &quot;labels&quot;: [
+        ],
+        &quot;min_allowed_amount&quot;: 0,
+        &quot;max_allowed_amount&quot;: 250000,
+        &quot;recommended_message&quot;: &quot;1 cuota de $ 1,00 ($ 1,00)&quot;,
+        &quot;installment_amount&quot;: 1,
+        &quot;total_amount&quot;: 1
+      }
+    ]
+  }
+]</string>
+	<key>GET/v1/payment_methods/deals?public_key=PK_MLA</key>
+	<string>[
+  {
+    &quot;id&quot;: &quot;e1b3cfbc8f8655f124b22cd8f3a9604d&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;294&quot;,
+      &quot;name&quot;: &quot;Banco Hipotecario&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;545301-MLA20314558611_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/545301-MLA20314558611_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/545301-MLA20314558611_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/294.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/294.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;Promoción válida en Argentina desde el 01/01/2017 hasta el 31/01/2017 para consumos con tarjetas de crédito Visa del Banco Hipotecario que no registren mora. No acumulable con otras promociones. (1) Costo Financiero Total Nominal Anual (CFTNA) 0,00%. Planes de hasta 3 cuotas con TNA/TEA 0.00%. El Costo Financiero Total Nominal Anual (CFTNA) incluye el costo total por contratación y administración de seguro de vida. Banco Hipotecario S.A. CUIT 30-50001107-2, Reconquista 151, Ciudad Autónoma de Buenos Aires. **En productos seleccionados hasta 12 cuotas sin interés.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;2129d18f511d25313813fc59bfc66829&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;692&quot;,
+      &quot;name&quot;: &quot;Cencosud&quot;
+    },
+    &quot;max_installments&quot;: 6,
+    &quot;installments&quot;: [
+      1,
+      3,
+      6
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 6 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;725301-MLA20314565114_062015&quot;,
+      &quot;size&quot;: &quot;190x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/725301-MLA20314565114_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/725301-MLA20314565114_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/692.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/692.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;cencosud&quot;,
+        &quot;name&quot;: &quot;Cencosud&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cencosud.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cencosud.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;Costo Financiero Total: 0,00% - Promoción válida desde el 01/01/2017 al 31/01/2017 pagando con tarjetas Mastercard y Cencosud de Cencosud en www.mercadolibre.com. (1) Exclusivamente pagando con tarjetas Cencosud en hasta 6 cuotas fijas mensuales sin interés en toda la compra. Plan 6: Tasa Nominal Anual: 0%; Tasa Efectiva Anual: 0%; Costo Financiero Total (CFT): 0,00% (*) El CFT no incluye cargos mensuales de administracíon de cuenta y costos asociados al mantenimiento de la tarjeta. Consulte cargos vigentes asociados a su cuenta al 0810-9999-627. CENCOSUD S.A., CUIT 30-59036076-3, Suipacha 1111, Piso 18, CABA (Dom. No Comercial). (*) CFT: 0,00%.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;e4c32d4d007106554ed4498733d24860&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;1007&quot;,
+      &quot;name&quot;: &quot;Nativa Mastercard&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;924401-MLA20314531626_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/924401-MLA20314531626_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/924401-MLA20314531626_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:58.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1007.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1007.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;nativa&quot;,
+        &quot;name&quot;: &quot;Nativa Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/nativa.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/nativa.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;COSTO FINANCIERO TOTAL: 0,00% - Promoción válida del 01/01/2017 hasta 31/01/2017 para compras con tarjeta de crédito Mastercard y Nativa Mastercard de Nativa Mastercard. TNA (Tasa Nominal Anual): 0% - TEA (Tasa Efectiva Anual): 0% - CFT (Costo Financiero Total): 0,00% por gestión de contratación de Seguro de Vida sobre saldo deudor. Consulta los detalles de esta promoción en www.nativanacion.com.ar . **En productos seleccionados también 12 cuotas sin interés.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;660c04cb5d48797f12e952741b751bee&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;297&quot;,
+      &quot;name&quot;: &quot;Macro&quot;
+    },
+    &quot;max_installments&quot;: 6,
+    &quot;installments&quot;: [
+      1,
+      3,
+      6
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 6 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;645301-MLA20314559594_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/645301-MLA20314559594_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/645301-MLA20314559594_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2017-01-01T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-02T23:59:58.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/297.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/297.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/297.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/297.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;amex&quot;,
+        &quot;name&quot;: &quot;American Express&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/297.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/297.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;PROMOCIÓN VALIDA DESDE EL 02/01/2017 AL 02/01/2017, HASTA 6 CUOTAS SIN INTERÉS PARA COMPRAS EN SITIOS DE INTERNET QUE UTILICEN COMO MEDIO DE PAGO A “MERCADOPAGO” ASOCIANDO LA COMPRA CON LAS TARJETAS DE CRÉDITO VISA, MASTERCARD Y AMERICAN EXPRESS DE LOS BANCOS DEL GRUPO MACRO. EXCLUSIVO PARA VENTAS WEB. CONSULTE COSTOS DE ENVÍO AL REALIZAR LA COMPRA. NO APLICA A LAS TARJETAS DE CRÉDITO EMPRESA Y/O AGRO. TNA (TASA NOMINAL ANUAL) 0%, TEA (TASA EFECTIVA ANUAL) 0%, CFTNA (COSTO FINANCIERO TOTAL NOMINAL ANUAL) 2.10% (IVA NO ALCANZADO, INCLUYE SEGURO DE VIDA SOBRE SALDOS). VÁLIDA SÓLO PARA CONSUMOS DE TIPO PERSONAL/FAMILIAR. LOS ESTABLECIMIENTOS, LOS PRODUCTOS Y/O SERVICIOS QUE COMERCIALIZAN O LA CALIDAD DE LOS MISMOS NO SON PROMOCIONADOS NI GARANTIZADOS POR LOS BANCOS DEL GRUPO MACRO, COMO ASÍ TAMPOCO SE RESPONSABILIZAN POR LOS CUPONES PRESENTADOS FUERA DE TÉRMINO POR LOS COMERCIOS. MERCADOPAGO PERTENCE A MERCADOLIBRE SRL. CUIT: 30-70308853-4.CONSULTE BASES, CONDICIONES, ALCANCES DE LA PROMOCIÓN, Y TODA INFORMACIÓN ADICIONAL EN FORMA PREVIA A REALIZAR LA OPERACIÓN EN WWW.BENEFICIOSACANOMAS.COM.AR O AL 0810-555-2355 PARA BANCO MACRO, EN WWW.BANCOTUCUMAN.COM.AR O AL 0810-888-3300 PARA BANCO DEL TUCUMÁN O EN LA SUCURSAL MÁS CERCANA A SU DOMICILIO&quot;
+  },
+  {
+    &quot;id&quot;: &quot;0de39a449672b365916c4a69cf64f777&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;1044&quot;,
+      &quot;name&quot;: &quot;Banco Provincia&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;407301-MLA20314488985_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/407301-MLA20314488985_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/407301-MLA20314488985_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:58.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1044.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1044.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1044.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1044.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;(*) CFT: 0,73%. (*) Costo Financiero Total (CFT) Nominal Anual 0,73% por cargo seguro de vida sobre saldo deudor. Interés: Tasa Nominal Anual 0,00%. Tasa Efectiva Anual 0,00%. Promoción válida todos los días. (2) Para compras realizadas en hasta 3 cuotas sin interés desde el 01/01/2017 al 31/01/2017 con las tarjetas de crédito Visa y MasterCard emitidas por el Banco Provincia de Buenos. Promoción válida únicamente para la República Argentina. No combinable con otras promociones.(Ejemplo representativo de promoción de cuotas sin interés con tarjeta de crédito: en una compra con tarjeta de crédito de $1.500 en 3 cuotas sin interés, el cliente abonará 3 cuotas de $500 cada una. Adicionalmente, se incluirá en el rubro “Seguro sobre saldo deudor” la suma total de $1,81 que serán distribuidos en los dos primeros resúmenes, según el saldo de deuda que registre). Banco de la Provincia de Buenos Aires. CUIT 33-99924210-9 Calle 7 Nº 726 La Plata, Provincia de Buenos Aires. **En productos seleccionados hasta 12 cuotas sin interés.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;3517e9a6fc2bcb7b1c7d045713ed42bb&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;303&quot;,
+      &quot;name&quot;: &quot;Banco Patagonia&quot;
+    },
+    &quot;max_installments&quot;: 6,
+    &quot;installments&quot;: [
+      1,
+      3,
+      6
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 6 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;858301-MLA20314560418_062015&quot;,
+      &quot;size&quot;: &quot;201x50&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/858301-MLA20314560418_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/858301-MLA20314560418_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:58.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/303.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/303.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/303.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/303.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;amex&quot;,
+        &quot;name&quot;: &quot;American Express&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/303.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/303.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;C.F.T.N.A: 0,00% PARA COMPRAS ABONADAS EN CUOTAS POR USUARIOS DE SERVICIOS FINANCIEROS - CARTERA DE CONSUMO - SE APLICARA: TASA NOMINAL ANUAL: 0% - TASA EFECTIVA ANUAL: 0% - COSTO SEGURO DE VIDA 0% - COSTO FINANCIERO TOTAL NOMINAL ANUAL (C.F.T.N.A.). C.F.T.N.A: 4,26% PARA COMPRAS ABONADAS EN CUOTAS POR CLIENTES DE CARTERA COMERCIAL, SE APLICARÁ: TASA NOMINAL ANUAL: 0% - TASA EFECTIVA ANUAL: 0% - COSTO SEGURO DE VIDA 0.35% - COSTO FINANCIERO TOTAL NOMINAL ANUAL (C.F.T.N.A.). PROMOCIÓN VÁLIDA EN LA REPÚBLICA ARGENTINA DESDE EL 01/01/2017 HASTA EL 31/01/2017. ABONANDO TODOS LOS DÍAS CON TODAS LAS TARJETAS DE CRÉDITO DE BANCO PATAGONIA, RECIBIRÁ UNA FINANCIACIÓN DE HASTA 6 CUOTAS SIN INTERÉS EN MERCADO LIBRE. SE EXCLUYEN TARJETAS CORPORATIVAS. PROMOCIÓN NO ACUMULABLE CON OTRAS PROMOCIONES. LAS CUENTAS NO DEBERÁN REGISTRAR MORA. BANCO PATAGONIA S.A. NO SE RESPONSABILIZA POR LOS CUPONES PRESENTADOS FUERA DE LA FECHA DE VIGENCIA DE LA PROMOCIÓN. LOS ACCIONISTAS DE BANCO PATAGONIA S.A. LIMITAN SU RESPONSABILIDAD A LA INTEGRACIÓN DE LAS ACCIONES SUSCRIPTAS. LEY 25.738.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;0ff87c0ac3279a6a23bdccf5969e1fe1&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;282&quot;,
+      &quot;name&quot;: &quot;Banco Nacion&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;250401-MLA20314555290_062015&quot;,
+      &quot;size&quot;: &quot;201x61&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/250401-MLA20314555290_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/250401-MLA20314555290_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:58.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/282.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/282.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/282.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/282.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;COSTO FINANCIERO TOTAL: 0,00% - Promoción válida desde el 01/01/2017 hasta el 31/01/2017, ambas fechas inclusive con tarjetas Visa y Mastercard del Banco Nación. No válido para tarjetas Nativa del BNA. (*) TNA (Tasa Nominal Anual): 0% - TEA (Tasa Efectiva Anual): 0% - CFT (Costo Financiero Total): 0,00% por gestión de contratación de Seguro de Vida sobre saldo deudor. Consulta los comercios adheridos exclusivamente a esta promoción en www.bna.com.ar . **En productos seleccionados también 12 cuotas sin interés.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;85c68c484a9c18d70c4450540a216b4d&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;338&quot;,
+      &quot;name&quot;: &quot;ICBC&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;426301-MLA20314564170_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/426301-MLA20314564170_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/426301-MLA20314564170_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/338.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/338.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/338.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/338.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;Propuesta válida del 01/01/2017 al 31/01/2017 exclusivo compras con tarjetas de crédito Visa y Mastercard del ICBC. No válido para compras mayoristas, ni tarjetas purchasing, agro, corporate. (*) Planes en cuotas indicados tienen costo financiero total (CFT): 0,00%, tasa nominal anual: 0,00%, tasa efectiva anual: 0,00%, costo seguro de vida s/deudor: 0,00%. Industrial and Commercial Bank of China (Argentina) S.A. Es una sociedad anónima bajo la ley argentina. Sus accionistas limitan su responsabilidad al capital aportado (ley 25738).&quot;
+  },
+  {
+    &quot;id&quot;: &quot;5ce7700bc1c04fcc1a9e0f005f585eee&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;1041&quot;,
+      &quot;name&quot;: &quot;Emitida por American Express&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: null,
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:58.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;amex&quot;,
+        &quot;name&quot;: &quot;American Express&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1041.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1041.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;PROMOCIÓN VÁLIDA EN ARGENTINA DESDE EL 01/01/2017 HASTA EL 31/01/2017. 3 CUOTAS SIN INTERÉS APLICABLE A LAS TARJETAS PERSONALES Y CORPORATIVAS AMERICAN EXPRESS EMITIDAS Y ADMINISTRADAS POR AMERICAN EXPRESS ARGENTINA S.A. LAS COMPRAS CON PLAN DE PAGOS ESTÁN SUJETAS A APROBACIÓN DE AMERICAN EXPRESS ARGENTINA S.A.. AMERICAN EXPRESS PUEDE MODIFICAR O SUSPENDER EL PLAN DE PAGOS EN CUALQUIER MOMENTO. SE LE INFORMARÁ CUALQUIER CAMBIO A TRAVÉS DEL RESUMEN DE CUENTA. COSTO FINANCIERO TOTAL NOMINAL ANUAL (CFTNA) PARA COMPRAS EN 3 CUOTAS: MÁXIMO: 0,00% (con IVA) - MÍNIMO: 0%. TASA NOMINAL ANUAL (TNA): 0%. TASA EFECTIVA ANUAL (TEA): 0%. **En productos seleccionados hasta 12 cuotas sin interés.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;c0b6d636b63f8d2331aac25b59352376&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;326&quot;,
+      &quot;name&quot;: &quot;HSBC&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;868301-MLA20314562653_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/868301-MLA20314562653_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/868301-MLA20314562653_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/326.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/326.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/326.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/326.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;amex&quot;,
+        &quot;name&quot;: &quot;American Express&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/326.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/326.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;CFT (con IVA): 2,50%, C.F.T. (sin IVA): 2,07%, C.F.T. (costo financiero total), CFT mínimo 0%,T.N.A. (Tasa Nominal Anual) 0%, T.E.A. (Tasa Efectiva Anual) 0%. Promoción válida desde el 01/01/2017 y hasta el 31/01/2017 para las compras que sean abonadas en MercadoLibre con las tarjetas de crédito Visa, Mastercard y American Express emitidas por HSBC Bank Argentina S.A. (en adelante, HSBC). La promoción aplica para las compras realizadas en hasta 3 cuotas sin interés. Promoción válida únicamente para la República Argentina. Quedan excluidos de la presente promoción aquellos clientes que registren mora con HSBC. Promoción no válida para Tarjetas de Crédito Corporativas, Empresa, Business, Puchasing, Cuenta Central, C&amp;A, Bonesi y Tarjetas de Débito. Promoción no acumulable con otras promociones vigentes. HSBC no promueve los bienes y/o servicios ni al proveedor de los mismos. Los bienes y/o servicios aquí mencionados se ofrecen bajo responsabilidad exclusiva del establecimiento o proveedor de los bienes y/o servicios. Ley 25.738 (art. 1°): HSBC Bank Argentina S.A., es una sociedad anónima constituida bajo las leyes de la República Argentina. Sus operaciones son independientes de otras compañías del Grupo HSBC. Los accionistas limitan su responsabilidad al capital aportado.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;294c30d75527c3b7f2fc680a44547fc7&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;319&quot;,
+      &quot;name&quot;: &quot;Citi&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;274301-MLA20314562346_062015&quot;,
+      &quot;size&quot;: &quot;150x61&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/274301-MLA20314562346_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/274301-MLA20314562346_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/319.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/319.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/319.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/319.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;COSTO FINANCIERO TOTAL NOMINAL ANUAL: (CFTNA) 0,00% (para tarjetas de crédito con seguro de vida). CFTN: 0% (para tarjetas de crédito sin seguro de vida). La contratación del seguro de vida es optativa. Tasa de interés nominal anual: 0%. Tasa de interés máxima nominal anual: 0%. Tasa de interés efectiva anual: 0%. Tasa Fija. Válido exclusivamente del 01/01/2017 al 31/01/2017. Aplica a tarjetas de crédito Citi Visa y Citi MasterCard emitidas por Citibank Argentina (excepto corporativas y Gift Card). No acumulable con otras promociones vigentes. Exclusivamente venta online. Citibank N.A. no promociona ni garantiza los productos y/o servicios ni la calidad de los mismos. Sucursal de Citibank N.A. establecida en la República Argentina. Citibank N.A. realiza su actividad bancaria en Argentina a través de su sucursal. Las obligaciones resultantes de sus operaciones son pagaderas en Argentina y únicamente con los activos de la sucursal de Citibank N.A. en Argentina. Citi y el diseño del arco es una Marca Registrada de Citigroup Inc.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;433e7a4771a8a9d81dbd4ca73782657e&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;1078&quot;,
+      &quot;name&quot;: &quot;Mercado Pago + Banco Patagonia&quot;
+    },
+    &quot;max_installments&quot;: 12,
+    &quot;installments&quot;: [
+      1,
+      3,
+      6,
+      9,
+      12
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 12 cuotas sin interés&quot;,
+    &quot;picture&quot;: null,
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1078.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1078.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;PARA COMPRAS ABONADAS EN CUOTAS POR USUARIOS DE SERVICIOS FINANCIEROS - CARTERA DE CONSUMO - SE APLICARÁ: TASA NOMINAL ANUAL: 0% - TASA EFECTIVA ANUAL: 0% - COSTO SEGURO DE VIDA 0% . PROMOCIÓN VÁLIDA EN LA REPÚBLICA ARGENTINA DESDE EL 01/01/2017 HASTA EL 31/01/2017. ABONANDO TODOS LOS DÍAS CON LA TARJETA DE CRÉDITO MASTERCARD DE MERCADO PAGO + BANCO PATAGONIA, RECIBIRÁ UNA FINANCIACIÓN DE HASTA 12 CUOTAS SIN INTERÉS EN MERCADO LIBRE Y COMERCIOS ONLINE QUE ACEPTEN MERCADO PAGO. SE EXCLUYEN TARJETAS CORPORATIVAS. PROMOCIÓN NO ACUMULABLE CON OTRAS PROMOCIONES. BANCO PATAGONIA S.A. NO SE RESPONSABILIZA POR LOS CUPONES PRESENTADOS FUERA DE LA FECHA DE VIGENCIA DE LA PROMOCIÓN. LOS ACCIONISTAS DE BANCO PATAGONIA S.A. LIMITAN SU RESPONSABILIDAD A LA INTEGRACIÓN DE LAS ACCIONES SUSCRIPTAS. LEY 25.738.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;dbc5df24cf92d54f69860f6a9c18e598&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;313&quot;,
+      &quot;name&quot;: &quot;Banco Supervielle&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;467301-MLA20314560838_062015&quot;,
+      &quot;size&quot;: &quot;20x63&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/467301-MLA20314560838_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/467301-MLA20314560838_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/313.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/313.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/313.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/313.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;DISPONIBLE PARA CARTERA CONSUMO. Válido todos los desde el 01/01/2017 hasta el 31/01/2017. Promoción válida únicamente para la República Argentina. Para compras abonadas con tarjetas de crédito VISA y MasterCard emitidas por Banco Supervielle S.A (el “Banco”). La promoción solo es válida para clientes con paquete de productos del Banco y no es aplicable a tarjetas corporativas ni a tarjetas emitidas en origen por Cordial Compañía Financiera S.A. No combinable con otras promociones vigentes. Para compras en hasta 3 cuotas fijas: Tasa Nominal Anual (TNA): 0,00% Tasa Efectiva Anual (TEA): 0,00% Costo Financiero Total Nominal Anual (CFTNA): 0,00% el CFTNA y demás datos económicos informados en el presente, corresponden exclusivamente a la operación de compra en cuotas objeto de la presente. Ej.: Si compra un producto por $3.000, en 3 cuotas sin interés, del 1er. al 3er. resumen que se emita con posterioridad al cierre y luego de realizada la compra, se reflejará una cuota de $1.000 en cada uno de ellos. Banco Supervielle S.A. no es responsable por los productos y/o servicios comercializados por las marcas y locales participantes en las promociones. Banco Supervielle S.A.- B.Mitre 434 – C.A.B.A.- Cuit 33-50000517-9, Inscrip. I.G.J. N° 23, F° 502, L. 45, T° A de Estatutos Nac.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;047ed9e02543f2a9867c1d25d7e54346&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;688&quot;,
+      &quot;name&quot;: &quot;Cabal de todos los bancos&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;942401-MLA20314563857_062015&quot;,
+      &quot;size&quot;: &quot;180x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/942401-MLA20314563857_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/942401-MLA20314563857_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:58.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;cabal&quot;,
+        &quot;name&quot;: &quot;Cabal&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/cabal.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/cabal.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;Vigente desde 01/01/2017 hasta 31/01/2017, para el pago de consumos con Tarjeta de Crédito Cabal emitidas en la República Argentina, excepto AgroCabal y Cabal Mayorista. 3 cuotas sin interés: consulte CFT en la entidad emisora de su tarjeta.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;99c95c4d884828914e0471117c684f24&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;1049&quot;,
+      &quot;name&quot;: &quot;Banco de La Pampa&quot;
+    },
+    &quot;max_installments&quot;: 6,
+    &quot;installments&quot;: [
+      1,
+      3,
+      6
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 6 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;958901-MLA20429239367_092015&quot;,
+      &quot;size&quot;: &quot;224x24&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/958901-MLA20429239367_092015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/958901-MLA20429239367_092015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1049.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1049.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1049.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1049.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;Promoción válida desde el 01/01/2017 hasta el 31/01/2017 para las compras que sean abonadas en MercadoLibre con las tarjetas de crédito Visa y Mastercard emitidas por el Banco de La Pampa. La promoción aplica para las compras realizadas en hasta 6 cuotas sin interés. Promoción no válida para Tarjetas de Crédito Corporativas, Empresa o Tarjetas de Débito. Quedan excluidas las cuentas en mora y/o bloqueadas por motivos administrativos. El Banco de La Pampa no promueve los bienes y/o servicios ni al proveedor de los mismos. Los bienes y/o servicios aquí mencionados se ofrecen bajo responsabilidad exclusiva del establecimiento o proveedor de los bienes y/o servicios. Tasa Nominal Anual 0%, Tasa Efectiva Anual 0%, Costo Financiero Total: a) 3,59% (incluye seguro de vida sobre saldo deudor para menores de 65 años) - b) 4,76% (incluye seguro de vida sobre saldo deudor para mayores de 65 años).&quot;
+  },
+  {
+    &quot;id&quot;: &quot;1ca4f4cd207869a1b1b09eea800cb9e9&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;1028&quot;,
+      &quot;name&quot;: &quot;Diners&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;779301-MLA20314535406_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/779301-MLA20314535406_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/779301-MLA20314535406_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:58.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;diners&quot;,
+        &quot;name&quot;: &quot;Diners&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/diners.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/diners.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;Promoción válida desde el 01/01/2017 hasta el 31/01/2017 abonando hasta 3 cuotas sin interés exclusivamente con tarjetas Diners Club International emitidas en Argentina. No acumulable con otras promociones. No incluye tarjetas corporativas. Sólo válido para aquellos clientes que se encuentran al día en sus productos. *CARGO POR PRIMA E IMPUESTO SEGURO SALDO DEUDOR 0,00%. TNA: 0,00% TASA NOMINAL ANUAL. TEA: 0,00% TASA EFECTIVA ANUAL.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;81fe01e3100595677d6b5b9b0910268b&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;1043&quot;,
+      &quot;name&quot;: &quot;Tucuman&quot;
+    },
+    &quot;max_installments&quot;: 6,
+    &quot;installments&quot;: [
+      1,
+      3,
+      6
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 6 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;483401-MLA20314539798_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/483401-MLA20314539798_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/483401-MLA20314539798_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2017-01-01T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-02T23:59:58.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1043.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1043.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/1043.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/1043.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;PROMOCIÓN VALIDA DESDE EL 02/01/2017 AL 02/01/2017, HASTA 6 CUOTAS SIN INTERÉS PARA COMPRAS EN SITIOS DE INTERNET QUE UTILICEN COMO MEDIO DE PAGO A “MERCADOPAGO” ASOCIANDO LA COMPRA CON LAS TARJETAS DE CRÉDITO VISA, MASTERCARD Y AMERICAN EXPRESS DE LOS BANCOS DEL GRUPO MACRO. EXCLUSIVO PARA VENTAS WEB. CONSULTE COSTOS DE ENVÍO AL REALIZAR LA COMPRA. NO APLICA A LAS TARJETAS DE CRÉDITO EMPRESA Y/O AGRO. TNA (TASA NOMINAL ANUAL) 0%, TEA (TASA EFECTIVA ANUAL) 0%, CFTNA (COSTO FINANCIERO TOTAL NOMINAL ANUAL) 2.10% (IVA NO ALCANZADO, INCLUYE SEGURO DE VIDA SOBRE SALDOS). VÁLIDA SÓLO PARA CONSUMOS DE TIPO PERSONAL/FAMILIAR. LOS ESTABLECIMIENTOS, LOS PRODUCTOS Y/O SERVICIOS QUE COMERCIALIZAN O LA CALIDAD DE LOS MISMOS NO SON PROMOCIONADOS NI GARANTIZADOS POR LOS BANCOS DEL GRUPO MACRO, COMO ASÍ TAMPOCO SE RESPONSABILIZAN POR LOS CUPONES PRESENTADOS FUERA DE TÉRMINO POR LOS COMERCIOS. MERCADOPAGO PERTENCE A MERCADOLIBRE SRL. CUIT: 30-70308853-4.CONSULTE BASES, CONDICIONES, ALCANCES DE LA PROMOCIÓN, Y TODA INFORMACIÓN ADICIONAL EN FORMA PREVIA A REALIZAR LA OPERACIÓN EN WWW.BENEFICIOSACANOMAS.COM.AR O AL 0810-555-2355 PARA BANCO MACRO, EN WWW.BANCOTUCUMAN.COM.AR O AL 0810-888-3300 PARA BANCO DEL TUCUMÁN O EN LA SUCURSAL MÁS CERCANA A SU DOMICILIO&quot;
+  },
+  {
+    &quot;id&quot;: &quot;0f3d7b0ba1205561da5f1a0c7ea9e196&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;331&quot;,
+      &quot;name&quot;: &quot;Nuevo Banco de Entre Rios&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;238301-MLA20314562739_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/238301-MLA20314562739_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/238301-MLA20314562739_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/331.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/331.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/331.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/331.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;Vigencia del 01/01/2017 al 31/01/2017. (1) Válido en hasta 3 cuotas sin interés, válido todos los días de la semana, abonando con Tarjetas de Crédito emitidas por el Nuevo Banco de Entre Ríos S.A. NO VÁLIDO PARA VUELOS. (1) Costo Financiero Total (Nominal Anual) CFT (NA): 0,00%, TNA (Tasa Nominal Anual): 0%, TEA (Tasa Efectiva Anual): 0%. Ejemplo: Ud. podrá financiar una compra de $ 1.200 en 3 cuotas de $ 400 c/u. VÁLIDO PARA CARTERA DE CONSUMO Y CARTERA COMERCIAL. Los datos y ofertas revisten carácter exclusivamente informativo y en modo alguno suponen que los establecimientos, productos o la calidad de los mismos se encuentran promocionados y/o garantizados por el Nuevo Banco de Entre Ríos SA. Aviso – Ley 25.738. El Nuevo Banco de Entre Ríos S.A. es una Sociedad Anónima constituida bajo las leyes de la República Argentina. Sus accionistas limitan su responsabilidad al capital aportado. VÁLIDO PARA CARTERA DE CONSUMO Y CARTERA COMERCIAL (1) C.F.T.N.A: 0,00%&quot;
+  },
+  {
+    &quot;id&quot;: &quot;225af44a6b6d9a14f8e6e5ee57a2929b&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;333&quot;,
+      &quot;name&quot;: &quot;Nuevo Banco de Santa Fe&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;316301-MLA20314564091_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/316301-MLA20314564091_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/316301-MLA20314564091_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/333.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/333.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/333.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/333.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;COSTO FINANCIERO TOTAL NOMINAL ANUAL: 3,61% TNA (Tasa Nominal Anual): 0%, TEA (Tasa Efectiva Anual): 0%. Seguro de vida sobre saldo deudor: 0,2955%. Válido Todos los días desde el 01/01/2017 hasta el 31/01/2017 abonando con Tarjetas de Crédito Visa o MasterCard emitidas por el Banco Santa Fe. Promoción no acumulable con otras promociones vigentes. Ejemplo: en una compra de $ 1.200 abonada con tarjeta de crédito, financiada en tres cuotas, recibirá en la primera liquidación de su tarjeta un consumo de $400 y en las dos liquidaciones posteriores a la compra, recibirá un consumo de $400 en cada uno de ellos. Adicionalmente, se incluirá en el rubro Gto de contratación Seguro la suma total de $8,87 que será distribuida en los tres resúmenes posteriores al que ingresa la compra conforme el saldo de deuda que registre. Los datos y ofertas incluidos en este revisten carácter exclusivamente informativo y en modo alguno suponen que los establecimientos, productos o la calidad de los mismos se encuentran promocionados y/o garantizados por el Banco Santa Fe. Aviso – Ley 25.738. Banco Santa Fe es una marca registrada de Nuevo Banco de Santa Fe S.A., la cual es una Sociedad Anónima constituida bajo las leyes de la República Argentina. Sus accionistas limitan su responsabilidad al capital aportado.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;df73490a0fdddd4cbe17ee253cc24e71&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;287&quot;,
+      &quot;name&quot;: &quot;Banco Santa Cruz&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;695301-MLA20314556248_062015&quot;,
+      &quot;size&quot;: &quot;200x59&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/695301-MLA20314556248_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/695301-MLA20314556248_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/287.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/287.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/287.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/287.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;Comprá todos los días en hasta 12 cuotas sin interés (1) en productos seleccionados y en hasta 3 cuotas sin interés (2) en el resto de la tienda, con las tarjetas de crédito de Banco Santa Cruz. CFTNA: 4,87% (sin IVA, por gestión de contratación de cobertura de seguro de vida sobre saldo). Vigencia desde el 01/01/2017 hasta el 31/01/2017 inclusive. Válido todos los días de la semana, abonando con Tarjetas de Crédito emitidas por Banco Santa Cruz S.A. (1) TNA (Tasa Nominal Anual): 0%, TEA (Tasa Efectiva Anual): 0%. Ejemplo: Ud. podrá financiar una compra de $ 1.200 en 12 cuotas de $ 100 c/u. Adicionalmente, se incluirá en el rubro “Qualia Seguros s/Saldo Deudor” conforme el saldo de deuda que registre. (2) TNA (Tasa Nominal Anual): 0%, TEA (Tasa Efectiva Anual): 0%. Ejemplo: Ud. podrá financiar una compra de $ 600 en 3 cuotas de $ 200 c/u. Adicionalmente, se incluirá en el rubro “Qualia Seguros s/Saldo Deudor” conforme el saldo de deuda que registre. Los datos y ofertas incluidos en este revisten carácter exclusivamente informativo y en modo alguno suponen que los establecimientos, productos o la calidad de los mismos se encuentran promocionados y/o garantizados por el Banco Santa Cruz S.A. Aviso – Ley 25.738. El Banco Santa Cruz S.A. es una Sociedad Anónima constituida bajo las leyes de la República Argentina. Sus accionistas limitan su responsabilidad al capital aportado.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;86e21ed3f3978fc4407a5cb1ffd5347c&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;286&quot;,
+      &quot;name&quot;: &quot;Banco San Juan&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: {
+      &quot;id&quot;: &quot;958301-MLA20314555455_062015&quot;,
+      &quot;size&quot;: &quot;200x60&quot;,
+      &quot;url&quot;: &quot;http://mla-s1-p.mlstatic.com/958301-MLA20314555455_062015-F.jpg&quot;,
+      &quot;secure_url&quot;: &quot;https://mla-s1-p.mlstatic.com/958301-MLA20314555455_062015-F.jpg&quot;
+    },
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/286.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/286.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/286.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/286.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;VÁLIDO PARA CARTERA DE CONSUMO Y CARTERA COMERCIAL. Vigencia desde el 01/01/2017 hasta el 31/01/2017 inclusive. Válido todos los días de la semana, abonando con Tarjetas de Crédito emitidas por Banco San Juan S.A. (1) De 1 a 3 cuotas aplicable a toda la tienda y de 4 a 12 cuotas aplicable solo en productos seleccionados. CFTNA: 4,98% (sin IVA, por gestión de contratación de cobertura de seguro de vida sobre saldo), TNA (Tasa Nominal Anual): 0%, TEA (Tasa Efectiva Anual): 0%. Ejemplo: Ud. podrá financiar una compra de $ 1.200 en 12 cuotas de $ 100 c/u.. Los datos y ofertas incluidos en este revisten carácter exclusivamente informativo y en modo alguno suponen que los establecimientos, productos o la calidad de los mismos se encuentran promocionados y/o garantizados por Banco San Juan S.A. Aviso - Ley 25.738. El Banco San Juan. es una Sociedad Anónima constituida bajo las leyes de la República Argentina. Sus accionistas limitan su responsabilidad al capital aportado. 1) C.F.T.N.A: 4,98% (sin IVA).&quot;
+  },
+  {
+    &quot;id&quot;: &quot;ebd7601ecbbc7391bdbc1cc8767f4bf6&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;2033&quot;,
+      &quot;name&quot;: &quot;Banco Bica&quot;
+    },
+    &quot;max_installments&quot;: 3,
+    &quot;installments&quot;: [
+      1,
+      3
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 3 cuotas sin interés&quot;,
+    &quot;picture&quot;: null,
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/2033.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/2033.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/2033.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/2033.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;CFT 3,08%. 3 cuotas sin interés. Promoción válida todos los días desde el 01/01/2017 al 31/01/2017 para tarjetas Mastercard Regional, Internacional, Gold, Platinum, Black, Corporate y para tarjetas Visa Internacional, Gold, Platinum y Signature emitidas por Banco Bica S.A.TNA (tasa nominal anual) 0 %( incluye seguro de vida sobre saldos). No válido para tarjeta de débito.&quot;
+  },
+  {
+    &quot;id&quot;: &quot;469106c4572977ea376d7b479115addf&quot;,
+    &quot;issuer&quot;: {
+      &quot;id&quot;: &quot;2035&quot;,
+      &quot;name&quot;: &quot;Banco de Chaco&quot;
+    },
+    &quot;max_installments&quot;: 6,
+    &quot;installments&quot;: [
+      1,
+      3,
+      6
+    ],
+    &quot;recommended_message&quot;: &quot;Hasta 6 cuotas sin interés&quot;,
+    &quot;picture&quot;: null,
+    &quot;date_started&quot;: &quot;2016-12-31T23:00:00.000-04:00&quot;,
+    &quot;date_expired&quot;: &quot;2017-01-31T23:59:59.000-04:00&quot;,
+    &quot;total_financial_cost&quot;: null,
+    &quot;payment_methods&quot;: [
+      {
+        &quot;id&quot;: &quot;visa&quot;,
+        &quot;name&quot;: &quot;Visa&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/2035.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/2035.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;master&quot;,
+        &quot;name&quot;: &quot;Mastercard&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/2035.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/2035.gif&quot;
+      },
+      {
+        &quot;id&quot;: &quot;cabal&quot;,
+        &quot;name&quot;: &quot;Cabal&quot;,
+        &quot;secure_thumbnail&quot;: &quot;https://www.mercadopago.com/org-img/MP3/API/logos/2035.gif&quot;,
+        &quot;thumbnail&quot;: &quot;http://img.mlstatic.com/org-img/MP3/API/logos/2035.gif&quot;
+      }
+    ],
+    &quot;legals&quot;: &quot;Promoción válida en hasta 6 cuotas sin interés exclusivamente para compras en MercadoLibre a través de MercadoPago. Válido desde el 01/01/2017 hasta el 31/01/2017. Consulte con su banco emisor la eventual aplicación de cargos y/o seguros asociados a la operatoria en cuotas.&quot;
+  }
+]</string>
 	<key>GET/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2000.0&amp;access_token=ACCESS_TOKEN</key>
 	<string>{
 	&quot;default_option&quot;: null,

--- a/MercadoPagoSDK/MercadoPagoSDKTests/PromoViewControllerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/PromoViewControllerTest.swift
@@ -1,0 +1,13 @@
+//
+//  PromoViewControllerTest.swift
+//  MercadoPagoSDK
+//
+//  Created by Maria cristina rodriguez on 1/3/17.
+//  Copyright © 2017 MercadoPago. All rights reserved.
+//
+
+import UIKit
+
+class PromoViewControllerTest: BaseTest {
+
+}

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         //MercadoPagoContext.setPayerAccessToken("APP_USR-6105282339975037-110310-7994b404127b8d755adff11a60052b01__LC_LA__-233395668")
         
-        MercadoPagoContext.setMerchantAccessToken(ExamplesUtils.MERCHANT_ACCESS_TOKEN)
+     //   MercadoPagoContext.setMerchantAccessToken(ExamplesUtils.MERCHANT_ACCESS_TOKEN)
 
         MercadoPagoContext.setDisplayDefaultLoading(flag: false)
         

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/MainExamplesViewController.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/MainExamplesViewController.swift
@@ -65,6 +65,8 @@ class MainExamplesViewController: UIViewController, UITableViewDataSource, UITab
         switch (indexPath as NSIndexPath).row {
         case 0:
             //Checkout Example
+            let pp = PaymentPreference()
+            pp.excludedPaymentTypeIds = ["ticket", "atm", ""]
             let choFlow = MPFlowBuilder.startCheckoutViewController( "223362579-96d6c137-02c3-48a2-bf9c-76e2d263c632", callback: { (payment: Payment) in
             })
             self.present(choFlow, animated: true, completion: {})

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/StepsExamplesViewController.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/StepsExamplesViewController.swift
@@ -98,8 +98,8 @@ class StepsExamplesViewController: UIViewController, UITableViewDelegate, UITabl
 */
         MercadoPagoContext.setAccountMoneyAvailable(accountMoneyAvailable: true)
         let pp = PaymentPreference()
-        pp.excludedPaymentTypeIds = ["ticket",  "atm"]
-        //pp.excludedPaymentMethodIds = ["master"]
+        pp.excludedPaymentTypeIds = ["ticket",  "atm", "bank_transfer"]
+        pp.excludedPaymentMethodIds = ["master"]
         pp.maxAcceptedInstallments = 3
 
         let pv = MPFlowBuilder.startPaymentVaultViewController(5, paymentPreference : pp, callback: { (paymentMethod, token, issuer, payerCost) in

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/StepsExamplesViewController.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/StepsExamplesViewController.swift
@@ -19,6 +19,7 @@ class StepsExamplesViewController: UIViewController, UITableViewDelegate, UITabl
         "Selección de Banco".localized,
         "Selección de Cuotas".localized,
         "Crear Pago".localized,
+        "Ver Promociones".localized
     ]
     
     @IBOutlet weak var stepsExamplesTable: UITableView!
@@ -86,7 +87,7 @@ class StepsExamplesViewController: UIViewController, UITableViewDelegate, UITabl
         case 6:
             createPayment()
         default:
-            break
+            showBankDeals()
         }
     }
     
@@ -219,6 +220,11 @@ class StepsExamplesViewController: UIViewController, UITableViewDelegate, UITabl
             
         }
         
+    }
+    
+    func showBankDeals(){
+        let promosVC = MPStepBuilder.startPromosStep()
+        self.navigationController!.present(promosVC, animated: true, completion: {})
     }
 }
 


### PR DESCRIPTION
Fix #317 

##  Cambios introducidos : 
- La visualización de Promociones depende de las promociones que vengan en API y no la PK en SDK 
- Se visualiza el título con el color de Fuente correcto
- Testeado con PK de MLA y MLB

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [X] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
