### PR TITLE
Validate checkout preference amount

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutPreference.swift
@@ -157,7 +157,9 @@ open class CheckoutPreference : NSObject {
         if isExpired() {
             return "La preferencia esta expirada".localized
         }
-        
+        if (self.getAmount() < 0) {
+            return "El monto de la compra no es válido".localized
+        }
         return nil
     }
     
@@ -176,6 +178,8 @@ open class CheckoutPreference : NSObject {
                 return error
             }
         }
+        
+        
         return nil
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutPreferenceTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutPreferenceTest.swift
@@ -186,12 +186,31 @@ class CheckoutPreferenceTest: XCTestCase {
         XCTAssertEqual(checkoutPreference.itemsValid(), "El título del item esta vacio")
     }
     
-    func testValidate() {
+    func testValidateMissingPayer() {
         let checkoutPreference = CheckoutPreference()
         let item1 = Item(_id: "id1", title : "item 1 title", quantity: 1, unitPrice: 10)
         let item2 = Item(_id: "id2", title : "item 2 title", quantity: 3, unitPrice: 5)
         checkoutPreference.addItems(items: [item1, item2])
         XCTAssertEqual(checkoutPreference.validate(), "Se requiere email de comprador")
+    }
+    
+    func testValidateGreaterThanZeroAmount() {
+        let checkoutPreference = CheckoutPreference()
+        let item1 = Item(_id: "id1", title : "item 1 title", quantity: 1, unitPrice: 10)
+        let item2 = Item(_id: "id2", title : "item 2 title", quantity: 3, unitPrice: -5)
+        checkoutPreference.addItems(items: [item1, item2])
+        checkoutPreference.payer = Payer()
+        checkoutPreference.setPayerEmail("payerem@il.com")
+        XCTAssertEqual(checkoutPreference.validate(), "El monto de la compra no es válido")
+    }
+    
+    func testValidateGreaterThanZeroAmount_OneItem() {
+        let checkoutPreference = CheckoutPreference()
+        let item1 = Item(_id: "id1", title : "item 1 title", quantity: 4, unitPrice: -2)
+        checkoutPreference.addItems(items: [item1])
+        checkoutPreference.payer = Payer()
+        checkoutPreference.setPayerEmail("payerem@il.com")
+        XCTAssertEqual(checkoutPreference.validate(), "El monto de la compra no es válido")
     }
     
 }


### PR DESCRIPTION
Fix #582 

##  Cambios introducidos : 
- Validar que amount total sea superior a cero

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [X] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [X] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
