### PR TITLE
Add start with PaymentResult

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -40,6 +40,16 @@ open class MercadoPagoCheckout: NSObject {
         }
     }
     
+    public init(checkoutPreference : CheckoutPreference, paymentData : PaymentData, navigationController : UINavigationController, paymentResult: PaymentResult) {
+        viewModel = MercadoPagoCheckoutViewModel(checkoutPreference : checkoutPreference, paymentData: paymentData, paymentResult: paymentResult)
+        
+        self.navigationController = navigationController
+        
+        if self.navigationController.viewControllers.count > 0 {
+            viewControllerBase = self.navigationController.viewControllers[0]
+        }
+    }
+    
     open static func setDecorationPreference(_ decorationPreference: DecorationPreference){
         MercadoPagoCheckoutViewModel.decorationPreference = decorationPreference
     }
@@ -274,16 +284,17 @@ open class MercadoPagoCheckout: NSObject {
     
     func displayPaymentResult() {
         // TODO : por que dos? esta bien? no hay view models, ver que onda
-        
-        let paymentResult = PaymentResult(payment: self.viewModel.payment!, paymentData: self.viewModel.paymentData)
+        if self.viewModel.paymentResult == nil {
+            self.viewModel.paymentResult = PaymentResult(payment: self.viewModel.payment!, paymentData: self.viewModel.paymentData)
+        }
 
         let congratsViewController : UIViewController
-        if (PaymentTypeId.isOfflineType(paymentTypeId: self.viewModel.payment!.paymentTypeId)) {
-            congratsViewController = InstructionsRevampViewController(paymentResult: paymentResult,  callback: { (state :MPStepBuilder.CongratsState) in
+        if (PaymentTypeId.isOfflineType(paymentTypeId: self.viewModel.paymentData.paymentMethod.paymentTypeId)) {
+            congratsViewController = InstructionsRevampViewController(paymentResult: self.viewModel.paymentResult!,  callback: { (state :MPStepBuilder.CongratsState) in
                 self.executeNextStep()
             })
         } else {
-            congratsViewController = CongratsRevampViewController(paymentResult: paymentResult, callback: { (state : MPStepBuilder.CongratsState) in
+            congratsViewController = CongratsRevampViewController(paymentResult: self.viewModel.paymentResult!, callback: { (state : MPStepBuilder.CongratsState) in
                 self.executeNextStep()
             })
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -67,6 +67,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
 
     var paymentData = PaymentData()
     var payment : Payment?
+    var paymentResult: PaymentResult?
     
     static var error : MPSDKError?
     internal var errorCallback : ((Void) -> Void)?
@@ -91,6 +92,19 @@ open class MercadoPagoCheckoutViewModel: NSObject {
             self.paymentData = paymentData
             self.reviewAndConfirm = true
         }
+        if !String.isNullOrEmpty(self.checkoutPreference._id) {
+            // Cargar información de preferencia en caso que tenga id
+            needLoadPreference = true
+        }
+    }
+    
+    init(checkoutPreference : CheckoutPreference, paymentData : PaymentData, paymentResult: PaymentResult) {
+        self.checkoutPreference = checkoutPreference
+        if paymentData.isComplete() {
+            self.paymentData = paymentData
+            self.reviewAndConfirm = false
+        }
+        self.paymentResult = paymentResult
         if !String.isNullOrEmpty(self.checkoutPreference._id) {
             // Cargar información de preferencia en caso que tenga id
             needLoadPreference = true

--- a/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
@@ -114,7 +114,7 @@ extension MercadoPagoCheckoutViewModel {
     }
     
     func shouldShowCongrats() -> Bool {
-        return self.payment != nil
+        return self.payment != nil || self.paymentResult != nil
     }
     
     func shouldExitCheckout() -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResult.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResult.swift
@@ -17,20 +17,7 @@ open class PaymentResult: NSObject {
     open var amount: Double?
     open var statementDescription: String?
     
-    init (status: String, statusDetail: String, paymentData: PaymentData?, siteId: String, payerEmail:String?, id: String?, amount: Double?, statementDescription: String?){
-        
-        MercadoPagoContext.setSiteID(siteId)
-        self.status = status
-        self.statusDetail = statusDetail
-        self.paymentData = paymentData
-        self.currencyId = MercadoPagoContext.getCurrency()._id
-        self.payerEmail = payerEmail
-        self._id = id
-        self.amount = amount
-        self.statementDescription = statementDescription
-    }
-    
-    init (payment: Payment, paymentData: PaymentData?){
+    public init (payment: Payment, paymentData: PaymentData?){
         self.status = payment.status
         self.statusDetail = payment.statusDetail
         self.paymentData = paymentData
@@ -39,5 +26,20 @@ open class PaymentResult: NSObject {
         self.amount = payment.transactionAmount
         self.payerEmail = payment.payer.email
         self.statementDescription = payment.statementDescriptor
+    }
+    
+    public init (status: String, statusDetail: String, paymentData: PaymentData?, siteId: String, payerEmail:String?, id: String?, amount: Double = 0, statementDescription: String?) {
+        
+        MercadoPagoContext.setSiteID(siteId)
+        self.status = status
+        self.statusDetail = statusDetail
+        self.paymentData = paymentData
+        self.currencyId = MercadoPagoContext.getCurrency()._id
+        self.payerEmail = payerEmail
+        self._id = id
+        if amount != 0 {
+            self.amount = amount
+        }
+        self.statementDescription = statementDescription
     }
 }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -154,11 +154,15 @@
     
     pd.issuer = [[Issuer alloc] init];
     pd.issuer._id = [NSNumber numberWithInt:200];;
+    
+    
+    PaymentResult *paymentResult = [[PaymentResult alloc] initWithStatus:@"approved" statusDetail:@"approved" paymentData:pd siteId:@"MLA" payerEmail:nil id:nil amount:50.0 statementDescription:nil];
 
     
 
     CheckoutPreference * pref = [[CheckoutPreference alloc] initWith_id: @"150216849-68645cbb-dfe6-4410-bfd6-6e5aa33d8a33"];
-    self.mpCheckout = [[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:pd navigationController:self.navigationController];
+    self.mpCheckout = [[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:pd navigationController:self.navigationController paymentResult:paymentResult];
+    
     UIViewController *vc =  [ self.mpCheckout getRootViewController];
     
     //UIViewController *vc = [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:pref navigationController:self.navigationController] getRootViewController];


### PR DESCRIPTION
Fix #638 

##  Cambios introducidos : 
- Se puede empezar la SDK con un paymentResult

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
