### PR TITLE
Add light font to decorationPreference

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/DecorationPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/DecorationPreference.swift
@@ -12,39 +12,58 @@ open class DecorationPreference : NSObject{
     var baseColor: UIColor
     var textColor: UIColor = UIColor.white
     var fontName: String
+    var fontLightName: String
     
-    public init(baseColor: UIColor = UIColor.px_blueMercadoPago(), fontName: String = ".SFUIDisplay-Regular"){
+    public init(baseColor: UIColor = UIColor.px_blueMercadoPago(), fontName: String = ".SFUIDisplay-Regular", fontLightName: String = ".SFUIDisplay-Light"){
         self.baseColor = baseColor
         self.fontName = fontName
+        self.fontLightName = fontLightName
     }
 
     public func setBaseColor(color: UIColor){
         baseColor = color
     }
+    
     public func setBaseColor(hexColor: String){
         baseColor = UIColor.fromHex(hexColor)
     }
+    
     public func enableDarkFont(){
         textColor = UIColor.black
     }
+    
     public func enableLightFont(){
         textColor = UIColor.white
     }
-    public func setCustomFontWithName(fontName: String){
-        self.fontName = fontName
+    
+    public func setCustomFontWith(name: String){
+        self.fontName = name
     }
+    
+    public func setLightCustomFontWith(name: String){
+        self.fontLightName = name
+    }
+    
     public func setMercadoPagoBaseColor(){
         baseColor = UIColor.px_blueMercadoPago()
     }
+    
     public func setMercadoPagoFont(){
         fontName = ".SFUIDisplay-Regular"
     }
+    
     public func getBaseColor() -> UIColor {
         return baseColor
     }
+    
     public func getFontColor() -> UIColor {
         return textColor
     }
+    
+    public func getLightFontName() -> String {
+        return fontLightName
+    }
+    
     public func getFontName() -> String {
         return fontName
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
@@ -130,6 +130,10 @@ class Utils {
         return UIFont(name: MercadoPagoContext.getDecorationPreference().getFontName(), size: size) ?? UIFont.systemFont(ofSize: size)
     }
     
+    class func getLightFont(size: CGFloat) -> UIFont {
+        return UIFont(name: MercadoPagoContext.getDecorationPreference().getLightFontName(), size: size) ?? UIFont.systemFont(ofSize: size, weight: UIFontWeightThin)
+    }
+    
     class func append(firstJSON: String, secondJSON: String) -> String {
         if firstJSON == "" && secondJSON == "" {
             return ""

--- a/MercadoPagoSDK/MercadoPagoSDKTests/DecorationPreferenceTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/DecorationPreferenceTest.swift
@@ -46,7 +46,7 @@ class DecorationPreferenceTest: BaseTest {
     }
     func testSetMercadoPagoFont(){
         let decoration = DecorationPreference()
-        decoration.setCustomFontWithName(fontName: "sarasa")
+        decoration.setCustomFontWith(name: "sarasa")
         decoration.setMercadoPagoFont()
         XCTAssertEqual(decoration.getFontName(), ".SFUIDisplay-Regular")
     }
@@ -54,7 +54,7 @@ class DecorationPreferenceTest: BaseTest {
     func testSetFontName(){
         let decoration = DecorationPreference()
         XCTAssertEqual(decoration.getFontName(), ".SFUIDisplay-Regular")
-        decoration.setCustomFontWithName(fontName: "Comic")
+        decoration.setCustomFontWith(name: "Comic")
         XCTAssertEqual(decoration.getFontName(), "Comic")
     }
     

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -29,7 +29,7 @@
 - (IBAction)checkoutFlow:(id)sender {
 
     // Decoration Preference con colores custom
-    DecorationPreference *decorationPreference = [[DecorationPreference alloc] initWithBaseColor:[UIColor greenColor] fontName:@"fontName"];
+    DecorationPreference *decorationPreference = [[DecorationPreference alloc] initWithBaseColor:[UIColor greenColor] fontName:@"fontName" fontLightName:@"fontName"];
     [MercadoPagoCheckout setDecorationPreference:decorationPreference];
     
     // Service Preference para seteo de servicio de pago


### PR DESCRIPTION
Fix #509

##  Cambios introducidos : 
- Se aceptan dos fuentes en la decorationPreference

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
