### PR TITLE
Add loading to PaymentSelection Screen

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,6 @@
 codecov:
   notify:
     require_ci_to_pass: yes
-    branch: development
-    strict_yaml_branch: development
 
 coverage:
   precision: 2
@@ -12,13 +10,11 @@ coverage:
   status:
     project:
       default:
-        target: 20
         threshold: null
         if_not_found: success
-        branches: development
 
-    patch: off
-    changes: off
+    patch: yes
+    changes: no
 
  parsers:
   gcov:

--- a/MercadoPagoSDK/MercadoPagoSDK/AppDecorationKeeper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/AppDecorationKeeper.swift
@@ -27,6 +27,10 @@ extension DecorationPreference {
         navigationController.navigationBar.isTranslucent = navControllerMemento.navIsTranslucent
         navigationController.navigationBar.backgroundColor = navControllerMemento.navBackgroundColor
         navigationController.navigationBar.restoreBottomLine()
+        navigationController.navigationBar.setBackgroundImage(navControllerMemento.navBackgroundImage, for: UIBarMetrics.default)
+        navigationController.navigationBar.shadowImage = navControllerMemento.navShadowImage
+        
+
     }
 }
 
@@ -38,6 +42,8 @@ internal class NavigationControllerMemento {
     var navIsTranslucent : Bool = false
     var navViewBackgroundColor : UIColor?
     var navBackgroundColor : UIColor?
+    var navBackgroundImage : UIImage?
+    var navShadowImage : UIImage?
     
     init(navigationController : UINavigationController) {
         self.navBarTintColor =  navigationController.navigationBar.barTintColor
@@ -46,5 +52,7 @@ internal class NavigationControllerMemento {
         self.navIsTranslucent = navigationController.navigationBar.isTranslucent
         self.navViewBackgroundColor = navigationController.view.backgroundColor
         self.navBackgroundColor = navigationController.navigationBar.backgroundColor
+        self.navBackgroundImage = navigationController.navigationBar.backgroundImage(for: .default)
+        self.navShadowImage = navigationController.navigationBar.shadowImage
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/AppDecorationKeeper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/AppDecorationKeeper.swift
@@ -29,6 +29,9 @@ extension DecorationPreference {
         navigationController.navigationBar.restoreBottomLine()
         navigationController.navigationBar.setBackgroundImage(navControllerMemento.navBackgroundImage, for: UIBarMetrics.default)
         navigationController.navigationBar.shadowImage = navControllerMemento.navShadowImage
+        if let _ = navControllerMemento.navBarStyle {
+            navigationController.navigationBar.barStyle = navControllerMemento.navBarStyle!
+        }
         
 
     }
@@ -44,6 +47,7 @@ internal class NavigationControllerMemento {
     var navBackgroundColor : UIColor?
     var navBackgroundImage : UIImage?
     var navShadowImage : UIImage?
+    var navBarStyle : UIBarStyle?
     
     init(navigationController : UINavigationController) {
         self.navBarTintColor =  navigationController.navigationBar.barTintColor
@@ -54,5 +58,6 @@ internal class NavigationControllerMemento {
         self.navBackgroundColor = navigationController.navigationBar.backgroundColor
         self.navBackgroundImage = navigationController.navigationBar.backgroundImage(for: .default)
         self.navShadowImage = navigationController.navigationBar.shadowImage
+        self.navBarStyle = navigationController.navigationBar.barStyle
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -81,7 +81,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        self.showLoading()
+        //self.showLoading()
         
         self.checkoutTable.tableHeaderView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: self.checkoutTable.bounds.size.width, height: 0.01))
         
@@ -90,7 +90,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         } else {
             //TODO : OJO TOKEN RECUPERABLE
             if self.viewModel.paymentData.paymentMethod != nil {
-                self.hideLoading()
+                //self.hideLoading()
               //  self.checkoutTable.reloadData()
                 if (recover){
                     recover = false
@@ -109,7 +109,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.navBarTextColor = UIColor.px_blueMercadoPago()
         self.titleCellHeight = 44
         self.hideNavBar()
-        self.hideLoading()
+        //self.hideLoading()
      
     }
 
@@ -211,7 +211,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.hideNavBar()
         self.hideBackButton()
         self.hideTimer()
-        self.showLoading()
+        //self.showLoading()
         self.callbackConfirm(self.viewModel.paymentData)
     }
  
@@ -411,7 +411,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     
     open override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        self.hideLoading()
+        //self.hideLoading()
     }
     
     public func invokeCallbackWithPaymentData(rowCallback : ((PaymentData) -> Void)) {

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -81,8 +81,6 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        //self.showLoading()
-        
         self.checkoutTable.tableHeaderView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: self.checkoutTable.bounds.size.width, height: 0.01))
         
         if !self.viewModel.isPreferenceLoaded() {
@@ -90,7 +88,6 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         } else {
             //TODO : OJO TOKEN RECUPERABLE
             if self.viewModel.paymentData.paymentMethod != nil {
-                //self.hideLoading()
               //  self.checkoutTable.reloadData()
                 if (recover){
                     recover = false
@@ -109,7 +106,6 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.navBarTextColor = UIColor.px_blueMercadoPago()
         self.titleCellHeight = 44
         self.hideNavBar()
-        //self.hideLoading()
      
     }
 
@@ -211,7 +207,6 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.hideNavBar()
         self.hideBackButton()
         self.hideTimer()
-        //self.showLoading()
         self.callbackConfirm(self.viewModel.paymentData)
     }
  
@@ -411,7 +406,6 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     
     open override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        //self.hideLoading()
     }
     
     public func invokeCallbackWithPaymentData(rowCallback : ((PaymentData) -> Void)) {

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -82,8 +82,8 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.registerAllCells()
         
         self.displayStatusBar()
+
         
-        self.hideNavBar()
     }
 
     
@@ -91,6 +91,12 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         super.viewDidAppear(animated)
         
         self.showLoading()
+        
+        
+        self.titleCellHeight = 44
+        
+        
+        self.hideNavBar()
         
         self.checkoutTable.tableHeaderView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: self.checkoutTable.bounds.size.width, height: 0.01))
         
@@ -108,17 +114,20 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
                     auth = false
                     //self.startAuthCard(self.viewModel.paymentData.token!)
                 }
-            } 
+            }
         }
 
         self.extendedLayoutIncludesOpaqueBars = true
         
         self.navBarTextColor = UIColor.px_blueMercadoPago()
-        self.titleCellHeight = 44
+        
  
         
-        self.hideLoading()
         
+        if self.shouldShowNavBar(self.checkoutTable) {
+            self.showNavBar()
+        }
+        self.hideLoading()
      
     }
 
@@ -439,20 +448,16 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     }
     
     private func removeStatusBar(){
-        if self.navigationController != nil {
-            for v in (self.navigationController!.navigationBar.subviews) {
-                if (v.tag != 0) {
-                    v.removeFromSuperview()
-
-                }
-            }
+        guard let _ = self.navigationController, let view = statusBarView else {
+            return
         }
+        view.removeFromSuperview()
     }
     
     private func displayStatusBar(){
     
         self.statusBarView = UIView(frame: CGRect(x: 0, y: -20, width: self.view.frame.width, height: 20))
-        self.statusBarView!.backgroundColor = UIColor.px_grayLines()
+        self.statusBarView!.backgroundColor = UIColor.grayStatusBar()
     
         
         self.statusBarView!.tag = 1

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -22,6 +22,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     var viewModel : CheckoutViewModel!
     override open var screenName : String { get{ return "REVIEW_AND_CONFIRM" } }
     fileprivate var reviewAndConfirmContent = Set<String>()
+    private var statusBarView : UIView?
     
     fileprivate var recover = false
     fileprivate var auth = false
@@ -53,8 +54,13 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         fatalError("init(coder:) has not been implemented")
     }
     
-    override open func viewDidLoad() {
-        super.viewDidLoad()
+    override func showNavBar() {
+        
+        super.showNavBar()
+        
+        if self.statusBarView == nil {
+            self.displayStatusBar()
+        }
     }
     
     var paymentEnabled = true
@@ -74,12 +80,18 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.checkoutTable.delegate = self
         
         self.registerAllCells()
-     
+        
+        self.displayStatusBar()
+        
+        self.hideNavBar()
     }
 
     
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        
+        self.showLoading()
+        self.hideNavBar()
         
         self.checkoutTable.tableHeaderView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: self.checkoutTable.bounds.size.width, height: 0.01))
         
@@ -105,7 +117,10 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         
         self.navBarTextColor = UIColor.px_blueMercadoPago()
         self.titleCellHeight = 44
-        self.hideNavBar()
+ 
+        
+        self.hideLoading()
+        
      
     }
 
@@ -207,6 +222,16 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.hideNavBar()
         self.hideBackButton()
         self.hideTimer()
+        
+        // Add status bar
+        self.statusBarView = UIView(frame: CGRect(x: 0, y: -20, width: self.view.frame.width, height: 20))
+        self.statusBarView!.backgroundColor = UIColor.lightGray
+        self.statusBarView!.tag = 1
+        
+        self.navigationController!.navigationBar.addSubview(self.statusBarView!)
+        
+        self.showLoading()
+
         self.callbackConfirm(self.viewModel.paymentData)
     }
  
@@ -411,6 +436,37 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     public func invokeCallbackWithPaymentData(rowCallback : ((PaymentData) -> Void)) {
         rowCallback(self.viewModel.paymentData)
     }
+    
+    open override func willMove(toParentViewController parent: UIViewController?) {
+        super.willMove(toParentViewController: parent)
+        removeStatusBar()
+    }
+    
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.removeStatusBar()
+    }
+    
+    private func removeStatusBar(){
+        if self.navigationController != nil {
+            for v in (self.navigationController!.navigationBar.subviews) {
+                if (v.tag != 0) {
+                    v.removeFromSuperview()
+                }
+            }
+        }
+    }
+    
+    private func displayStatusBar(){
+    
+        self.statusBarView = UIView(frame: CGRect(x: 0, y: -20, width: self.view.frame.width, height: 20))
+        self.statusBarView!.backgroundColor = UIColor.lightGray
+        self.statusBarView!.tag = 1
+        self.navigationController!.navigationBar.addSubview(self.statusBarView!)
+    
+    }
+    
+    
 }
 
 open class CheckoutViewModel {
@@ -627,6 +683,8 @@ open class CheckoutViewModel {
     func isPaymentMethodCellFor(indexPath: IndexPath) -> Bool {
         return indexPath.section == 3
     }
+    
+    
     
 
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -104,11 +104,10 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
                     recover = false
                     //self.startRecoverCard()
                 }
-                if (auth){
+                if (auth) {
                     auth = false
                     //self.startAuthCard(self.viewModel.paymentData.token!)
                 }
-                
             } 
         }
 
@@ -444,6 +443,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
             for v in (self.navigationController!.navigationBar.subviews) {
                 if (v.tag != 0) {
                     v.removeFromSuperview()
+
                 }
             }
         }
@@ -452,10 +452,13 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     private func displayStatusBar(){
     
         self.statusBarView = UIView(frame: CGRect(x: 0, y: -20, width: self.view.frame.width, height: 20))
-        self.statusBarView!.backgroundColor = UIColor.lightGray
-        self.statusBarView!.tag = 1
-        self.navigationController!.navigationBar.addSubview(self.statusBarView!)
+        self.statusBarView!.backgroundColor = UIColor.px_grayLines()
     
+        
+        self.statusBarView!.tag = 1
+        
+        self.navigationController!.navigationBar.barStyle = .blackTranslucent
+        self.navigationController!.navigationBar.addSubview(self.statusBarView!)
     }
     
     

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -91,7 +91,6 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         super.viewDidAppear(animated)
         
         self.showLoading()
-        self.hideNavBar()
         
         self.checkoutTable.tableHeaderView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: self.checkoutTable.bounds.size.width, height: 0.01))
         
@@ -222,13 +221,6 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         self.hideNavBar()
         self.hideBackButton()
         self.hideTimer()
-        
-        // Add status bar
-        self.statusBarView = UIView(frame: CGRect(x: 0, y: -20, width: self.view.frame.width, height: 20))
-        self.statusBarView!.backgroundColor = UIColor.lightGray
-        self.statusBarView!.tag = 1
-        
-        self.navigationController!.navigationBar.addSubview(self.statusBarView!)
         
         self.showLoading()
 

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -28,7 +28,9 @@ open class MercadoPagoCheckout: NSObject {
         self.navigationController = navigationController
         
         if self.navigationController.viewControllers.count > 0 {
-            viewControllerBase = self.navigationController.viewControllers.last
+            let  newNavigationStack = self.navigationController.viewControllers.filter {!$0.isKind(of:MercadoPagoUIViewController.self) || $0.isKind(of:CheckoutViewController.self);
+            }
+            viewControllerBase = newNavigationStack.last
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -330,6 +330,7 @@ open class MercadoPagoCheckout: NSObject {
     }
     
     func createPayment() {
+        self.presentLoading()
         
         var paymentBody : [String:Any]
         if MercadoPagoCheckoutViewModel.servicePreference.isUsingDeafaultPaymentSettings() {
@@ -342,6 +343,7 @@ open class MercadoPagoCheckout: NSObject {
         MerchantServer.createPayment(paymentUrl : MercadoPagoCheckoutViewModel.servicePreference.getPaymentURL(), paymentUri : MercadoPagoCheckoutViewModel.servicePreference.getPaymentURI(), paymentBody : paymentBody as NSDictionary, success: {(payment : Payment) -> Void in
             self.viewModel.updateCheckoutModel(payment: payment)
             self.executeNextStep()
+            self.dismissLoading()
         }, failure: {(error : NSError) -> Void in
             self.viewModel.errorInputs(error: MPSDKError.convertFrom(error), errorCallback: { (Void) in
                 self.createPayment()

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoUIScrollViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoUIScrollViewController.swift
@@ -36,7 +36,7 @@ open class MercadoPagoUIScrollViewController: MercadoPagoUIViewController {
             
         }
 
-        if (scrollView.contentOffset.y > -scrollPositionToShowNavBar() ) {
+        if self.shouldShowNavBar(scrollView) {
             showNavBar()
         } else {
             hideNavBar()
@@ -46,6 +46,10 @@ open class MercadoPagoUIScrollViewController: MercadoPagoUIViewController {
     
     override func getNavigationBarTitle() -> String {
         return ""
+    }
+    
+    internal func shouldShowNavBar(_ scrollView: UIScrollView) -> Bool {
+        return scrollView.contentOffset.y > -scrollPositionToShowNavBar()
     }
   
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
@@ -85,6 +85,7 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
     
     open override func viewDidLoad() {
         super.viewDidLoad()
+        self.showLoading()
         var upperFrame = self.collectionSearch.bounds
         upperFrame.origin.y = -upperFrame.size.height + 10;
         upperFrame.size.width = UIScreen.main.bounds.width
@@ -129,6 +130,7 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
     
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+       
         
         self.collectionSearch.allowsSelection = true
         self.getCustomerCards()
@@ -141,7 +143,18 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
             self.loadingInstance = LoadingOverlay.shared.showOverlay(temporalView, backgroundColor: UIColor.primaryColor())
             self.view.bringSubview(toFront: self.loadingInstance!)
         }
+         self.hideLoading()
         
+    }
+    
+    open override func willMove(toParentViewController parent: UIViewController?) {
+        super.willMove(toParentViewController: parent)
+        self.hideLoading()
+    }
+    
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.hideLoading()
     }
 
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UIColor+Additions.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UIColor+Additions.swift
@@ -123,6 +123,10 @@ extension UIColor {
         return UIColorFromRGB(0xFF5959)
     }
     
+    class public func grayStatusBar() -> UIColor {
+        return UIColorFromRGB(0xE6E6E6)
+    }
+    
     class public func primaryColor() -> UIColor {
         return MercadoPagoCheckoutViewModel.decorationPreference.getBaseColor()
     }


### PR DESCRIPTION
Fix #752

##  Cambios introducidos : 
- Se agrega un loading en paymentSelectionScreen para mejorar la animación cuando esta pantalla se llama 2 veces seguidas.

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
