### PR TITLE
Se cambia el nombre del PaymentMethod en los pagos off en Ryc

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
@@ -74,7 +74,7 @@ class OfflinePaymentMethodCell: UITableViewCell {
         if complementaryTitle.existsLocalized() {
             attributedTitle.append(NSAttributedString(string : complementaryTitle.localized))
         }
-        attributedTitle.append(NSAttributedString(string : paymentMethod.name))
+        attributedTitle.append(NSAttributedString(string : paymentMethodMethodSearchItem._description))
         
         self.paymentMethodDescription.attributedText = attributedTitle
         


### PR DESCRIPTION
Fix #486

##  Cambios introducidos : 
-  Se agarra el nombre real de un paymentMethod off en Ryc. Esto se mostraba mal en Mexico y en Peru

### Revisión
- [NA] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [NA] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
