### PR TITLE
LightCustomFont Added to CFT & TEA

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/ConfirmAdditionalInfoTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ConfirmAdditionalInfoTableViewCell.swift
@@ -25,10 +25,10 @@ class ConfirmAdditionalInfoTableViewCell: UITableViewCell {
     }
     func fillCell(payerCost: PayerCost?){
         if let payerCost = payerCost {
-            //CFT.font = Utils.getFont(size: CFT.font.pointSize)
-            //TEALabel.font = Utils.getFont(size: TEALabel.font.pointSize)
             
+            CFT.font = Utils.getLightFont(size: CFT.font.pointSize)
             CFT.textColor = UIColor.px_grayDark()
+            TEALabel.font = Utils.getLightFont(size: TEALabel.font.pointSize)
             TEALabel.textColor = UIColor.px_grayDark()
             
             if let CFTValue = payerCost.getCFTValue() {

--- a/MercadoPagoSDK/MercadoPagoSDK/ConfirmInstallmentsTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ConfirmInstallmentsTableViewCell.swift
@@ -38,7 +38,9 @@ class ConfirmInstallmentsTableViewCell: UITableViewCell {
             self.interest.attributedText = NSAttributedString(string : "Sin interés".localized)
         }
         
+        CFT.font = Utils.getLightFont(size: CFT.font.pointSize)
         CFT.textColor = UIColor.px_grayDark()
+        TEALabel.font = Utils.getLightFont(size: TEALabel.font.pointSize)
         TEALabel.textColor = UIColor.px_grayDark()
         
         if let CFTValue = payerCost.getCFTValue() {

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
@@ -74,12 +74,9 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
 			self.selectOtherPaymentMethodButton.isHidden = true;
 		}
         
-
-        
-        //CFT.font = Utils.getFont(size: CFT.font.pointSize)
-        //TEALabel.font = Utils.getFont(size: TEALabel.font.pointSize)
-        
+        CFT.font = Utils.getLightFont(size: CFT.font.pointSize)
         CFT.textColor = UIColor.px_grayDark()
+        TEALabel.font = Utils.getLightFont(size: TEALabel.font.pointSize)
         TEALabel.textColor = UIColor.px_grayDark()
         
         if let CFTValue = payerCost?.getCFTValue() {


### PR DESCRIPTION
Fix #622 

##  Cambios introducidos : 
- Setearle fuente custom Ligth a CFT y TEA

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [x] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
