### PR TITLE
Add exit Callbacks

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -74,6 +74,14 @@ open class MercadoPagoCheckout: NSObject {
         MercadoPagoCheckoutViewModel.paymentDataCallback = paymentDataCallback
     }
     
+    open static func setPaymentCallback(paymentCallback : @escaping (_ payment : Payment) -> Void) {
+        MercadoPagoCheckoutViewModel.paymentCallback = paymentCallback
+    }
+    
+    open static func setCallback(callback : @escaping (Void) -> Void) {
+        MercadoPagoCheckoutViewModel.callback = callback
+    }
+    
     public func start(){
         executeNextStep()
     }
@@ -319,6 +327,11 @@ open class MercadoPagoCheckout: NSObject {
         
         ReviewScreenPreference.clear()
         PaymentResultScreenPreference.clear()
+        if let payment = self.viewModel.payment, let paymentCallback = MercadoPagoCheckoutViewModel.paymentCallback {
+            paymentCallback(payment)
+        } else if let callback = MercadoPagoCheckoutViewModel.callback {
+            callback()
+        }
         if let rootViewController = viewControllerBase {
             self.navigationController.popToViewController(rootViewController, animated: true)
             self.navigationController.setNavigationBarHidden(false, animated: false)

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -35,9 +35,12 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     internal static var servicePreference = ServicePreference()
     internal static var decorationPreference = DecorationPreference()
     internal static var flowPreference = FlowPreference()
-    internal static var paymentDataCallback : ((PaymentData) -> Void)?
     internal static var reviewScreenPreference = ReviewScreenPreference()
     internal static var paymentResultScreenPreference = PaymentResultScreenPreference()
+    
+    internal static var paymentDataCallback : ((PaymentData) -> Void)?
+    internal static var paymentCallback : ((Payment) -> Void)?
+    internal static var callback: ((Void) -> Void)?
 
     var checkoutPreference : CheckoutPreference!
     

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -170,6 +170,18 @@
      
      PaymentResult *paymentResult = [[PaymentResult alloc] initWithStatus:@"approved" statusDetail:@"approved" paymentData:pd siteId:@"MLA" payerEmail:nil id:nil amount:50.0 statementDescription:nil];*/
     
+    //Callback que devuelve un payment
+    
+//    [MercadoPagoCheckout setPaymentCallbackWithPaymentCallback:^(Payment * payment) {
+//        NSLog(@"%@", payment._id);
+//    }];
+    
+    // Callback que no devuelve nada
+    
+//    [MercadoPagoCheckout setCallbackWithCallback:^{
+//        NSLog(@"Se termino el flujo");
+//    }];
+    
     
     CheckoutPreference * pref = [[CheckoutPreference alloc] initWith_id: @"150216849-68645cbb-dfe6-4410-bfd6-6e5aa33d8a33"];
     //    UIViewController *vc = [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:pref paymentData:pd navigationController:self.navigationController] getRootViewController];


### PR DESCRIPTION
Fix #644

##  Cambios introducidos : 
- Se agrega la opción de que el integrador pueda setear un paymentCallback que devuelve un pago hecho por la sdk y un callback simple que no devuelve nada para los casos que no hacemos el pago.

Ejemplo: 
```
    [MercadoPagoCheckout setPaymentCallbackWithPaymentCallback:^(Payment * payment) {
        NSLog(@"%@", payment._id);
    }];
    [MercadoPagoCheckout setCallbackWithCallback:^{
        NSLog(@"Se termino el flujo");
    }];
```


### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
