### PR TITLE
Fix celdas customs en Objectve C

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -260,9 +260,9 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.checkoutTable.register(purchaseTermsAndConditions, forCellReuseIdentifier: "termsAndConditionsViewCell")
         var i = 0
         
-        if MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell != nil {
-            for customCell in MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell! {
-                self.checkoutTable.register(customCell.cell.getNib(), forCellReuseIdentifier: String(i))
+        if !MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell.isEmpty {
+            for customCell in MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell {
+                self.checkoutTable.register(customCell.inflator.getNib(), forCellReuseIdentifier: String(i))
                 i += 1
             }
         }
@@ -295,8 +295,8 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     private func getCustomCell(indexPath: IndexPath) -> UITableViewCell{
         let custom = self.checkoutTable.dequeueReusableCell(withIdentifier: String(indexPath.row), for: indexPath) as! MPCustomTableViewCell
         
-        let inflator = MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell?[indexPath.row].inflator
-        inflator!.fillCell(cell: custom)
+        let inflator = MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell[indexPath.row].inflator
+        inflator.fillCell(cell: custom)
         return custom
     }
     
@@ -472,7 +472,7 @@ open class CheckoutViewModel {
         }
             
         else if isAddtionalCustomCellsFor(indexPath: indexPath) {
-            return MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell![indexPath.row].cell.getHeigth()
+            return MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell[indexPath.row].inflator.getHeigth()
         }
             
         else if isFotterCellFor(indexPath: indexPath) {
@@ -497,8 +497,8 @@ open class CheckoutViewModel {
     }
     
     func numberOfCustomCell() -> Int {
-        if let count = MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell?.count {
-            return count
+        if !MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell.isEmpty {
+            return MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell.count
         }
         return 0
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/MPCustomInflator.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPCustomInflator.swift
@@ -11,4 +11,10 @@ import Foundation
 public protocol MPCustomInflator : NSObjectProtocol {
     
     func fillCell(cell: MPCustomTableViewCell)
+    
+    func getNib() -> UINib
+    
+    func getHeigth() -> CGFloat
+    
+    var nib: UINib {get}
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/MPCustomTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPCustomTableViewCell.swift
@@ -12,26 +12,13 @@ import UIKit
 open class MPCustomTableViewCell: UITableViewCell{
     //var imageDelegate: bundle.CellProtocol?
     
-    var nib: UINib?
-    var heigth: CGFloat = 0.0
-    
-    public init(uiNib : UINib, heigth: CGFloat) {
-        super.init(style: .default, reuseIdentifier: "identifier")
-        self.nib = uiNib
-        self.heigth = heigth
-    }
-    
-    public required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    open func getNib() -> UINib? {
-        return nib
-    }
-    
-    open func getHeigth() -> CGFloat {
-        return heigth
-    }
+//    open func getNib() -> UINib? {
+//        return nib
+//    }
+//    
+//    open func getHeigth() -> CGFloat {
+//        return heigth
+//    }
     
     func fillCell(customCell: MPCustomTableViewCell){
         customCell.fillContent()
@@ -42,6 +29,7 @@ open class MPCustomTableViewCell: UITableViewCell{
     }
     
 }
+import Foundation
 
 @objc open class MPCustomCells : NSObject {
     open let cell: MPCustomTableViewCell

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -37,7 +37,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     internal static var flowPreference = FlowPreference()
     internal static var paymentDataCallback : ((PaymentData) -> Void)?
     
-    internal static var confirmAdditionalCustomCell: [MPCustomCells]?
+    open static var confirmAdditionalCustomCell = [MPCustomCells]()
 
     var checkoutPreference : CheckoutPreference!
     

--- a/MercadoPagoSDK/MercadoPagoSDK/PayerCostTitleTableViewCell.xib
+++ b/MercadoPagoSDK/MercadoPagoSDK/PayerCostTitleTableViewCell.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,11 +15,11 @@
             <rect key="frame" x="0.0" y="0.0" width="498" height="61"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="498" height="61"/>
+                <rect key="frame" x="0.0" y="0.0" width="498" height="60"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="¿En cuántas cuotas?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4j-Iq-ZVl">
-                        <rect key="frame" x="24" y="8" width="450" height="26.5"/>
+                        <rect key="frame" x="24" y="8" width="450" height="27"/>
                         <fontDescription key="fontDescription" type="system" pointSize="22"/>
                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>

--- a/MercadoPagoSDKExamples/MercadoPagoSDKExamples/MainExamplesViewController.swift
+++ b/MercadoPagoSDKExamples/MercadoPagoSDKExamples/MainExamplesViewController.swift
@@ -84,8 +84,8 @@ open class MainExamplesViewController: UIViewController, UITableViewDataSource, 
             let pref = CheckoutPreference(_id: "223362579-96d6c137-02c3-48a2-bf9c-76e2d263c632")
             
             let customCell = CustomTableViewCell()
-            customCell.setHeigth(heigth: 100)
-            customCell.setNib(uiNib: UINib(nibName: "CustomTableViewCell", bundle: Bundle.main))
+//            customCell.setHeigth(heigth: 100)
+//            customCell.setNib(uiNib: UINib(nibName: "CustomTableViewCell", bundle: Bundle.main))
             
             let inflator = CustomInflator()
             inflator.setTitle(text: "Numero de telefono")

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomInflator.h
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomInflator.h
@@ -14,6 +14,4 @@
 SWIFT_SUBCLASS
 @interface CustomInflator : NSObject<MPCustomInflator>
 
-- setTitle:(NSString*)title;
-
 @end

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomInflator.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomInflator.m
@@ -13,9 +13,27 @@
 
 @implementation CustomInflator
 
+UINib *customCellNib = nil;
+
+-(id)initWithUINib:(UINib*)nib{
+    self = [super init];
+    if (self) {
+        customCellNib = nib;
+    }
+    return self;
+    
+}
 -(void)fillCellWithCell:(MPCustomTableViewCell *)cell {
     CustomTableViewCell *currentCell = (CustomTableViewCell *)cell;
     currentCell.label.text = @"override";
+}
+
+-(UINib *)getNib {
+    return [UINib nibWithNibName:@"CustomTableViewCell" bundle: [NSBundle mainBundle]];
+}
+
+-(CGFloat *)getHeigth {
+    return 100;
 }
 
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomTableViewCell.h
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomTableViewCell.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @import MercadoPagoSDK;
 
@@ -14,8 +15,8 @@
 
 SWIFT_SUBCLASS
 @interface CustomTableViewCell : MPCustomTableViewCell
-
 @property (weak, nonatomic) IBOutlet UILabel *label;
+
 
 
 @end

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomTableViewCell.xib
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomTableViewCell.xib
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CustomTableViewCell">
-            <connections>
-                <outlet property="label" destination="Nvs-nj-xcC" id="TjN-yV-vKU"/>
-            </connections>
-        </placeholder>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="108" id="cRC-YB-hu3" customClass="CustomTableViewCell">
             <rect key="frame" x="0.0" y="0.0" width="492" height="108"/>
@@ -31,6 +27,9 @@
                     </label>
                 </subviews>
             </tableViewCellContentView>
+            <connections>
+                <outlet property="label" destination="Nvs-nj-xcC" id="9Fi-PY-LlJ"/>
+            </connections>
             <point key="canvasLocation" x="95" y="113"/>
         </tableViewCell>
     </objects>

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -57,8 +57,8 @@
     
     //CheckoutPreference * pref = [[CheckoutPreference alloc] initWithItems:<#(NSArray<Item *> * _Nonnull)#> payer:<#(Payer * _Nonnull)#> paymentMethods:<#(PaymentPreference * _Nullable)#>
     
-    UINib *customCellNib = [UINib nibWithNibName:@"CustomTableViewCell" bundle:nil];
-    CustomTableViewCell *customCell = [[CustomTableViewCell alloc] initWithUiNib:customCellNib heigth:20.0];
+    UINib *customCellNib = [UINib nibWithNibName:@"CustomTableViewCell" bundle: [NSBundle mainBundle]];
+    CustomTableViewCell *customCell = [[CustomTableViewCell alloc] init];
     
     CustomInflator *inflator = [[CustomInflator alloc] init];
   // [inflator setTitle:@"inflator overriden title"];


### PR DESCRIPTION

##  Cambios introducidos : 
- Se arregla las celdas customisables para ObjC

### Revisión
- [ ] Todos los textos se encuentran localizables
- [ ] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [ ] No se agregan logs / prints innecesarios
- [ ] No se agregan comentarios basura

### Testeo
- [ ] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
