### PR TITLE
Fix customer card selection when RyC is disabled

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -164,10 +164,11 @@ open class MercadoPagoCheckout: NSObject {
     
     
     func collectPaymentMethods(){
+        // Se limpia paymentData antes de ofrecer selección de medio de pago
+        self.viewModel.paymentData.clear()
         let paymentMethodSelectionStep = PaymentVaultViewController(viewModel: self.viewModel.paymentVaultViewModel(), callback : { (paymentOptionSelected : PaymentMethodOption) -> Void  in
             self.viewModel.updateCheckoutModel(paymentOptionSelected : paymentOptionSelected)
             self.viewModel.rootVC = false
-            self.viewModel.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
             self.executeNextStep()
         })
         
@@ -261,6 +262,7 @@ open class MercadoPagoCheckout: NSObject {
     
     func collectSecurityCode(){
         let securityCodeVc = SecrurityCodeViewController(viewModel: self.viewModel.securityCodeViewModel(), collectSecurityCodeCallback : { (token: Token?) -> Void in
+            self.viewModel.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
             if token == nil {
                 self.navigationController.popViewController(animated: true)
                 self.viewModel.paymentData.clear()

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -204,14 +204,18 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     //PAYMENT_METHOD_SELECTION
     public func updateCheckoutModel(paymentOptionSelected : PaymentMethodOption){
         self.paymentOptionSelected = paymentOptionSelected
-        if let childrenOptions = paymentOptionSelected.getChildren() {
-            self.paymentMethodOptions =  childrenOptions
+        if paymentOptionSelected.hasChildren() {
+            self.paymentMethodOptions =  paymentOptionSelected.getChildren()
         }
         
         if self.paymentOptionSelected!.isCustomerPaymentMethod() {
             self.findAndCompletePaymentMethodFor(paymentMethodId: paymentOptionSelected.getId())
+            if self.paymentOptionSelected!.getId() == PaymentTypeId.ACCOUNT_MONEY.rawValue {
+                self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
+            }
         } else if !paymentOptionSelected.isCard() && !paymentOptionSelected.hasChildren() {
             self.paymentData.paymentMethod = Utils.findPaymentMethod(self.availablePaymentMethods!, paymentMethodId: paymentOptionSelected.getId())
+            self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
         }
         
     }
@@ -313,6 +317,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     
     public func updateCheckoutModel(token : Token) {
         self.paymentData.token = token
+        self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
     }
 
     public class func createMPPayment(_ email : String, preferenceId : String, paymentData : PaymentData, customerId : String? = nil) -> MPPayment {

--- a/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
@@ -122,18 +122,17 @@ extension MercadoPagoCheckoutViewModel {
     }
     
     func setPaymentOptionSelected(){
-        if self.paymentData.paymentMethod.isAccountMoney() {
-            if !Array.isNullOrEmpty(self.customPaymentOptions) {
-                let result = self.customPaymentOptions!.filter({ (cardInformation : CardInformation) -> Bool in
-                    return cardInformation.getPaymentMethodId() == PaymentTypeId.ACCOUNT_MONEY.rawValue
-                })
-                self.paymentOptionSelected = result[0] as? PaymentMethodOption
-            }
-        } else if !self.paymentData.paymentMethod.isCard() && self.paymentData.paymentMethod.isAccountMoney() {
+        if self.paymentData.hasCustomerPaymentOption() {
+            // Account_money o customer cards
+            let customOption = Utils.findCardInformationIn(customOptions: self.customPaymentOptions!, paymentData: self.paymentData)
+            self.paymentOptionSelected = customOption as? PaymentMethodOption
+        } else if !self.paymentData.paymentMethod.isOnlinePaymentMethod() {
+            // Medios off
             if let paymentTypeId = PaymentTypeId(rawValue : paymentData.paymentMethod.paymentTypeId) {
                 self.paymentOptionSelected = Utils.findPaymentMethodSearchItemInGroups(self.search!, paymentMethodId: paymentData.paymentMethod._id, paymentTypeId: paymentTypeId)
             }
         } else {
+            // Tarjetas, efectivo, crédito, debito
             if let paymentTypeId = PaymentTypeId(rawValue : paymentData.paymentMethod.paymentTypeId) {
                 self.paymentOptionSelected = Utils.findPaymentMethodTypeId(self.search!.groups, paymentTypeId: paymentTypeId)
             }

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentData.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentData.swift
@@ -30,7 +30,7 @@ public class PaymentData: NSObject {
             return false
         }
         
-        if paymentMethod._id == PaymentTypeId.ACCOUNT_MONEY.rawValue {
+        if paymentMethod._id == PaymentTypeId.ACCOUNT_MONEY.rawValue || !paymentMethod.isOnlinePaymentMethod() {
             return true
         }
         
@@ -39,6 +39,10 @@ public class PaymentData: NSObject {
         }
 
         return true
+    }
+    
+    func hasCustomerPaymentOption() -> Bool {
+        return self.paymentMethod != nil && (self.paymentMethod.isAccountMoney() || (self.token != nil && !String.isNullOrEmpty(self.token!.cardId)))
     }
     
     func toJSONString() -> String {

--- a/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
@@ -225,6 +225,20 @@ class Utils {
         return nil
     }
     
+    static internal func findCardInformationIn(customOptions : [CardInformation], paymentData : PaymentData) -> CardInformation? {
+        let customOptionsFound = customOptions.filter { (cardInformation : CardInformation) -> Bool in
+            if paymentData.paymentMethod.isAccountMoney(){
+                return  cardInformation.getPaymentMethodId() == PaymentTypeId.ACCOUNT_MONEY.rawValue
+            } else {
+                if (paymentData.token != nil) {
+                    return paymentData.token!.cardId == cardInformation.getCardId()
+                }
+            }
+            return false
+        }
+        return !Array.isNullOrEmpty(customOptionsFound) ? customOptionsFound[0] : nil
+    }
+    
     static fileprivate func findPaymentMethodSearchItemById(_ paymentMethodSearchList : [PaymentMethodSearchItem], paymentMethodId : String, paymentTypeId : PaymentTypeId?) -> PaymentMethodSearchItem? {
         
         var filterPaymentMethodSearchFound = paymentMethodSearchList.filter { (arg : PaymentMethodSearchItem) -> Bool in


### PR DESCRIPTION

##  Cambios introducidos : 
- Se puede ingresar a RyC con tarjeta guardada
- Se fixea error al seleccionar tarjeta guardada (salteaba ingreso de código de seguridad)
- Se limpia información de pago al iniciar la selección de medio de pago

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [X] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
