### PR TITLE
Fix Desaparece el navbar al volver a RyC

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -83,7 +83,8 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
         
         self.displayStatusBar()
 
-        
+        checkoutTable.setContentOffset(CGPoint(x:0, y: -(statusBarHeigth + navBarHeigth))  , animated: false)
+     
     }
 
     


### PR DESCRIPTION
Fix #754 

##  Cambios introducidos : 
- Se scrollea hacia arriba de todo la vista de RyC al volver a entrar

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
