### PR TITLE
Fix flow with debitCard

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -287,6 +287,11 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     public func updateCheckoutModel(paymentMethodSearch : PaymentMethodSearch) {
         self.search = paymentMethodSearch
         
+        // La primera vez las opciones a mostrar van a ser el root de grupos
+        self.rootPaymentMethodOptions = paymentMethodSearch.groups
+        self.paymentMethodOptions = self.rootPaymentMethodOptions
+        self.availablePaymentMethods = paymentMethodSearch.paymentMethods
+        
         if search?.getPaymentOptionsCount() == 0 {
             self.errorInputs(error: MPSDKError(message: "Ha ocurrido un error".localized, messageDetail: "No se ha podido obtener los métodos de pago con esta preferencia".localized, retry: false), errorCallback: { (Void) in
                 
@@ -314,10 +319,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
             }
         }
         
-        // La primera vez las opciones a mostrar van a ser el root de grupos
-        self.rootPaymentMethodOptions = paymentMethodSearch.groups
-        self.paymentMethodOptions = self.rootPaymentMethodOptions
-        self.availablePaymentMethods = paymentMethodSearch.paymentMethods
+
     }
     
     

--- a/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
@@ -15,7 +15,7 @@ extension MercadoPagoCheckoutViewModel {
     }
     func isPaymentTypeSelected() -> Bool {
         
-        if self.paymentData.isComplete() && (self.search != nil) && self.paymentOptionSelected == nil {
+        if self.paymentData.isComplete() && (self.search != nil){
             self.setPaymentOptionSelected()
             return true
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
@@ -16,7 +16,9 @@ extension MercadoPagoCheckoutViewModel {
     func isPaymentTypeSelected() -> Bool {
         
         if self.paymentData.isComplete() && (self.search != nil){
-            self.setPaymentOptionSelected()
+            if self.paymentOptionSelected == nil {
+                self.setPaymentOptionSelected()
+            }
             return true
         }
         

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentData.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentData.swift
@@ -35,6 +35,10 @@ public class PaymentData: NSObject {
         }
         
         if paymentMethod!.isCard() && (token == nil || payerCost == nil) {
+            
+            if paymentMethod.paymentTypeId == "debit_card" && token != nil{
+                return true
+            }
             return false
         }
 


### PR DESCRIPTION
Fix #718 #723 #725 

##  Cambios introducidos : 
- Se arregla el flujo para que puedas volver a entrar a Revisa y Confirma con una tarjeta de debito
- Se arregla un problema de que si volvias a entrar al flujo con un paymentData para mostrar Revisa y confirma con una prefid con exclusiones (por ejemplo: Solo el nodo de tarjeta o solo el nodo de pagoOff) no iba a revisa y confirma. Iba directamente a grupos
- Fix bug con accountMoney


### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
