### PR TITLE
Add summaryRow to ReviewScreenPreference

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -251,6 +251,8 @@
 		4B88E2431E489B3D00D52527 /* ConfirmInstallmentsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4B88E2401E489B3D00D52527 /* ConfirmInstallmentsTableViewCell.xib */; };
 		4B88E2441E489B3D00D52527 /* ConfirmInstallmentsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4B88E2401E489B3D00D52527 /* ConfirmInstallmentsTableViewCell.xib */; };
 		4B88E2571E48CC5C00D52527 /* MPCustomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B88E2561E48CC5C00D52527 /* MPCustomCell.swift */; };
+		4B8D73511E780F8F009C1209 /* SummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8D73501E780F8F009C1209 /* SummaryRow.swift */; };
+		4B8D73521E780F8F009C1209 /* SummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8D73501E780F8F009C1209 /* SummaryRow.swift */; };
 		4BA4DB071E425C6700B70550 /* TotalPayerCostRowTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFD451D1E4220BB006F9F62 /* TotalPayerCostRowTableViewCell.swift */; };
 		4BA4DB0B1E43902900B70550 /* ConfirmAdditionalInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BA4DB081E43902900B70550 /* ConfirmAdditionalInfoTableViewCell.swift */; };
 		4BA4DB0C1E43902900B70550 /* ConfirmAdditionalInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4BA4DB091E43902900B70550 /* ConfirmAdditionalInfoTableViewCell.xib */; };
@@ -662,6 +664,7 @@
 		4B88E23F1E489B3D00D52527 /* ConfirmInstallmentsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmInstallmentsTableViewCell.swift; sourceTree = "<group>"; };
 		4B88E2401E489B3D00D52527 /* ConfirmInstallmentsTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ConfirmInstallmentsTableViewCell.xib; sourceTree = "<group>"; };
 		4B88E2561E48CC5C00D52527 /* MPCustomCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPCustomCell.swift; sourceTree = "<group>"; };
+		4B8D73501E780F8F009C1209 /* SummaryRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SummaryRow.swift; sourceTree = "<group>"; };
 		4BA4DB081E43902900B70550 /* ConfirmAdditionalInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmAdditionalInfoTableViewCell.swift; sourceTree = "<group>"; };
 		4BA4DB091E43902900B70550 /* ConfirmAdditionalInfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ConfirmAdditionalInfoTableViewCell.xib; sourceTree = "<group>"; };
 		4BAA55E51DB0012300501061 /* CardAdditionalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardAdditionalViewController.swift; sourceTree = "<group>"; };
@@ -950,6 +953,7 @@
 				4BEF80F51E53308C00797CD1 /* PaymentResult.swift */,
 				4BDE2D441E37B4AC00C1D614 /* ServicePreference.swift */,
 				76EF21E61E52C07700718ED2 /* ReviewScreenPreference.swift */,
+				4B8D73501E780F8F009C1209 /* SummaryRow.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -1997,6 +2001,7 @@
 				0F98835F1AD2AB6000F750F0 /* Cardholder.swift in Sources */,
 				0F9883911AD2AB6000F750F0 /* SavedCardToken.swift in Sources */,
 				15DA7E5E1CD92C670068896E /* IdentificationViewController.swift in Sources */,
+				4B8D73511E780F8F009C1209 /* SummaryRow.swift in Sources */,
 				76AA2E341CBD8BCA006D0678 /* MPTextView.swift in Sources */,
 				76445ADB1CC921B5008EE68E /* ViewUtils.swift in Sources */,
 				765F8E5D1DCA57D000943FAC /* ConfirmPaymentTableViewCell.swift in Sources */,
@@ -2229,6 +2234,7 @@
 				769A73611DF736D30089A1BF /* Utils.swift in Sources */,
 				76EC47CC1C85E3E60086FA53 /* CardIssuerTest.swift in Sources */,
 				767254681C7CB2AB00EB5EBA /* CheckoutViewControllerTest.swift in Sources */,
+				4B8D73521E780F8F009C1209 /* SummaryRow.swift in Sources */,
 				0F9883781AD2AB6000F750F0 /* IdentificationType.swift in Sources */,
 				0F9883BB1AD2AD1600F750F0 /* String+Additions.swift in Sources */,
 				76D00A011CA2CA3E00F52BC6 /* UtilsTest.swift in Sources */,

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -494,14 +494,16 @@ open class CheckoutViewModel {
     }
     
     func setSummaryRows() {
-        if MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows()[0].customDescription != MercadoPagoCheckoutViewModel.reviewScreenPreference.getProductsTitle() {
-        let productsSummary = SummaryRow(customDescription: MercadoPagoCheckoutViewModel.reviewScreenPreference.getProductsTitle(), descriptionColor: nil, customAmount: self.preference!.getAmount(), amountColor: nil, separatorLine: true)
         
         var summaryRows = MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows()
+        
+        if summaryRows.count == 0 || summaryRows[0].customDescription != MercadoPagoCheckoutViewModel.reviewScreenPreference.getProductsTitle() {
+        let productsSummary = SummaryRow(customDescription: MercadoPagoCheckoutViewModel.reviewScreenPreference.getProductsTitle(), descriptionColor: nil, customAmount: self.preference!.getAmount(), amountColor: nil, separatorLine: true)
         
         summaryRows.insert(productsSummary, at: 0)
         
         MercadoPagoCheckoutViewModel.reviewScreenPreference.setSummaryRows(summaryRows: summaryRows)
+        
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -116,13 +116,10 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
                 }
             }
         }
-
+        
         self.extendedLayoutIncludesOpaqueBars = true
         
         self.navBarTextColor = UIColor.px_blueMercadoPago()
-        
- 
-        
         
         if self.shouldShowNavBar(self.checkoutTable) {
             self.showNavBar()
@@ -174,8 +171,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
             return getMainTitleCell(indexPath : indexPath)
             
         } else if self.viewModel.isProductlCellFor(indexPath: indexPath){
-            let productsTitle = MercadoPagoCheckoutViewModel.reviewScreenPreference.getProductsTitle()
-            return self.getPurchaseSimpleDetailCell(indexPath: indexPath, title : productsTitle, amount : self.viewModel.preference!.getAmount())
+            return self.getSummaryCell(indexPath: indexPath)
             
         } else if self.viewModel.isInstallmentsCellFor(indexPath: indexPath) {
             return self.getPurchaseDetailCell(indexPath: indexPath, title : "Pagas".localized, amount : self.viewModel.preference!.getAmount(), payerCost : self.viewModel.paymentData.payerCost, addSeparatorLine: true)
@@ -343,6 +339,13 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     }
     
     
+    private func getSummaryCell(indexPath : IndexPath) -> UITableViewCell{
+        let currency = MercadoPagoContext.getCurrency()
+        let purchaseSimpleDetailTableViewCell = self.checkoutTable.dequeueReusableCell(withIdentifier: "purchaseSimpleDetailTableViewCell", for: indexPath) as! PurchaseSimpleDetailTableViewCell
+        purchaseSimpleDetailTableViewCell.fillCell(summaryRow: MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows()[indexPath.row], currency: currency, payerCost: nil)
+        return purchaseSimpleDetailTableViewCell
+    }
+    
     private func getPurchaseSimpleDetailCell(indexPath : IndexPath, title : String, amount : Double, payerCost : PayerCost? = nil, addSeparatorLine : Bool = true) -> UITableViewCell{
         let currency = MercadoPagoContext.getCurrency()
         let purchaseSimpleDetailTableViewCell = self.checkoutTable.dequeueReusableCell(withIdentifier: "purchaseSimpleDetailTableViewCell", for: indexPath) as! PurchaseSimpleDetailTableViewCell
@@ -486,6 +489,20 @@ open class CheckoutViewModel {
         self.preference = checkoutPreference
         self.paymentData = paymentData
         self.paymentOptionSelected = paymentOptionSelected
+        
+        self.setSummaryRows()
+    }
+    
+    func setSummaryRows() {
+        if MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows()[0].customDescription != MercadoPagoCheckoutViewModel.reviewScreenPreference.getProductsTitle() {
+        let productsSummary = SummaryRow(customDescription: MercadoPagoCheckoutViewModel.reviewScreenPreference.getProductsTitle(), descriptionColor: nil, customAmount: self.preference!.getAmount(), amountColor: nil, separatorLine: true)
+        
+        var summaryRows = MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows()
+        
+        summaryRows.insert(productsSummary, at: 0)
+        
+        MercadoPagoCheckoutViewModel.reviewScreenPreference.setSummaryRows(summaryRows: summaryRows)
+        }
     }
     
     func isPaymentMethodSelectedCard() -> Bool {
@@ -506,7 +523,8 @@ open class CheckoutViewModel {
     
     func numberOfRowsInMainSection() -> Int {
         // Productos
-        var numberOfRows = 1
+        var numberOfRows = 0
+        
         if self.isPaymentMethodSelectedCard() {
             numberOfRows = numberOfRows +  1
         }
@@ -522,6 +540,8 @@ open class CheckoutViewModel {
         if hasPayerCostAddionalInfo() {
             numberOfRows += 1
         }
+        // Productos + customSummaryRows
+        numberOfRows += MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows().count
         
         // Total
         numberOfRows = numberOfRows + 1
@@ -630,11 +650,11 @@ open class CheckoutViewModel {
     }
     
     func isProductlCellFor(indexPath: IndexPath) -> Bool{
-        return indexPath.section == 1 && indexPath.row == 0
+        return indexPath.section == 1 && indexPath.row < MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows().count
     }
     
     func isInstallmentsCellFor(indexPath: IndexPath) -> Bool{
-        if indexPath.section == 1 && indexPath.row == 1 {
+        if indexPath.section == 1 && indexPath.row == MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows().count {
             return isPaymentMethodSelectedCard()
         } else {
             return false
@@ -642,14 +662,14 @@ open class CheckoutViewModel {
     }
     func isTotalCellFor(indexPath: IndexPath) -> Bool {
         if isPaymentMethodSelectedCard() {
-            return indexPath.section == 1 && indexPath.row == 2
+            return indexPath.section == 1 && indexPath.row == MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows().count + 1
         } else {
-            return indexPath.section == 1 && indexPath.row == 1
+            return indexPath.section == 1 && indexPath.row == MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows().count
         }
     }
     
     func isConfirmButtonCellFor(indexPath: IndexPath) -> Bool {
-        var row = 2
+        var row = MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows().count + 1
         if isPaymentMethodSelectedCard() {
             row += 1
             if hasPayerCostAddionalInfo(){
@@ -667,7 +687,7 @@ open class CheckoutViewModel {
     
     func isConfirmAdditionalInfoFor(indexPath: IndexPath) -> Bool {
         if hasPayerCostAddionalInfo() {
-            return indexPath.section == 1 && indexPath.row == 3
+            return indexPath.section == 1 && indexPath.row == MercadoPagoCheckoutViewModel.reviewScreenPreference.getSummaryRows().count + 2
         }
         return false
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PurchaseSimpleDetailTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PurchaseSimpleDetailTableViewCell.swift
@@ -24,19 +24,45 @@ class PurchaseSimpleDetailTableViewCell: UITableViewCell {
         super.setSelected(selected, animated: animated)
     }
     
-    internal func fillCell(_ title : String, amount : Double, currency : Currency, payerCost : PayerCost? = nil, addSeparatorLine : Bool = true){
+    internal func fillCell(_ title : String, amount : Double, currency : Currency, payerCost : PayerCost? = nil, addSeparatorLine : Bool = true, titleColor: UIColor = UIColor.px_grayDark(), amountColor: UIColor = UIColor.px_grayDark()){
         
-        //Deafult values for cells
+        fillDescription(title: title, color: titleColor)
+        
+        self.removeFromSuperview()
+        
+        fillAmount(amount: amount, color: amountColor, payerCost: payerCost, currency: currency)
+        
+        addSeperatorLine(addLine: addSeparatorLine)
+    }
+    
+    internal func fillCell(summaryRow: SummaryRow, currency : Currency, payerCost : PayerCost? = nil){
+        
+        fillDescription(title: summaryRow.customDescription, color: summaryRow.colorDescription)
+        
+        self.removeFromSuperview()
+        
+        fillAmount(amount: summaryRow.customAmount, color: summaryRow.colorAmount, payerCost: payerCost, currency: currency)
+        
+        addSeperatorLine(addLine: summaryRow.separatorLine)
+    }
+    
+    func fillDescription(title: String, color: UIColor) {
         self.titleLabel.text = title
         self.titleLabel.font = Utils.getFont(size: titleLabel.font.pointSize)
-        self.removeFromSuperview()
+        self.titleLabel.textColor = color
+    }
+    
+    func fillAmount(amount: Double, color: UIColor, payerCost: PayerCost?, currency: Currency) {
         if payerCost != nil {
             let purchaseAmount = getInstallmentsAmount(payerCost: payerCost!)
             self.unitPrice.attributedText = purchaseAmount
         } else {
-            self.unitPrice.attributedText = Utils.getAttributedAmount(amount, thousandSeparator: currency.thousandsSeparator, decimalSeparator: currency.decimalSeparator, currencySymbol: currency.symbol, color : UIColor.px_grayDark(), fontSize : 18, baselineOffset : 5)
+            self.unitPrice.attributedText = Utils.getAttributedAmount(amount, thousandSeparator: currency.thousandsSeparator, decimalSeparator: currency.decimalSeparator, currencySymbol: currency.symbol, color : color , fontSize : 18, baselineOffset : 5)
         }
-        if addSeparatorLine {
+    }
+    
+    func addSeperatorLine(addLine: Bool) {
+        if addLine {
             let separatorLine = ViewUtils.getTableCellSeparatorLineView(21, y: PurchaseSimpleDetailTableViewCell.SEPARATOR_LINE_HEIGHT, width: self.frame.width - 42, height: 1)
             self.addSubview(separatorLine)
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/PurchaseSimpleDetailTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PurchaseSimpleDetailTableViewCell.swift
@@ -37,13 +37,7 @@ class PurchaseSimpleDetailTableViewCell: UITableViewCell {
     
     internal func fillCell(summaryRow: SummaryRow, currency : Currency, payerCost : PayerCost? = nil){
         
-        fillDescription(title: summaryRow.customDescription, color: summaryRow.colorDescription)
-        
-        self.removeFromSuperview()
-        
-        fillAmount(amount: summaryRow.customAmount, color: summaryRow.colorAmount, payerCost: payerCost, currency: currency)
-        
-        addSeperatorLine(addLine: summaryRow.separatorLine)
+        fillCell(summaryRow.customDescription, amount: summaryRow.customAmount, currency: currency, addSeparatorLine: summaryRow.separatorLine, titleColor: summaryRow.colorDescription, amountColor: summaryRow.colorAmount)
     }
     
     func fillDescription(title: String, color: UIColor) {

--- a/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenPreference.swift
@@ -17,6 +17,8 @@ open class ReviewScreenPreference: NSObject {
     private var cancelButtonText = "Cancelar Pago".localized
 	private var shouldDisplayChangeMethodOption = true
     
+    private var summaryRows = [SummaryRow]()
+    
     internal static var additionalInfoCells = [MPCustomCell]()
     internal static var customItemCells = [MPCustomCell]()
     
@@ -75,6 +77,14 @@ open class ReviewScreenPreference: NSObject {
 	open func enableChangeMethodOption() {
 		self.shouldDisplayChangeMethodOption = true
 	}
+    
+    open func setSummaryRows(summaryRows: [SummaryRow]) {
+        self.summaryRows = summaryRows
+    }
+    
+    open func getSummaryRows() -> [SummaryRow]{
+        return summaryRows
+    }
 	
     open static func setCustomItemCell(customCell : [MPCustomCell]) {
         ReviewScreenPreference.customItemCells = customCell

--- a/MercadoPagoSDK/MercadoPagoSDK/SummaryRow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SummaryRow.swift
@@ -1,0 +1,30 @@
+//
+//  SummaryRow.swift
+//  MercadoPagoSDK
+//
+//  Created by Eden Torres on 3/14/17.
+//  Copyright © 2017 MercadoPago. All rights reserved.
+//
+
+import Foundation
+
+open class SummaryRow: NSObject {
+    var customDescription: String
+    var customAmount: Double
+    var colorDescription: UIColor = UIColor.px_grayDark()
+    var colorAmount: UIColor = UIColor.px_grayDark()
+    var separatorLine: Bool = true
+    
+    public init(customDescription: String, descriptionColor: UIColor? , customAmount: Double, amountColor: UIColor?, separatorLine: Bool = true) {
+        self.customDescription = customDescription
+        self.customAmount = customAmount
+        self.separatorLine = separatorLine
+        
+        if let descriptionColor = descriptionColor {
+            self.colorDescription = descriptionColor
+        }
+        if let amountColor = amountColor {
+            self.colorAmount = amountColor
+        }
+    }
+}

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -255,6 +255,7 @@
     [reviewPreference setCancelButtonTextWithCancelButtonText:@"Cancelar recarga"];
     //[ReviewScreenPreference addCustomItemCellWithCustomCell:customCargaSube];
     
+    SummaryRow *summaryRow = [[SummaryRow alloc] initWithCustomDescription:@"Comisión BACEN" descriptionColor: UIColor.brownColor customAmount:20.0 amountColor:UIColor.redColor separatorLine:YES];
     
     [reviewPreference setSummaryRowsWithSummaryRows:[NSArray arrayWithObjects:summaryRow, nil]];
     

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -255,6 +255,9 @@
     [reviewPreference setCancelButtonTextWithCancelButtonText:@"Cancelar recarga"];
     //[ReviewScreenPreference addCustomItemCellWithCustomCell:customCargaSube];
     
+    
+    [reviewPreference setSummaryRowsWithSummaryRows:[NSArray arrayWithObjects:summaryRow, nil]];
+    
     [ReviewScreenPreference setAddionalInfoCellsWithCustomCells:[NSArray arrayWithObjects:customCargaSube, nil]];
     
     [MercadoPagoCheckout setReviewScreenPreference:reviewPreference];


### PR DESCRIPTION
Fix #760 

##  Cambios introducidos : 
- Se agrega la opcion de agregar items al summary de Revisa y Confirma

Ejemplo:
```
    SummaryRow *summaryRow = [[SummaryRow alloc] initWithCustomDescription:@"Comisión BACEN" descriptionColor: UIColor.brownColor customAmount:20.0 amountColor:UIColor.redColor separatorLine:YES];
    
    [reviewPreference setSummaryRowsWithSummaryRows:[NSArray arrayWithObjects:summaryRow, nil]];
```

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
