### PR TITLE
Add custom Row items to RyC

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -38,8 +38,12 @@ open class MercadoPagoCheckout: NSObject {
     }
     
     
-    open static func addReviewble(cell: [MPCustomCells]){
-        MercadoPagoCheckoutViewModel.confirmAdditionalCustomCell = cell
+    open static func addConfirmAdditionalCells(_ cells: [MPCustomCells]){
+        MercadoPagoCheckoutViewModel.confirmAdditionalCustomCells = cells
+    }
+    
+    open static func addConfirmItemCells(_ cells: [MPCustomCells]){
+        MercadoPagoCheckoutViewModel.confirmItemsCells = cells
     }
     
     open static func setDecorationPreference(_ decorationPreference: DecorationPreference){

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -37,7 +37,8 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     internal static var flowPreference = FlowPreference()
     internal static var paymentDataCallback : ((PaymentData) -> Void)?
     
-    open static var confirmAdditionalCustomCell = [MPCustomCells]()
+    open static var confirmAdditionalCustomCells = [MPCustomCells]()
+    open static var confirmItemsCells: [MPCustomCells]?
 
     var checkoutPreference : CheckoutPreference!
     

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomInflator.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomInflator.m
@@ -10,19 +10,10 @@
 #import "CustomTableViewCell.h"
 @import MercadoPagoSDK;
 
-
 @implementation CustomInflator
 
 UINib *customCellNib = nil;
 
--(id)initWithUINib:(UINib*)nib{
-    self = [super init];
-    if (self) {
-        customCellNib = nib;
-    }
-    return self;
-    
-}
 -(void)fillCellWithCell:(UITableViewCell *)cell {
     CustomTableViewCell *currentCell = (CustomTableViewCell *)cell;
     currentCell.label.text = @"1562663448";

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -66,7 +66,12 @@
     
     MPCustomCells *customCellPair = [[MPCustomCells alloc] initWithCell:customCell inflator:inflator];
     NSArray *customCells = [[NSArray alloc] initWithObjects:customCellPair, nil];
-    [MercadoPagoCheckout addReviewbleWithCell:customCells];
+    [MercadoPagoCheckout addConfirmAdditionalCells:customCells];
+    
+    
+    MPCustomCells *customItemCellPair = [[MPCustomCells alloc] initWithCell:customCell inflator:inflator];
+    NSArray *customItemCells = [[NSArray alloc] initWithObjects: customItemCellPair, customItemCellPair, nil];
+    [MercadoPagoCheckout addConfirmItemCells:customItemCells];
     
 
 //


### PR DESCRIPTION
Fix #607 

##  Cambios introducidos : 
- Se añade la opción de usar celdas de items custom

Snippet de código:
```
    MPCustomCells *customItemCellPair = [[MPCustomCells alloc] initWithCell:customCell inflator:inflator];
    NSArray *customItemCells = [[NSArray alloc] initWithObjects: customItemCellPair, customItemCellPair, nil];
    [MercadoPagoCheckout addConfirmItemCells:customItemCells];
```

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
