### PR TITLE
Change constraints in PaymentMethodCell in RyC

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
@@ -24,6 +24,8 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
     @IBOutlet weak var CFT: UILabel!
     @IBOutlet weak var noRateLabel: MPLabel!
     
+    @IBOutlet weak var changePaymentMethodCFTConstraint: NSLayoutConstraint!
+    
     @IBOutlet weak var totalAmountLabel: MPLabel!
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -83,6 +85,7 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
                 CFT.text = "CFT " + CFTValue
         } else {
             CFT.text = ""
+            self.changePaymentMethodCFTConstraint.constant = 10
         }
         if let TEAValue = payerCost?.getTEAValeu() {
             TEALabel.text = "TEA " + TEAValue
@@ -105,7 +108,7 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
 		}
 
         if let dic = payerCost?.getCFTValue() {
-            cellHeight += 65
+            cellHeight += 74
         }
 
         return cellHeight

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.xib
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -130,6 +130,7 @@
             <connections>
                 <outlet property="CFT" destination="B9H-cX-bxB" id="Voe-vt-JFl"/>
                 <outlet property="TEALabel" destination="Z7P-hF-Nl6" id="SDx-8C-ojU"/>
+                <outlet property="changePaymentMethodCFTConstraint" destination="1MJ-vX-PPV" id="pLw-5y-5dw"/>
                 <outlet property="noRateLabel" destination="Zf5-PV-8ZU" id="KuN-lT-dB9"/>
                 <outlet property="paymentDescription" destination="e6B-2G-k5B" id="D8F-XV-nTU"/>
                 <outlet property="paymentMethodDescription" destination="aDj-L7-Gmd" id="Ohc-6W-Sh4"/>


### PR DESCRIPTION
Fix #737 

##  Cambios introducidos : 
- Se arregla la altura de la celda de PaymentMethod en Revisa y Confirma

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
