### PR TITLE
Fix traducciones portugues

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
@@ -168,3 +168,19 @@
 
 "Términos y Condiciones"="Termos e Condições";
 "Verifique su conexión a internet e intente nuevamente"="Sem conexão";
+
+"Pagáras " = "Você pagará ";
+
+"ryc_title_default"=" no ";
+"ryc_title_cargavirtual"=" no ";
+"ryc_title_redlink_bank_transfer"=" com ";
+"ryc_title_bancomer_bank_transfer"=" com ";
+"ryc_title_serfin_bank_transfer"=" com ";
+"ryc_title_banamex_bank_transfer"=" com ";
+
+"ryc_complementary_bancomer_bank_transfer"="Internet Banking de ";
+"ryc_complementary_serfin_bank_transfer"="Internet Banking de ";
+"ryc_complementary_redlink_bank_transfer"="Internet Banking de ";
+"ryc_complementary_banamex_bank_transfer"="Internet Banking de ";
+"ryc_complementary_banamex_atm"="caixa eletrônico de ";
+"ryc_complementary_redlink_atm"="caixa eletrônico de ";

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         MercadoPagoContext.setDisplayDefaultLoading(flag: false)
         
-        MercadoPagoContext.setLanguage(language: MercadoPagoContext.languages.PORTUGUESE)
+        MercadoPagoContext.setLanguage(language: MercadoPagoContext.Languages._PORTUGUESE)
         
 //        let tracker = TrackerExample()
 //        


### PR DESCRIPTION
Fix #519 

##  Cambios introducidos : 
- Se agregan traducciones de portugues faltantes

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [X] Test funcionales OK
- [ ] Documentación actualizada
