### PR TITLE
Cambiar todos los addCustomCell a setCustomCell

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenPreference.swift
@@ -76,8 +76,8 @@ open class ReviewScreenPreference: NSObject {
 		self.shouldDisplayChangeMethodOption = true
 	}
 	
-    open static func addCustomItemCell(customCell : MPCustomCell) {
-        ReviewScreenPreference.customItemCells.append(customCell)
+    open static func setCustomItemCell(customCell : [MPCustomCell]) {
+        ReviewScreenPreference.customItemCells = customCell
     }
     
     open static func setAddionalInfoCells(customCells : [MPCustomCell]) {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -157,7 +157,7 @@
     NSArray *items = [NSArray arrayWithObjects:item2, item2, nil];
     
     PaymentPreference *paymentExclusions = [[PaymentPreference alloc] init];
-    paymentExclusions.excludedPaymentTypeIds = [NSSet setWithObjects:@"atm", @"ticket", @"debit_card",@"credit_card", nil];
+    paymentExclusions.excludedPaymentTypeIds = [NSSet setWithObjects:@"atm", @"ticket", @"debit_card", nil];
     paymentExclusions.defaultInstallments = 1;
     
     self.pref = [[CheckoutPreference alloc] initWithItems:items payer:payer paymentMethods:paymentExclusions];
@@ -178,7 +178,7 @@
 }
 
 -(void)setCheckoutPref_WithId {
-    self.pref = [[CheckoutPreference alloc] initWith_id: @"150216849-68645cbb-dfe6-4410-bfd6-6e5aa33d8a338"];
+    self.pref = [[CheckoutPreference alloc] initWith_id: @"150216849-68645cbb-dfe6-4410-bfd6-6e5aa33d8a33"];
 }
 
 -(void)setPaymentResultScreenPreference {


### PR DESCRIPTION
Fix #726 

##  Cambios introducidos : 
- Se cambian todos los addCustomCell a setCustomCell

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
