### PR TITLE
Fix last four digits in cardAdittionalStep

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CardAdditionalViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardAdditionalViewController.swift
@@ -164,7 +164,7 @@ open class CardAdditionalViewController: MercadoPagoUIScrollViewController, UITa
             let cardCell = tableView.dequeueReusableCell(withIdentifier: "cardNib", for: indexPath as IndexPath) as! PayerCostCardTableViewCell
             cardCell.selectionStyle = .none
             cardCell.loadCard()
-            cardCell.updateCardSkin(token: self.viewModel.token, paymentMethod: self.viewModel.paymentMethods[0])
+            cardCell.updateCardSkin(token: self.viewModel.token, paymentMethod: self.viewModel.paymentMethods[0], cardInformation: self.viewModel.cardInformation)
             cardCell.backgroundColor = UIColor.primaryColor()
             
             return cardCell

--- a/MercadoPagoSDK/MercadoPagoSDK/PayerCostCardTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PayerCostCardTableViewCell.swift
@@ -35,7 +35,7 @@ class PayerCostCardTableViewCell: UITableViewCell {
         cardView.addSubview(cardFront!)
         self.cell.backgroundColor = UIColor.primaryColor()
     }
-    func updateCardSkin(token: CardInformationForm?, paymentMethod: PaymentMethod?) {
+    func updateCardSkin(token: CardInformationForm?, paymentMethod: PaymentMethod?, cardInformation: CardInformation?) {
         
         if let paymentMethod = paymentMethod{
             
@@ -47,6 +47,9 @@ class PayerCostCardTableViewCell: UITableViewCell {
           //  cardFront?.cardNumber.text =  "•••• •••• •••• " + (token.getCardLastForDigits())!
                 let mask = TextMaskFormater(mask: paymentMethod.getLabelMask(), completeEmptySpaces: true, leftToRight: false)
                 cardFront?.cardNumber.text = mask.textMasked(token.getCardLastForDigits())
+            } else if let cardInformation = cardInformation {
+                let mask = TextMaskFormater(mask: paymentMethod.getLabelMask(), completeEmptySpaces: true, leftToRight: false)
+                cardFront?.cardNumber.text = mask.textMasked(cardInformation.getCardLastForDigits())
             }
             
             cardFront?.cardName.text = ""


### PR DESCRIPTION
Fix #669 

##  Cambios introducidos : 
- Se ven los 4 últimos dígitos de una tarjeta guarda cuando selecciona cuotas

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
