### PR TITLE
Terms & Conditions in English Fixed

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
@@ -165,7 +165,7 @@
 "Al pagar, afirmo que soy mayor de edad y acepto los Términos y Condiciones de Mercado Pago"="By paying, I claim to be an adult and that I accept the Terms and Conditions";
 
 "¿Cómo quiéres pagar?"="How do you want to pay?";
-"Términos y Condiciones"="Terms and conditions";
+"Términos y Condiciones"="Terms and Conditions";
 "Confirma tu compra" = "Confirm your purchase";
 "Total" = "Total";
 "Cantidad : " = "Quantity: ";


### PR DESCRIPTION
Fix #621 
##  Cambios introducidos : 
- Se solucionó el bug que no permitía mostrar el link para acceder a Términos y Condiciones cuando el lenguaje estaba seteado a Ingles

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [x] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
