### PR TITLE
Add locale brach to development

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		4BE51C201E2CFEC6004E5F7D /* DecorationPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE51C1F1E2CFEC6004E5F7D /* DecorationPreference.swift */; };
 		4BFAC0FC1E2E8A0D005EB383 /* DecorationPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE51C1F1E2CFEC6004E5F7D /* DecorationPreference.swift */; };
 		4BFAC0FE1E2E8A6C005EB383 /* DecorationPreferenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFAC0FD1E2E8A6C005EB383 /* DecorationPreferenceTest.swift */; };
+		4BC4EA031E007ABB0066D6F9 /* PaymentMethod.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4BC4EA021E007ABB0066D6F9 /* PaymentMethod.plist */; };
 		76062BC41C4D1EFD0067A14B /* PaymentMethodSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76062BC31C4D1EFD0067A14B /* PaymentMethodSearch.swift */; };
 		76062BC51C4D1EFD0067A14B /* PaymentMethodSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76062BC31C4D1EFD0067A14B /* PaymentMethodSearch.swift */; };
 		76062BC71C4D1F220067A14B /* PaymentMethodSearchItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76062BC61C4D1F220067A14B /* PaymentMethodSearchItem.swift */; };
@@ -864,6 +865,7 @@
 		15FCA78E1C84993B00D9E8CE /* PaymentMethodImageViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodImageViewCell.swift; sourceTree = "<group>"; };
 		15FCA78F1C84993B00D9E8CE /* PaymentMethodImageViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PaymentMethodImageViewCell.xib; sourceTree = "<group>"; };
 		4B2823931E2E4536004C02E9 /* UIImage+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Additions.swift"; sourceTree = "<group>"; };
+		4B241A991E01A7E00059640C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4B62AC261DD005B500D668DA /* InstructionBodyTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionBodyTableViewCell.swift; sourceTree = "<group>"; };
 		4B62AC271DD005B500D668DA /* InstructionBodyTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InstructionBodyTableViewCell.xib; sourceTree = "<group>"; };
 		4B762E941DCF7DDE00694336 /* InstructionsSubtitleTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionsSubtitleTableViewCell.swift; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 		4BAE1D511DCBE9340000ED5C /* CongratsRevampViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CongratsRevampViewController.xib; sourceTree = "<group>"; };
 		4BE51C1F1E2CFEC6004E5F7D /* DecorationPreference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecorationPreference.swift; sourceTree = "<group>"; };
 		4BFAC0FD1E2E8A6C005EB383 /* DecorationPreferenceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecorationPreferenceTest.swift; sourceTree = "<group>"; };
+		4BC4EA021E007ABB0066D6F9 /* PaymentMethod.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PaymentMethod.plist; path = MercadoPagoSDK/PaymentMethod.plist; sourceTree = "<group>"; };
 		76062BC31C4D1EFD0067A14B /* PaymentMethodSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodSearch.swift; sourceTree = "<group>"; };
 		76062BC61C4D1F220067A14B /* PaymentMethodSearchItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodSearchItem.swift; sourceTree = "<group>"; };
 		76062BC91C4D1F450067A14B /* PaymentMethodSearchService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodSearchService.swift; sourceTree = "<group>"; };
@@ -1107,6 +1110,7 @@
 		0F9883001AD2A97A00F750F0 = {
 			isa = PBXGroup;
 			children = (
+
 				762B57381E008DEB00EF3EE4 /* PaymentMethod.plist */,
 				4BAA56071DB6861400501061 /* Images.xcassets */,
 				0F0749081AED5BAE003DD39D /* Localizable.strings */,
@@ -2967,6 +2971,7 @@
 				0F07490A1AED5BBB003DD39D /* es */,
 				0F07490B1AED5BC0003DD39D /* es-MX */,
 				0F07490C1AED5BD3003DD39D /* es-CO */,
+				4B241A991E01A7E00059640C /* en */,
 			);
 			name = Localizable.strings;
 			path = MercadoPagoSDK;

--- a/MercadoPagoSDK/MercadoPagoSDK/ConfirmPaymentTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ConfirmPaymentTableViewCell.swift
@@ -18,6 +18,7 @@ class ConfirmPaymentTableViewCell: UITableViewCell {
         super.awakeFromNib()
         self.confirmPaymentButton.layer.cornerRadius = 4
         self.confirmPaymentButton.titleLabel?.font = Utils.getFont(size: 16)
+        self.confirmPaymentButton.setTitle("Confirmar".localized,for: .normal)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/MercadoPagoSDK/MercadoPagoSDK/InstructionsService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/InstructionsService.swift
@@ -48,7 +48,12 @@ open class InstructionsService: MercadoPagoService {
             params = params + "&payment_type=" + paymentTypeId!
         }
         params = params + "&api_version=" + MercadoPago.API_VERSION
-        self.request(uri: MP_INSTRUCTIONS_URI.replacingOccurrences(of: "${payment_id}", with: paymentId), params: params, body: nil, method: "GET", cache: false, success: { (jsonResult) -> Void in
+        
+        let headers = NSMutableDictionary()
+        headers.setValue(MercadoPagoContext.getLanguage() , forKey: "Accept-Language")
+        
+        self.request(uri: MP_INSTRUCTIONS_URI.replacingOccurrences(of: "${payment_id}", with: String(paymentId)), params: params, body: nil, method: "GET",headers: headers, cache: false, success: { (jsonResult) -> Void in
+
             let error = jsonResult?["error"] as? String
             if error != nil && error!.characters.count > 0 {
                 let e : NSError = NSError(domain: "com.mercadopago.sdk.getInstructions", code: MercadoPago.ERROR_INSTRUCTIONS, userInfo: [NSLocalizedDescriptionKey : "No se ha podido obtener las intrucciones correspondientes al pago".localized, NSLocalizedFailureReasonErrorKey : jsonResult!["error"] as! String])

--- a/MercadoPagoSDK/MercadoPagoSDK/MPSDKLoadingView.m
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPSDKLoadingView.m
@@ -57,7 +57,9 @@
 		self.alpha = 1;
 		self.tag = kLoadingViewTag;
 
+
         MLSpinnerConfig *config = [[MLSpinnerConfig alloc] initWithSize:MLSpinnerSizeBig primaryColor:loadingColor? loadingColor : UIColorFromRGB(0x009EE3) secondaryColor:loadingColor? loadingColor : UIColorFromRGB(0x009EE3)];
+
 
 		self.spinner = [[MLSpinner alloc] initWithConfig:config text:text];
 

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -36,8 +36,6 @@ open class MercadoPagoContext : NSObject, MPTrackerDelegate {
     
     var site : Site!
     
-    var language : String!
-    
     var termsAndConditionsSite : String!
 
     var account_money_available = false
@@ -47,6 +45,8 @@ open class MercadoPagoContext : NSObject, MPTrackerDelegate {
     var display_default_loading = true
     
     var decorationPreference = DecorationPreference()
+
+    var language: String = NSLocale.preferredLanguages[0]
     
     open class var PUBLIC_KEY : String {
         return "public_key"
@@ -104,7 +104,6 @@ open class MercadoPagoContext : NSObject, MPTrackerDelegate {
         let siteConfig = MercadoPagoContext.siteIdsSettings[site.rawValue]
         if siteConfig != nil {
             self.site = site
-            self.language = siteConfig!["language"] as! String
             self.termsAndConditionsSite = siteConfig!["termsconditions"] as! String
             let currency = CurrenciesUtil.getCurrencyFor(siteConfig!["currency"] as? String)
             if currency != nil {
@@ -134,9 +133,24 @@ open class MercadoPagoContext : NSObject, MPTrackerDelegate {
     open static func getTrackListener() -> MPTrackListener? {
         return sharedInstance.trackListener
     }
-    
+    open static func setLanguage(language: String) -> Void {
+        sharedInstance.language = language
+    }
     open static func getLanguage() -> String {
         return sharedInstance.language
+    }
+    open static func getLocalizedPath() -> String {
+        let bundle = MercadoPago.getBundle() ?? Bundle.main
+        
+        let currentLanguage = MercadoPagoContext.getLanguage()
+        if let path = bundle.path(forResource: currentLanguage, ofType : "lproj"){
+            return path
+        } else if let path = bundle.path(forResource: MercadoPagoContext.getLanguage().components(separatedBy: "-")[0], ofType : "lproj"){
+            return path
+        } else {
+            let path = bundle.path(forResource: "es", ofType : "lproj")
+            return path!
+        }
     }
     
     open static func getTermsAndConditionsSite() -> String {

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -143,8 +143,8 @@ open class MercadoPagoContext : NSObject, MPTrackerDelegate {
     open static func getTrackListener() -> MPTrackListener? {
         return sharedInstance.trackListener
     }
-    open static func setLanguage(language: String) -> Void {
-        sharedInstance.language = language
+    open static func setLanguage(language: languages) -> Void {
+        sharedInstance.language = language.rawValue
     }
     open static func getLanguage() -> String {
         return sharedInstance.language

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -94,6 +94,16 @@ open class MercadoPagoContext : NSObject, MPTrackerDelegate {
         case MCO = "MCO"
     }
     
+    public enum languages : String {
+        case SPANISH = "es"
+        case SPANISH_MEXICO = "es-MX"
+        case SPANISH_COLOMBIA = "es-CO"
+        case SPANISH_URUGUAY = "es-UY"
+        case SPANISH_PERU = "es-PE"
+        case SPANISH_VENEZUELA = "es-VE"
+        case PORTUGUESE = "pt"
+    }
+    
     
     
     open func siteId() -> String! {

--- a/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
@@ -81,6 +81,7 @@ class OfflinePaymentMethodCell: UITableViewCell {
         self.acreditationTimeLabel.attributedText = NSMutableAttributedString(string: paymentMethodMethodSearchItem.comment!, attributes: [NSFontAttributeName: Utils.getFont(size: 12)])
         
         self.changePaymentButton.titleLabel?.font = Utils.getFont(size: 18)
+        self.changePaymentButton.setTitle("Cambiar pago".localized, for: .normal)
     }
     
     

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearchService.swift
@@ -77,9 +77,12 @@ open class PaymentMethodSearchService: MercadoPagoService {
             ]
             groupsPayerBody = JSONHandler.jsonCoding(groupsPayerBodyJson) as AnyObject?
         }
-
         
-        self.request(uri: MP_SEARCH_PAYMENTS_URI, params: params, body: groupsPayerBody, method: "POST", cache: false , success: { (jsonResult) -> Void in
+        let headers = NSMutableDictionary()
+        headers.setValue(MercadoPagoContext.getLanguage() , forKey: "Accept-Language")
+       
+        
+        self.request(uri: MP_SEARCH_PAYMENTS_URI, params: params, body: groupsPayerBody, method: "POST", headers: headers, cache: false, success: { (jsonResult) -> Void in
             
             if let paymentSearchDic = jsonResult as? NSDictionary {
                 if paymentSearchDic["error"] != nil {

--- a/MercadoPagoSDK/MercadoPagoSDK/SecrurityCodeViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecrurityCodeViewController.swift
@@ -10,13 +10,13 @@ import UIKit
 
 open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextFieldDelegate{
     
-    @IBOutlet weak var button: UIButton!
     var securityCodeLabel: UILabel!
     @IBOutlet weak var securityCodeTextField: HoshiTextField!
     @IBOutlet weak var errorLabel: UILabel!
     
     @IBOutlet weak var panelView: UIView!
     var viewModel : SecrurityCodeViewModel!
+    @IBOutlet weak var button: UIButton!
     var textMaskFormater : TextMaskFormater!
     var cardFront : CardFrontView!
     var cardBack : CardBackView!
@@ -29,6 +29,7 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
         super.viewDidLoad()
          self.hideNavBar()
         loadMPStyles()
+        self.button.setTitle("Continuar".localized,for: .normal)
         self.errorLabel.alpha = 0
         self.securityCodeTextField.placeholder = "security_code".localized
         self.errorLabel.text = "Revisa este dato".localized

--- a/MercadoPagoSDK/MercadoPagoSDK/SecrurityCodeViewController.xib
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecrurityCodeViewController.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SecrurityCodeViewController" customModule="MercadoPagoSDK" customModuleProvider="target">
             <connections>
-                <outlet property="button" destination="eRB-5n-7JU" id="jdx-oc-eTS"/>
+                <outlet property="button" destination="eRB-5n-7JU" id="cMD-Ug-6XA"/>
                 <outlet property="errorLabel" destination="h3x-Y7-b4M" id="ucc-T7-Pcr"/>
                 <outlet property="panelView" destination="yob-kR-dQh" id="kZV-OM-lKE"/>
                 <outlet property="securityCodeTextField" destination="CLV-K5-LXP" id="s6C-CM-zBJ"/>

--- a/MercadoPagoSDK/MercadoPagoSDK/String+Additions.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/String+Additions.swift
@@ -17,10 +17,9 @@ extension String {
 		if bundle == nil {
 			bundle = Bundle.main
 		}
-        let currentLanguage = MercadoPagoContext.getLanguage()
-        let path = bundle!.path(forResource: currentLanguage, ofType : "lproj")
-        let languageBundle = Bundle(path : path!)
+        let languageBundle = Bundle(path : MercadoPagoContext.getLocalizedPath())
         return languageBundle!.localizedString(forKey: self, value : "", table : nil)
+
 	}
 	
     public func existsLocalized() -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
@@ -1,0 +1,198 @@
+/*
+ Localizable.strings
+ MercadoPagoSDK
+ 
+ Created by Matias Gualino on 26/4/15.
+ Copyright (c) 2015 MercadoPago. All rights reserved.
+ */
+"Cargando..." = "Loading...";
+
+"invalid_cvv_length" = "Ingresa los %1$s números del código de seguridad";
+"invalid_field" = "Check this information";
+"invalid_card_length" = "Enter the %1$s card numbers";
+"security_code" = "Security Code";
+"cod_seg_desc" = "Last %1$s digits code on the back of the card";
+"cod_seg_desc_amex" = "%1$s digits code on the front of the card";
+"NOT_INSTALLMENTS_FOUND" = "No interest were found available for an amount of $";
+"PAYMENT_ERROR" = "Payment failed.";
+"No se ha podido obtener los métodos de pago con esta preferencia" = "Payment methods could not be obtained with this preference";
+
+"visa"="Visa";
+"master"="Mastercard";
+"amex"="Amex";
+
+
+
+//CONGRATS
+
+"Cancelar pago" = "Cancel payment";
+"¿Qué puedo hacer?" = "What can I do?";
+
+// -- CallForAuth
+
+"Debes autorizar ante %p el pago de %t a MercadoPago" = "You must authorize with %p the payment of %t to Mercado Pago";
+"Ya hable con %0 y me autorizó" = "Already talked with %0 and I am authorized";
+"El teléfono está al dorso de tu tarjeta." = "The phone number is on the back of your card.";
+"Pagar con otro medio" = "Choose another payment method";
+
+// -- Approved
+"¡Listo, se acreditó tu pago!" = "Done, your payment was accredited!";
+"También enviamos el código a tu email" = "También enviamos el código a tu email";
+"Te enviaremos este comprobante a %0" = "We will send you the data to %0";
+"Dinero en cuenta de MercadoPago" = "Account Money of MercadoPago";
+"Terminada en " = "Ending in ";
+"En tu estado de cuenta verás el cargo como %0" = "On your statement you will see the charge as %0";
+"Comprobante" = "Ticket";
+
+// -- Pending
+"Estamos procesando el pago" = "We are processing the payment";
+"En menos de 1 hora te enviaremos por e-mail el resultado."="In less than an hour we will send you the result by e-mail.";
+"En poquitas horas te diremos por e-mail si se acreditó o si necesitamos más información."="In a few hours we will tell you by e-mail if it is accredited or if we need more information.";
+
+// -- Rejected
+"¿Qué puedo hacer?" = "What can I do?";
+"rejected_high_risk_title"="For security reasons, we had to reject your payment";
+"cc_rejected_insufficient_amount_title" = "Yours %0 has insufficient funds";
+"cc_rejected_other_reason_title"="%0 did not process the payment";
+"cc_rejected_max_attempts_title"= "You reached the limit of attempts allowed";
+"cc_rejected_duplicated_payment_title"="%0 did not process the payment";
+"cc_rejected_card_disabled_title"="Calls to %1$s for activate your card";
+"cc_rejected_bad_filled_other_title"="Some data of your %1$s is incorect";
+"cc_rejected_bad_filled_card_number_title"="Algún dato de tu %0 es incorrecto";
+"cc_rejected_bad_filled_security_code_title"="Algún dato de tu %0 es incorrecto";
+"cc_rejected_bad_filled_date_title"="The expiration date is not correct.";
+"cc_rejected_call_for_authorize_title" = "Could not authorize it?";
+"Ingresalo nuevamente" = "Ingresalo nuevamente";
+"Algo salió mal… " = "Something went wrong…";
+
+
+"rejected_high_risk_subtitle_credit_card"="If you want to pay with the money from your account, contact Mercado Pago customer service.\n\n Or if you prefer, you can choose other payment method.";
+"cc_rejected_insufficient_amount_subtitle_credit_card" = "Don't worry! You can choose another payment method.";
+"cc_rejected_other_reason_subtitle_credit_card"="Use another card or another payment method";
+"cc_rejected_max_attempts_subtitle_credit_card"= "Choose another card or another payment method";
+"cc_rejected_duplicated_payment_subtitle_credit_card"="If you need to repay, use another card or other payment method.";
+"cc_rejected_card_disabled_subtitle_credit_card"="The phone number is on the back of your card.";
+
+
+
+"rejected_high_risk_subtitle_debit_card"=">If you want to pay with the money from your account, contact Mercado Pago customer service. \n\n Or if you prefer, you can choose other payment method.";
+"cc_rejected_insufficient_amount_subtitle_debit_card" = "Don't worry! Recharge at any bank or from your electronic banking and try again. Or if you prefer, you can choose another payment method.";
+"cc_rejected_other_reason_subtitle_debit_card"="Use another card or another payment method";
+"cc_rejected_max_attempts_subtitle_debit_card"= "Choose another card or another payment method.";
+"cc_rejected_duplicated_payment_subtitle_debit_card"="If you need to repay, use another card or other payment method.";
+"cc_rejected_card_disabled_subtitle_debit_card"="The phone number is on the back of your card.";
+"cc_rejected_bad_filled_other_subtitle_debit_card"="Some number of your %0 is incorrect.";
+"cc_rejected_bad_filled_card_number_subtitle_debit_card"="The number of your %0 is incorrect.";
+"cc_rejected_bad_filled_security_code_subtitle_debit_card"="The security code is not correct";
+"cc_rejected_bad_filled_date_subtitle_debit_card"="The expiration date is not correct.";
+
+"Ingresalo nuevamente" = "Enter again";
+
+
+//---- Formulario de tarjeta
+"Ver promociones"="Show Promotions";
+"Número de tarjeta"="Card number";
+"NOMBRE APELLIDO"="NAME SURNAME";
+"MM/AA"="MM/AA";
+"Fecha de expiración"="Expiration date";
+"Código de seguridad"="Security code";
+"Continuar"="Continue";
+"Anterior"="Previous";
+"Ingresa el número de la tarjeta de crédito"="Enter all the numbers of the card";
+"Revisa este dato"="Check this information";
+"Ingresa el nombre y apellido impreso en la tarjeta"="Enter the name and last name printed on the card";
+"Ingresa los %1$s números del código de seguridad"="Enter the %1$s security code numbers";
+"Método de pago no soportado"="Payment Method no supported";
+
+"Nombre y apellido"="Name and surname";
+
+//---Identification
+"OK"="OK";
+"DOCUMENTO DEL TITULAR DE LA TARJETA"="CARD HOLDER DOCUMENT";
+"Número"="Number";
+"Tipo"="Type";
+
+//Installment Cell
+
+" Sin interés"=" Interest free";//--
+"¿En cuántas cuotas?" = "How many installments?";
+"¿Quién emitió tu tarjeta?" = "Which is your bank?";
+"¿Qué tipo de tarjeta es?" = "Which type of card is it?";
+"Crédito" = "Credit";
+"Débito" = "Debit";
+
+//Instructions
+
+"Continuar"= "Continue";//--
+
+//--
+"¡Felicitaciones!"="¡Congratulations!";
+"Se aprobó tu pago."="Se aprobó tu pago.";
+"Estamos procesando el pago"="We are processing the payment";
+"¡Ups! Ocurrió un problema"="¡Ups! Ocurrió un problema";
+"Imprime el cupón y paga. Se acreditará en 1 a 3 días hábiles."="Imprime el cupón y paga. Se acreditará en 1 a 3 días hábiles.";
+"En unos minutos te enviaremos por e-mail el resultado."="En unos minutos te enviaremos por e-mail el resultado.";
+"No se pudo realizar el pago."="No se pudo realizar el pago.";
+//--
+
+
+
+//CONGRATS
+
+"terminada en "="ending in ";
+"terminada en "="ending in ";
+"Terminada en " = "Ending in ";
+" terminada en " = " ending in ";
+"Sin interés"="Interest free";
+"Uy, no pudimos procesar el pago"="Oops, we could not process your payment";
+"Algún dato de tu %1$s es incorrecto."="Some data of your %1$s is incorect.";
+"El teléfono está al dorso de tu tarjeta"="The phone number is on the back of your card";
+"Debes autorizar el pago ante tu tarjeta"="You must authorize the payment with your card";
+"Debes autorizar ante %1$s el pago de " = "You must authorize with %1$s the payment of";
+" a MercadoPago" = " to MercadoPago";
+"Ya hablé con %1$s y me autorizó" = "Already talked with %0 and I am authorized";
+
+
+"Total"="Total";
+"Medio de pago"="Payment method";
+"Operación"="Operación";
+"Fecha"="Date";
+
+// RyC
+"Revisa si está todo bien..." = "Verify that everything is fine…";
+"Total a pagar " = "Total to pay ";
+"Al pagar, afirmo que soy mayor de edad y acepto los Términos y Condiciones de Mercado Pago"="By paying, I claim to be an adult and that I accept the Terms and Conditions";
+
+"¿Cómo quiéres pagar?"="How do you want to pay?";
+"Términos y Condiciones"="Terms and conditions";
+"Confirma tu compra" = "Confirm your purchase";
+"Total" = "Total";
+"Cantidad : " = "Quantity: ";
+"Precio Unitario : " = "Unit price: ";
+"Pagas" = "You will pay";
+"Cambiar pago" = "Change payment";
+"Productos" = "Products";
+"Confirmar" = "Confirm";
+
+"Medio de pago" = "Payment Method";
+"Operación" = "Operation";
+"Fecha" = "Date";
+"Cancelar Pago"="Cancel Payment";
+"Pagáras " = "You will pay ";
+
+
+
+// PaymentTypes para RyC
+"ryc_title_default"=" in a ";
+"ryc_title_cargavirtual"=" in ";
+"ryc_title_redlink_bank_transfer"=" in your ";
+"ryc_title_bancomer_bank_transfer"=" in your ";
+"ryc_title_serfin_bank_transfer"=" in your ";
+"ryc_title_banamex_bank_transfer"=" in your ";
+
+"ryc_complementary_bancomer_bank_transfer"="Home Banking of ";
+"ryc_complementary_serfin_bank_transfer"="Home Banking of ";
+"ryc_complementary_redlink_bank_transfer"="Home Banking of ";
+"ryc_complementary_banamex_bank_transfer"="Home Banking of ";
+"ryc_complementary_banamex_atm"="ATM of ";
+"ryc_complementary_redlink_atm"="ATM of ";

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
@@ -23,6 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
     
         MercadoPagoContext.setPublicKey("APP_USR-8e3869a6-638f-45cd-b5b7-267c8e6f2b09")
+        
+        //MercadoPagoContext.setPublicKey("TEST-ad365c37-8012-4014-84f5-6c895b3f8e0a")
         //MercadoPagoContext.setPublicKey("APP_USR-5bd14fdd-3807-446f-babd-095788d5ed4d")
 
         //MercadoPagoContext.setPayerAccessToken("APP_USR-6105282339975037-110310-7994b404127b8d755adff11a60052b01__LC_LA__-233395668")
@@ -30,6 +32,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
      //   MercadoPagoContext.setMerchantAccessToken(ExamplesUtils.MERCHANT_ACCESS_TOKEN)
 
         MercadoPagoContext.setDisplayDefaultLoading(flag: false)
+        
+        //MercadoPagoContext.setLanguage(language: "es")
         
 //        let tracker = TrackerExample()
 //        

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         MercadoPagoContext.setDisplayDefaultLoading(flag: false)
         
-        //MercadoPagoContext.setLanguage(language: "es")
+        MercadoPagoContext.setLanguage(language: "pt-br")
         
 //        let tracker = TrackerExample()
 //        

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         MercadoPagoContext.setDisplayDefaultLoading(flag: false)
         
-        MercadoPagoContext.setLanguage(language: "pt-br")
+        MercadoPagoContext.setLanguage(language: MercadoPagoContext.languages.PORTUGUESE)
         
 //        let tracker = TrackerExample()
 //        


### PR DESCRIPTION
Fix #474 #399 #410 

##  Cambios introducidos : 
- Se vuelve a agregar el branch locale
- Se agrega un enum con todos idiomas soportados por la SDK. Ejemplo:
`MercadoPagoContext.setLanguage(language: MercadoPagoContext.languages.PORTUGUESE)`

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
