### PR TITLE
Remove services from SecurityCodeViewController

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -169,10 +169,10 @@
 		1565B1311CBFD7F100181998 /* GuessingFormTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1565B1301CBFD7F100181998 /* GuessingFormTest.swift */; };
 		157420F61DF881770041171E /* UIView+RotateView.h in Headers */ = {isa = PBXBuildFile; fileRef = 157420F41DF881770041171E /* UIView+RotateView.h */; };
 		157420F71DF881770041171E /* UIView+RotateView.m in Sources */ = {isa = PBXBuildFile; fileRef = 157420F51DF881770041171E /* UIView+RotateView.m */; };
-		157704B51DCBA1500038C550 /* SecrurityCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157704B31DCBA1500038C550 /* SecrurityCodeViewController.swift */; };
-		157704B61DCBA1500038C550 /* SecrurityCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157704B31DCBA1500038C550 /* SecrurityCodeViewController.swift */; };
-		157704B71DCBA1500038C550 /* SecrurityCodeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 157704B41DCBA1500038C550 /* SecrurityCodeViewController.xib */; };
-		157704B81DCBA1500038C550 /* SecrurityCodeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 157704B41DCBA1500038C550 /* SecrurityCodeViewController.xib */; };
+		157704B51DCBA1500038C550 /* SecurityCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157704B31DCBA1500038C550 /* SecurityCodeViewController.swift */; };
+		157704B61DCBA1500038C550 /* SecurityCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157704B31DCBA1500038C550 /* SecurityCodeViewController.swift */; };
+		157704B71DCBA1500038C550 /* SecurityCodeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 157704B41DCBA1500038C550 /* SecurityCodeViewController.xib */; };
+		157704B81DCBA1500038C550 /* SecurityCodeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 157704B41DCBA1500038C550 /* SecurityCodeViewController.xib */; };
 		157AA6821C970BEC00CC9B43 /* TermsAndConditionsViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76DA646A1C90C3E3004F9A7C /* TermsAndConditionsViewCell.xib */; };
 		157AA6831C970C0100CC9B43 /* TermsAndConditionsViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76DA64691C90C3E3004F9A7C /* TermsAndConditionsViewCell.swift */; };
 		158F17701D34141B00E7EBDA /* MercadoPagoContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1C1D19752A00A86097 /* MercadoPagoContext.swift */; };
@@ -624,8 +624,8 @@
 		1565B1301CBFD7F100181998 /* GuessingFormTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GuessingFormTest.swift; sourceTree = "<group>"; };
 		157420F41DF881770041171E /* UIView+RotateView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+RotateView.h"; sourceTree = "<group>"; };
 		157420F51DF881770041171E /* UIView+RotateView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+RotateView.m"; sourceTree = "<group>"; };
-		157704B31DCBA1500038C550 /* SecrurityCodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecrurityCodeViewController.swift; sourceTree = "<group>"; };
-		157704B41DCBA1500038C550 /* SecrurityCodeViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SecrurityCodeViewController.xib; sourceTree = "<group>"; };
+		157704B31DCBA1500038C550 /* SecurityCodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecurityCodeViewController.swift; sourceTree = "<group>"; };
+		157704B41DCBA1500038C550 /* SecurityCodeViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SecurityCodeViewController.xib; sourceTree = "<group>"; };
 		15904D4D1E09748C00B3B9FD /* MLSpinner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MLSpinner.h; sourceTree = "<group>"; };
 		15904D4E1E09748C00B3B9FD /* MLSpinner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MLSpinner.m; sourceTree = "<group>"; };
 		15904D4F1E09748C00B3B9FD /* MLSpinner.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MLSpinner.xib; sourceTree = "<group>"; };
@@ -1263,8 +1263,9 @@
 			isa = PBXGroup;
 			children = (
 				4BAA55E31DAFFBAC00501061 /* AdditionalStep */,
-				157704B31DCBA1500038C550 /* SecrurityCodeViewController.swift */,
-				157704B41DCBA1500038C550 /* SecrurityCodeViewController.xib */,
+				157704B31DCBA1500038C550 /* SecurityCodeViewController.swift */,
+				157704B41DCBA1500038C550 /* SecurityCodeViewController.xib */,
+
 			);
 			name = Revamp;
 			sourceTree = "<group>";
@@ -1796,7 +1797,7 @@
 				151A94101DBF8DE300A5557B /* RevampImages.xcassets in Resources */,
 				4B34DC311E5CE39D00FDD295 /* SecondaryExitButtonTableViewCell.xib in Resources */,
 				0FC4FC291B0FB2B200CF7148 /* PromosTyCTableViewCell.xib in Resources */,
-				157704B71DCBA1500038C550 /* SecrurityCodeViewController.xib in Resources */,
+				157704B71DCBA1500038C550 /* SecurityCodeViewController.xib in Resources */,
 				0FC4FC3B1B0FB53500CF7148 /* PromoViewController.xib in Resources */,
 				155F58331E3923180070A0D6 /* Images.xcassets in Resources */,
 				4BAA55EC1DB0015800501061 /* AdditionalStepCardTableViewCell.xib in Resources */,
@@ -1866,7 +1867,7 @@
 				76062BDA1C4D20C30067A14B /* PaymentVaultViewController.xib in Resources */,
 				0FC4FC241B0FAF0E00CF7148 /* PromoTableViewCell.xib in Resources */,
 				15DA7E611CD92C670068896E /* IdentificationViewController.xib in Resources */,
-				157704B81DCBA1500038C550 /* SecrurityCodeViewController.xib in Resources */,
+				157704B81DCBA1500038C550 /* SecurityCodeViewController.xib in Resources */,
 				15E7D6E81C87164E00101872 /* MockedData.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1909,7 +1910,7 @@
 				4BAA55FF1DB503E600501061 /* IssuerRowTableViewCell.swift in Sources */,
 				4BEF80F61E53308C00797CD1 /* PaymentResult.swift in Sources */,
 				76062BC41C4D1EFD0067A14B /* PaymentMethodSearch.swift in Sources */,
-				157704B51DCBA1500038C550 /* SecrurityCodeViewController.swift in Sources */,
+				157704B51DCBA1500038C550 /* SecurityCodeViewController.swift in Sources */,
 				7669999B1E675193005FB30F /* ConfirmAdditionalInfoTableViewCell.swift in Sources */,
 				0F9883771AD2AB6000F750F0 /* IdentificationType.swift in Sources */,
 				76743C821C46A21C00120347 /* CheckoutViewController.swift in Sources */,
@@ -2286,7 +2287,7 @@
 				7622E32E1DF5EFF500490C4E /* PaymentResultViewController.swift in Sources */,
 				7672545F1C7CB14500EB5EBA /* CheckoutPreferenceTest.swift in Sources */,
 				155692D21C47DA1200521403 /* PaymentPreference.swift in Sources */,
-				157704B61DCBA1500038C550 /* SecrurityCodeViewController.swift in Sources */,
+				157704B61DCBA1500038C550 /* SecurityCodeViewController.swift in Sources */,
 				0FC4FC341B0FB36F00CF7148 /* PromoTyCDetailTableViewCell.swift in Sources */,
 				15521E391E60A0B000148979 /* AppDecorationKeeper.swift in Sources */,
 				0F98837C1AD2AB6000F750F0 /* Issuer.swift in Sources */,

--- a/MercadoPagoSDK/MercadoPagoSDK/AdditionalStepViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/AdditionalStepViewController.swift
@@ -22,6 +22,7 @@ open class AdditionalStepViewController: MercadoPagoUIScrollViewController, UITa
     
     override open func viewDidLoad() {
         super.viewDidLoad()
+        self.showLoading()
         tableView.tableFooterView = UIView()
         tableView.separatorStyle = .none
         loadMPStyles()
@@ -62,7 +63,7 @@ open class AdditionalStepViewController: MercadoPagoUIScrollViewController, UITa
         
         self.extendedLayoutIncludesOpaqueBars = true
         self.titleCellHeight = 44
-        
+        self.hideLoading()
     }
     
     override func loadMPStyles(){
@@ -189,12 +190,10 @@ open class AdditionalStepViewController: MercadoPagoUIScrollViewController, UITa
             if self.viewModel.showTotalRow(){
                 if indexPath.row != 0{
                     let callbackData: NSObject = self.viewModel.dataSource[indexPath.row - 1] as! NSObject
-                    self.showLoading()
                     self.viewModel.callback!(callbackData)
                 }
             } else{
                 let callbackData: NSObject = self.viewModel.dataSource[indexPath.row] as! NSObject
-                self.showLoading()
                 self.viewModel.callback!(callbackData)
             }
         }
@@ -221,11 +220,6 @@ open class AdditionalStepViewController: MercadoPagoUIScrollViewController, UITa
     
     override func getNavigationBarTitle() -> String {
         return self.viewModel.getTitle()
-    }
-    
-    override open func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        self.hideLoading()
     }
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Card.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Card.swift
@@ -158,6 +158,10 @@ open class Card : NSObject, CardInformation, PaymentMethodOption {
         return self.issuer == nil
     }
     
+    public func canBeClone() -> Bool {
+        return false
+    }
+    
     /** PaymentOptionDrawable implementation */
     
     public func getTitle() -> String {
@@ -201,6 +205,7 @@ open class Card : NSObject, CardInformation, PaymentMethodOption {
     public func getComment() -> String {
         return ""
     }
+    
 }
 
 

--- a/MercadoPagoSDK/MercadoPagoSDK/CardInformation.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardInformation.swift
@@ -43,4 +43,6 @@ public protocol CardInformationForm : NSObjectProtocol {
     func getCardLastForDigits() -> String?
     
     func isIssuerRequired() -> Bool
+    
+    func canBeClone() -> Bool
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/CardToken.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardToken.swift
@@ -363,5 +363,9 @@ open class CardToken : NSObject, CardInformationForm {
     public func isIssuerRequired() -> Bool {
         return true
     }
+    
+    public func canBeClone() -> Bool {
+        return false
+    }
 
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/CustomerPaymentMethod.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CustomerPaymentMethod.swift
@@ -161,6 +161,9 @@ open class CustomerPaymentMethod: NSObject, CardInformation, PaymentMethodOption
         return ""
     }
     
+    public func canBeClone() -> Bool {
+        return false
+    }
     
 
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MPServicesBuilder.swift
@@ -15,7 +15,7 @@ open class MPServicesBuilder : NSObject {
     
     
     open class func createNewCardToken(_ cardToken : CardToken, baseURL: String = ServicePreference.MP_API_BASE_URL,
-                                       success:@escaping (_ token : Token?) -> Void,
+                                       success:@escaping (_ token : Token) -> Void,
                                        failure: ((_ error: NSError) -> Void)?) {
         
         MercadoPagoContext.initFlavor1()
@@ -24,11 +24,11 @@ open class MPServicesBuilder : NSObject {
         cardToken.device = Device()
         let service = GatewayService(baseURL: baseURL)
         service.getToken(key: MercadoPagoContext.keyValue(), cardToken: cardToken, success: {(jsonResult: AnyObject?) -> Void in
-            var token : Token? = nil
+            var token : Token
             if let tokenDic = jsonResult as? NSDictionary {
                 if tokenDic["error"] == nil {
                     token = Token.fromJSON(tokenDic)
-                    MPTracker.trackCreateToken(MercadoPagoContext.sharedInstance, token: token?._id)
+                    MPTracker.trackCreateToken(MercadoPagoContext.sharedInstance, token: token._id)
                     success(token)
                 } else {
                     if failure != nil {
@@ -40,7 +40,7 @@ open class MPServicesBuilder : NSObject {
     }
     
     open class func createToken(_ savedCardToken : SavedCardToken,
-                                baseURL: String =  ServicePreference.MP_API_BASE_URL, success: @escaping (_ token : Token?) -> Void,
+                                baseURL: String =  ServicePreference.MP_API_BASE_URL, success: @escaping (_ token : Token) -> Void,
                                 failure: ((_ error: NSError) -> Void)?) {
         
         MercadoPagoContext.initFlavor1()
@@ -48,11 +48,11 @@ open class MPServicesBuilder : NSObject {
         savedCardToken.device = Device()
         let service : GatewayService = GatewayService(baseURL: baseURL)
         service.getToken(key: MercadoPagoContext.keyValue(), savedCardToken: savedCardToken, success: {(jsonResult: AnyObject?) -> Void in
-            var token : Token? = nil
+            var token : Token
             if let tokenDic = jsonResult as? NSDictionary {
                 if tokenDic["error"] == nil {
                     token = Token.fromJSON(tokenDic)
-                    MPTracker.trackCreateToken(MercadoPagoContext.sharedInstance, token: token?._id)
+                    MPTracker.trackCreateToken(MercadoPagoContext.sharedInstance, token: token._id)
                     success(token)
                 } else {
                     if failure != nil {
@@ -66,18 +66,18 @@ open class MPServicesBuilder : NSObject {
     
     open class func cloneToken(_ token : Token,
                                securityCode: String,
-                               baseURL: String = ServicePreference.MP_API_BASE_URL, success: @escaping (_ token : Token?) -> Void,
+                               baseURL: String = ServicePreference.MP_API_BASE_URL, success: @escaping (_ token : Token) -> Void,
                                failure: ((_ error: NSError) -> Void)?) {
         
         MercadoPagoContext.initFlavor1()
         MPTracker.trackEvent(MercadoPagoContext.sharedInstance, action: "CLONE_TOKEN", result: nil)
         let service : GatewayService = GatewayService(baseURL: baseURL)
         service.cloneToken(public_key: MercadoPagoContext.publicKey(), token: token,securityCode: securityCode, success:{(jsonResult: AnyObject?) -> Void in
-            var token : Token? = nil
+            var token : Token
             if let tokenDic = jsonResult as? NSDictionary {
                 if tokenDic["error"] == nil {
                     token = Token.fromJSON(tokenDic)
-                    MPTracker.trackCreateToken(MercadoPagoContext.sharedInstance, token: token?._id)
+                    MPTracker.trackCreateToken(MercadoPagoContext.sharedInstance, token: token._id)
                     success(token)
                 } else {
                     if failure != nil {

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -223,16 +223,66 @@ open class MercadoPagoCheckout: NSObject {
         self.navigationController.pushViewController(issuerStep, animated: true)
     }
     
-    func createCardToken() {
+    func createCardToken(cardInformation: CardInformation? = nil, securityCode: String? = nil) {
+        guard let cardInfo = cardInformation else {
+            createNewCardToken()
+            return
+        }
+        if cardInfo.canBeClone(){
+            cloneCardToken(cardInformation: cardInfo, securityCode: securityCode!)
+        
+        } else {
+            createSavedCardToken(cardInformation: cardInfo, securityCode: securityCode!)
+        }
+    }
+    
+    func createNewCardToken() {
+        //self.dismissLoading()
+        self.presentLoading()
+        
         MPServicesBuilder.createNewCardToken(self.viewModel.cardToken!, baseURL: MercadoPagoCheckoutViewModel.servicePreference.getGatewayURL(), success: { (token : Token?) -> Void in
             self.viewModel.updateCheckoutModel(token: token!)
             self.executeNextStep()
+            self.dismissLoading()
         }, failure : { (error) -> Void in
             self.viewModel.errorInputs(error: MPSDKError.convertFrom(error), errorCallback: { (Void) in
                 self.createCardToken()
             })
             self.executeNextStep()
         })
+    }
+    
+    func createSavedCardToken(cardInformation: CardInformation, securityCode: String) {
+        self.presentLoading()
+        let cardInformation = self.viewModel.paymentOptionSelected as! CardInformation
+        
+        let saveCardToken = SavedCardToken(card: cardInformation, securityCode: securityCode, securityCodeRequired: true)
+        
+        MPServicesBuilder.createToken(saveCardToken, baseURL: MercadoPagoCheckoutViewModel.servicePreference.getGatewayURL(), success: { (token) in
+            if token.lastFourDigits.isEmpty {
+                token.lastFourDigits = cardInformation.getCardLastForDigits()
+            }
+            self.viewModel.updateCheckoutModel(token: token)
+            self.executeNextStep()
+            self.dismissLoading()
+        }, failure: { (error) in
+            self.viewModel.errorInputs(error: MPSDKError.convertFrom(error), errorCallback: { (Void) in
+                self.createCardToken()
+            })
+        })
+    }
+    
+    func cloneCardToken(cardInformation: CardInformation, securityCode: String) {
+        if let token = cardInformation as? Token {
+            MPServicesBuilder.cloneToken(token,securityCode:securityCode, success: { (token) in
+                self.viewModel.updateCheckoutModel(token: token)
+                self.executeNextStep()
+            }, failure: { (error) in
+                self.viewModel.errorInputs(error: MPSDKError.convertFrom(error), errorCallback: { (Void) in
+                    self.createCardToken()
+                })
+            })
+        }
     }
 
     func collectPayerCosts() {
@@ -311,13 +361,9 @@ open class MercadoPagoCheckout: NSObject {
     }
     
     func collectSecurityCode(){
-        let securityCodeVc = SecrurityCodeViewController(viewModel: self.viewModel.securityCodeViewModel(), collectSecurityCodeCallback : { (token: Token?) -> Void in
-            if token == nil {
-                self.navigationController.popViewController(animated: true)
-            } else {
-                self.viewModel.updateCheckoutModel(token: token!)
-                self.executeNextStep()
-            }
+        let securityCodeVc = SecurityCodeViewController(viewModel: self.viewModel.savedCardSecurityCodeViewModel(), collectSecurityCodeCallback : { (cardInformation: CardInformation, securityCode: String) -> Void in
+            self.createCardToken(cardInformation: cardInformation, securityCode: securityCode)
+
         })
         self.pushViewController(viewController : securityCodeVc, animated: true)
         

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -228,7 +228,7 @@ open class MercadoPagoCheckout: NSObject {
             createNewCardToken()
             return
         }
-        if cardInfo.canBeClone(){
+        if cardInfo.canBeClone() {
             cloneCardToken(cardInformation: cardInfo, securityCode: securityCode!)
         
         } else {
@@ -237,13 +237,13 @@ open class MercadoPagoCheckout: NSObject {
     }
     
     func createNewCardToken() {
-        //self.dismissLoading()
         self.presentLoading()
         
         MPServicesBuilder.createNewCardToken(self.viewModel.cardToken!, baseURL: MercadoPagoCheckoutViewModel.servicePreference.getGatewayURL(), success: { (token : Token?) -> Void in
             self.viewModel.updateCheckoutModel(token: token!)
             self.executeNextStep()
             self.dismissLoading()
+        
         }, failure : { (error) -> Void in
             self.viewModel.errorInputs(error: MPSDKError.convertFrom(error), errorCallback: { (Void) in
                 self.createCardToken()
@@ -254,8 +254,8 @@ open class MercadoPagoCheckout: NSObject {
     
     func createSavedCardToken(cardInformation: CardInformation, securityCode: String) {
         self.presentLoading()
-        let cardInformation = self.viewModel.paymentOptionSelected as! CardInformation
         
+        let cardInformation = self.viewModel.paymentOptionSelected as! CardInformation
         let saveCardToken = SavedCardToken(card: cardInformation, securityCode: securityCode, securityCodeRequired: true)
         
         MPServicesBuilder.createToken(saveCardToken, baseURL: MercadoPagoCheckoutViewModel.servicePreference.getGatewayURL(), success: { (token) in
@@ -273,10 +273,13 @@ open class MercadoPagoCheckout: NSObject {
     }
     
     func cloneCardToken(cardInformation: CardInformation, securityCode: String) {
+        self.presentLoading()
+        
         if let token = cardInformation as? Token {
             MPServicesBuilder.cloneToken(token,securityCode:securityCode, success: { (token) in
                 self.viewModel.updateCheckoutModel(token: token)
                 self.executeNextStep()
+                self.dismissLoading()
             }, failure: { (error) in
                 self.viewModel.errorInputs(error: MPSDKError.convertFrom(error), errorCallback: { (Void) in
                     self.createCardToken()

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -150,9 +150,13 @@ open class MercadoPagoCheckoutViewModel: NSObject {
         return PayerCostAdditionalStepViewModel(amount: self.getAmount(), token: self.cardToken, paymentMethods: pms, dataSource: (installment?.payerCosts)!)
     }
     
-    public func securityCodeViewModel() -> SecrurityCodeViewModel {
+    public func savedCardSecurityCodeViewModel() -> SecurityCodeViewModel {
         let cardInformation = self.paymentOptionSelected as! CardInformation
-        return SecrurityCodeViewModel(paymentMethod: self.paymentData.paymentMethod!, cardInfo: cardInformation)
+        return SecurityCodeViewModel(paymentMethod: self.paymentData.paymentMethod!, cardInfo: cardInformation)
+    }
+    
+    public func recoverTokenSecurityCodeViewModel() -> SecurityCodeViewModel {
+        return SecurityCodeViewModel(paymentMethod: self.paymentData.paymentMethod!, cardInfo: paymentData.token!)
     }
     
     public func checkoutViewModel() -> CheckoutViewModel {

--- a/MercadoPagoSDK/MercadoPagoSDK/SecurityCodeViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecurityCodeViewController.swift
@@ -21,7 +21,6 @@ open class SecurityCodeViewController: MercadoPagoUIViewController, UITextFieldD
     var cardFront : CardFrontView!
     var cardBack : CardBackView!
     var ccvLabelEmpty : Bool = true
-    //var collectSecurityCodeCallback : ((_ cardInformation: CardInformation, _ securityCode: String) -> Void)!
     
     override open var screenName : String { get{ return "SECURITY_CODE" } }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/SecurityCodeViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecurityCodeViewController.swift
@@ -8,20 +8,20 @@
 
 import UIKit
 
-open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextFieldDelegate{
+open class SecurityCodeViewController: MercadoPagoUIViewController, UITextFieldDelegate{
     
     var securityCodeLabel: UILabel!
     @IBOutlet weak var securityCodeTextField: HoshiTextField!
     @IBOutlet weak var errorLabel: UILabel!
     
     @IBOutlet weak var panelView: UIView!
-    var viewModel : SecrurityCodeViewModel!
+    var viewModel : SecurityCodeViewModel!
     @IBOutlet weak var button: UIButton!
     var textMaskFormater : TextMaskFormater!
     var cardFront : CardFrontView!
     var cardBack : CardBackView!
     var ccvLabelEmpty : Bool = true
-    var collectSecurityCodeCallback : ((_ token: Token?)->Void)!
+    //var collectSecurityCodeCallback : ((_ cardInformation: CardInformation, _ securityCode: String) -> Void)!
     
     override open var screenName : String { get{ return "SECURITY_CODE" } }
     
@@ -49,7 +49,7 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
         
         securityCodeTextField.autocorrectionType = UITextAutocorrectionType.no
         securityCodeTextField.keyboardType = UIKeyboardType.numberPad
-        securityCodeTextField.addTarget(self, action: #selector(SecrurityCodeViewController.editingChanged(_:)), for: UIControlEvents.editingChanged)
+        securityCodeTextField.addTarget(self, action: #selector(SecurityCodeViewController.editingChanged(_:)), for: UIControlEvents.editingChanged)
         securityCodeTextField.delegate = self
         completeCvvLabel()
     }
@@ -67,11 +67,10 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
         super.init(coder: aDecoder)
     }
 
-    public init(viewModel : SecrurityCodeViewModel, collectSecurityCodeCallback: @escaping (_ token: Token?) -> Void ) {
-        super.init(nibName: "SecrurityCodeViewController", bundle: MercadoPago.getBundle())
+    public init(viewModel : SecurityCodeViewModel, collectSecurityCodeCallback: @escaping (_ cardInformation: CardInformation, _ securityCode: String) -> Void ) {
+        super.init(nibName: "SecurityCodeViewController", bundle: MercadoPago.getBundle())
         self.viewModel = viewModel
-        self.viewModel.vc = self
-        self.collectSecurityCodeCallback = collectSecurityCodeCallback
+        self.viewModel.callback = collectSecurityCodeCallback
     }
     
     open override func viewWillAppear(_ animated: Bool) {
@@ -97,7 +96,6 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
             
             self.navigationController?.navigationBar.setValue(true, forKey: "hidesShadow") //saca linea molesta
             displayBackButton()
-            self.navigationItem.leftBarButtonItem!.action = #selector(SecrurityCodeViewController.executeBack)
         }
     }
     
@@ -108,7 +106,7 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
             showErrorMessage()
             return
         }
-        self.viewModel.tokenAndCallback(secCode: securityCodeTextField.text)
+        self.viewModel.executeCallback(secCode:  securityCodeTextField.text)
     }
     
     func updateCardSkin(cardInformation: CardInformationForm?, paymentMethod: PaymentMethod?) {
@@ -189,24 +187,17 @@ open class SecrurityCodeViewController: MercadoPagoUIViewController, UITextField
         return true
         
     }
-    
-    override func executeBack(){
-        self.collectSecurityCodeCallback(nil)
-    }
-
 }
 
-open class SecrurityCodeViewModel: NSObject {
+open class SecurityCodeViewModel: NSObject {
     var paymentMethod : PaymentMethod!
     var cardInfo : CardInformationForm!
-
-    // TODO : OJO
-    weak var vc : SecrurityCodeViewController?
+    
+    var callback: ((_ cardInformation: CardInformation, _ securityCode: String) -> Void)?
     
     public init(paymentMethod : PaymentMethod, cardInfo : CardInformationForm){
         self.paymentMethod = paymentMethod
         self.cardInfo = cardInfo
-        
     }
     
     public func showFrontCard() -> Bool {
@@ -220,53 +211,12 @@ open class SecrurityCodeViewModel: NSObject {
         return paymentMethod.secCodeLenght()
     }
     
-    
-    func tokenAndCallback(secCode : String!){
-        if let token = cardInfo as? Token {
-            self.cloneTokenAndCallback(secCode: secCode)
-        }else{
-            self.createTokenAndCallback(secCode: secCode)
-        }
+    func executeCallback(secCode : String!) {
+        callback!(cardInfo as! CardInformation, secCode)
     }
-    func cloneTokenAndCallback(secCode : String!) {
-        
-        self.vc?.showLoading()
-        if let token = cardInfo as? Token {
-            MPServicesBuilder.cloneToken(token,securityCode:secCode, baseURL: MercadoPagoCheckoutViewModel.servicePreference.getGatewayURL(), success: { (token) in
-                self.vc?.hideLoading()
-                self.vc!.collectSecurityCodeCallback(token)
-                }, failure: { (error) in
-                    self.vc?.hideLoading()
-                    let mpError =  MPSDKError(message: "Hubo un error".localized, messageDetail: "", retry: false)
-                    self.vc?.displayFailure(mpError)
-            })
-        }
-       
-    }
-    
-    func createTokenAndCallback(secCode : String!) {
-        
-        self.vc?.showLoading()
-        let saveCardToken = SavedCardToken(card: cardInfo as! CardInformation, securityCode: secCode, securityCodeRequired: true)
-    
-        MPServicesBuilder.createToken(saveCardToken, baseURL: MercadoPagoCheckoutViewModel.servicePreference.getGatewayURL(), success: { (token) in
-            if token!.lastFourDigits.isEmpty {
-                token!.lastFourDigits = self.cardInfo.getCardLastForDigits()
-            }
-            self.vc!.hideLoading()
-            self.vc!.collectSecurityCodeCallback(token)
-            }, failure: { (error) in
-                self.vc!.hideLoading()
-                 let mpError =  MPSDKError(message: "Hubo un error".localized, messageDetail: "", retry: false)
-                self.vc!.displayFailure(mpError)
-           })
-
-        
-    }
-    
     
     func getCardHeight() -> CGFloat {
-        return getCardWidth()/12*7
+        return getCardWidth() / 12 * 7
     }
     
     func getCardWidth() -> CGFloat {

--- a/MercadoPagoSDK/MercadoPagoSDK/SecurityCodeViewController.xib
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecurityCodeViewController.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/MercadoPagoSDK/MercadoPagoSDK/Token.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Token.swift
@@ -160,6 +160,10 @@ open class Token : NSObject, CardInformationForm {
     public func isIssuerRequired() -> Bool {
         return true
     }
+    
+    public func canBeClone() -> Bool {
+        return true
+    }
 }
 
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -272,7 +272,7 @@
 }
 
 -(void)setDecorationPreference {
-    DecorationPreference *decorationPreference = [[DecorationPreference alloc] initWithBaseColor:[UIColor greenColor] fontName:@"fontName" fontLightName:@"fontName"];
+    DecorationPreference *decorationPreference = [[DecorationPreference alloc] initWithBaseColor:[UIColor fromHex:@"#CA254D"] fontName:@"fontName" fontLightName:@"fontName"];
     [MercadoPagoCheckout setDecorationPreference:decorationPreference];
 }
 


### PR DESCRIPTION
Fix #763 #762 #769 

##  Cambios introducidos : 
- Se sacan los api calls de creación de token de la pantalla SecurityCodeViewController
- Se agrega un loading en cardAdditionalStep mientras se carga en pantalla

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
