### PR TITLE
Differ paymentDataCallback from confirm payment callback

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -19,7 +19,8 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     var publicKey : String!
     var accessToken : String!
     var bundle : Bundle? = MercadoPago.getBundle()
-    var callback : ((PaymentData) -> Void)!
+    var callbackPaymentData : ((PaymentData) -> Void)!
+    var callbackConfirm : ((PaymentData) -> Void)!
     var viewModel : CheckoutViewModel!
  
     override open var screenName : String { get{ return "REVIEW_AND_CONFIRM" } }
@@ -30,12 +31,13 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     
     @IBOutlet weak var checkoutTable: UITableView!
     
-    init(viewModel: CheckoutViewModel, callback : @escaping (PaymentData) -> Void,  callbackCancel : @escaping ((Void) -> Void)) {
+    init(viewModel: CheckoutViewModel, callbackPaymentData : @escaping (PaymentData) -> Void,  callbackCancel : @escaping ((Void) -> Void), callbackConfirm : @escaping (PaymentData) -> Void) {
         super.init(nibName: "CheckoutViewController", bundle: MercadoPago.getBundle())
         self.initCommon()
         self.viewModel = viewModel
-        self.callback = callback
+        self.callbackPaymentData = callbackPaymentData
         self.callbackCancel = callbackCancel
+        self.callbackConfirm = callbackConfirm
     }
     
     private func initCommon(){
@@ -208,7 +210,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.hideBackButton()
         self.hideTimer()
         self.showLoading()
-        self.callback(self.viewModel.paymentData)
+        self.callbackConfirm(self.viewModel.paymentData)
     }
  
     fileprivate func loadPreference() {
@@ -364,7 +366,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     func changePaymentMethodSelected() {
         self.viewModel.paymentData.paymentMethod = nil
         self.viewModel.paymentData.clear()
-        self.callback(self.viewModel.paymentData)
+        self.callbackPaymentData(self.viewModel.paymentData)
     }
     
     internal func openTermsAndConditions(_ title: String, url : URL){

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -80,6 +80,10 @@ open class MercadoPagoCheckout: NSObject {
         MercadoPagoCheckoutViewModel.paymentCallback = paymentCallback
     }
     
+    open static func setPaymentDataConfirmCallback(paymentDataConfirmCallback : @escaping (_ paymentData : PaymentData) -> Void) {
+        MercadoPagoCheckoutViewModel.paymentDataConfirmCallback = paymentDataConfirmCallback
+    }
+    
     open static func setCallback(callback : @escaping (Void) -> Void) {
         MercadoPagoCheckoutViewModel.callback = callback
     }
@@ -169,6 +173,7 @@ open class MercadoPagoCheckout: NSObject {
         let paymentMethodSelectionStep = PaymentVaultViewController(viewModel: self.viewModel.paymentVaultViewModel(), callback : { (paymentOptionSelected : PaymentMethodOption) -> Void  in
             self.viewModel.updateCheckoutModel(paymentOptionSelected : paymentOptionSelected)
             self.viewModel.rootVC = false
+            self.viewModel.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
             self.executeNextStep()
         })
         
@@ -232,12 +237,19 @@ open class MercadoPagoCheckout: NSObject {
     
     func collectPaymentData() {
         if self.viewModel.reviewAndConfirm {
-            let checkoutVC = CheckoutViewController(viewModel: self.viewModel.checkoutViewModel(), callback: {(paymentData : PaymentData) -> Void in
+            let checkoutVC = CheckoutViewController(viewModel: self.viewModel.checkoutViewModel(), callbackPaymentData: {(paymentData : PaymentData) -> Void in
                 self.viewModel.updateCheckoutModel(paymentData: paymentData)
-                    self.executeNextStep()
+                self.executeNextStep()
             }, callbackCancel : { Void -> Void in
                 self.viewModel.setIsCheckoutComplete(isCheckoutComplete: true)
                 self.executeNextStep()
+            }, callbackConfirm : {(paymentData : PaymentData) -> Void in
+                self.viewModel.updateCheckoutModel(paymentData: paymentData)
+                if MercadoPagoCheckoutViewModel.paymentDataConfirmCallback != nil {
+                    MercadoPagoCheckoutViewModel.paymentDataConfirmCallback!(self.viewModel.paymentData)
+                } else {
+                    self.executeNextStep()
+                }
             })
             
             
@@ -246,6 +258,7 @@ open class MercadoPagoCheckout: NSObject {
             self.pushViewController(viewController :checkoutVC, animated: false)
             self.dismissLoading(animated: false)
         } else {
+            // Caso en que RyC esté deshabilitada
             self.executePaymentDataCallback()
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -39,6 +39,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     internal static var paymentResultScreenPreference = PaymentResultScreenPreference()
     
     internal static var paymentDataCallback : ((PaymentData) -> Void)?
+    internal static var paymentDataConfirmCallback : ((PaymentData) -> Void)?
     internal static var paymentCallback : ((Payment) -> Void)?
     internal static var callback: ((Void) -> Void)?
 


### PR DESCRIPTION

##  Cambios introducidos : 
- Diferenciar callback con paymentData del callback que se invoca al confirmar pago

## Cómo se diferencian?

### Callback que se invoca al deshabilitar RyC
```objc
[MercadoPagoCheckout setPaymentDataCallbackWithPaymentDataCallback: ^(PaymentData *paymentData) {
            NSLog(@"%@", paymentData.paymentMethod._id);
}];
```
### Callback que se invoca al confirmar pago en RyC
```objc
 [MercadoPagoCheckout setPaymentDataConfirmCallbackWithPaymentDataConfirmCallback:^(PaymentData *paymentData) {
        NSLog(@"Payment confirmed %@", paymentData.paymentMethod._id);
 }];
```

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [NA] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
