### PR TITLE
Se remueve el espacio entre el título de grupos y las otras celdas

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
@@ -435,7 +435,11 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
     public func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsetsMake(8, 8, 8, 8)
+        if section == 0 {
+           return UIEdgeInsetsMake(8, 8, 0, 8)
+        } else {
+            return UIEdgeInsetsMake(0, 8, 8, 8)
+        }
     }
 
     public func collectionView(_ collectionView: UICollectionView,


### PR DESCRIPTION
Fix #465 #435 

##  Cambios introducidos : 
- Se remueve el espacio entre el título de grupos y las otras celdas

### Revisión
- [NA] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [X] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
