### PR TITLE
MPCheckout finish final step + reviewAndConfirm flag removed + unit tests

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		76151B871C73C025007DF0E3 /* InstructionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76151B861C73C025007DF0E3 /* InstructionsService.swift */; };
 		76151B881C73C025007DF0E3 /* InstructionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76151B861C73C025007DF0E3 /* InstructionsService.swift */; };
 		761765751E8303280070855D /* MercadoPagoCheckoutTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761765741E8303280070855D /* MercadoPagoCheckoutTest.swift */; };
+		761765771E83120C0070855D /* NextStepHelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761765761E83120C0070855D /* NextStepHelperTest.swift */; };
 		7619E93B1DF05E2900CEFAC1 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E93A1DF05E2900CEFAC1 /* Array+Extension.swift */; };
 		7619E9451DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */; };
 		7619E9461DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */; };
@@ -755,6 +756,7 @@
 		76134AB71C5BED2300A1BAF1 /* OfflinePaymentMethodCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OfflinePaymentMethodCell.xib; sourceTree = "<group>"; };
 		76151B861C73C025007DF0E3 /* InstructionsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionsService.swift; sourceTree = "<group>"; };
 		761765741E8303280070855D /* MercadoPagoCheckoutTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoCheckoutTest.swift; sourceTree = "<group>"; };
+		761765761E83120C0070855D /* NextStepHelperTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NextStepHelperTest.swift; sourceTree = "<group>"; };
 		7619E93A1DF05E2900CEFAC1 /* Array+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
 		7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentOptionDrawable.swift; sourceTree = "<group>"; };
 		761B89391C625C130015D0BE /* MercadoPagoUIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoUIViewController.swift; sourceTree = "<group>"; };
@@ -1509,6 +1511,7 @@
 				76FB70651E783D00008935DF /* MPCheckoutTestAction.swift */,
 				76294CF01E721BC600CEAE6D /* MercadoPagoCheckoutViewModelTest.swift */,
 				765E7CAE1E736A32003AE4CD /* WalletIntegrationTest.swift */,
+				761765761E83120C0070855D /* NextStepHelperTest.swift */,
 			);
 			name = MercadoPagoCheckout;
 			sourceTree = "<group>";
@@ -2407,6 +2410,7 @@
 				7622E32E1DF5EFF500490C4E /* PaymentResultViewController.swift in Sources */,
 				7672545F1C7CB14500EB5EBA /* CheckoutPreferenceTest.swift in Sources */,
 				155692D21C47DA1200521403 /* PaymentPreference.swift in Sources */,
+				761765771E83120C0070855D /* NextStepHelperTest.swift in Sources */,
 				157704B61DCBA1500038C550 /* SecurityCodeViewController.swift in Sources */,
 				0FC4FC341B0FB36F00CF7148 /* PromoTyCDetailTableViewCell.swift in Sources */,
 				15521E391E60A0B000148979 /* AppDecorationKeeper.swift in Sources */,

--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -506,7 +506,7 @@
 		76F41E2B1D3D4AB300B25E5B /* MPServicesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1F1D19752A00A86097 /* MPServicesBuilder.swift */; };
 		76F41E2E1D3D4B9600B25E5B /* MPFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B8C1E1D19752A00A86097 /* MPFlowController.swift */; };
 		76F41E301D3D5F5800B25E5B /* MercadoPagoTestContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F41E2F1D3D5F5800B25E5B /* MercadoPagoTestContext.swift */; };
-		76FB70641E77100C008935DF /* MPCheckoutTestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FB70631E77100C008935DF /* MPCheckoutTestAction.swift */; };
+		76FB70661E783D00008935DF /* MPCheckoutTestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FB70651E783D00008935DF /* MPCheckoutTestAction.swift */; };
 		76FD24791C5BFEA1008C5DC0 /* CardBackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FD24701C5BFEA1008C5DC0 /* CardBackView.swift */; };
 		76FD247A1C5BFEA1008C5DC0 /* CardBackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FD24701C5BFEA1008C5DC0 /* CardBackView.swift */; };
 		76FD247B1C5BFEA1008C5DC0 /* CardBackView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76FD24711C5BFEA1008C5DC0 /* CardBackView.xib */; };
@@ -864,7 +864,7 @@
 		76EEF75C1D674BA80095D5A5 /* CardInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardInformation.swift; sourceTree = "<group>"; };
 		76EF21E61E52C07700718ED2 /* ReviewScreenPreference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewScreenPreference.swift; sourceTree = "<group>"; };
 		76F41E2F1D3D5F5800B25E5B /* MercadoPagoTestContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoTestContext.swift; sourceTree = "<group>"; };
-		76FB70631E77100C008935DF /* MPCheckoutTestAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPCheckoutTestAction.swift; sourceTree = "<group>"; };
+		76FB70651E783D00008935DF /* MPCheckoutTestAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPCheckoutTestAction.swift; sourceTree = "<group>"; };
 		76FD24701C5BFEA1008C5DC0 /* CardBackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardBackView.swift; sourceTree = "<group>"; };
 		76FD24711C5BFEA1008C5DC0 /* CardBackView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CardBackView.xib; sourceTree = "<group>"; };
 		76FD24721C5BFEA1008C5DC0 /* CardFormViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardFormViewController.swift; sourceTree = "<group>"; };
@@ -1504,6 +1504,7 @@
 		76294CED1E72186600CEAE6D /* MercadoPagoCheckout */ = {
 			isa = PBXGroup;
 			children = (
+				76FB70651E783D00008935DF /* MPCheckoutTestAction.swift */,
 				76294CF01E721BC600CEAE6D /* MercadoPagoCheckoutViewModelTest.swift */,
 				765E7CAE1E736A32003AE4CD /* WalletIntegrationTest.swift */,
 			);
@@ -1661,7 +1662,6 @@
 				15A7B18B1C88B2E4007D0C4E /* MockManager.swift */,
 				760BD1F11C99ADE300FDA170 /* MockedResponse.plist */,
 				76F41E2F1D3D5F5800B25E5B /* MercadoPagoTestContext.swift */,
-				76FB70631E77100C008935DF /* MPCheckoutTestAction.swift */,
 			);
 			name = Mock;
 			sourceTree = "<group>";
@@ -2247,7 +2247,6 @@
 				76EC47EA1C8614B20086FA53 /* PaymentTest.swift in Sources */,
 				7622E33B1DF5F1D700490C4E /* ConfirmPaymentTableViewCell.swift in Sources */,
 				7656F5251C9726A60076A14D /* PaymentMethodSearchServiceTest.swift in Sources */,
-				76FB70641E77100C008935DF /* MPCheckoutTestAction.swift in Sources */,
 				76EC47D61C85E84F0086FA53 /* DiscountTest.swift in Sources */,
 				7622E3341DF5F04C00490C4E /* RejectedTableViewCell.swift in Sources */,
 				0FC4FC221B0FAF0E00CF7148 /* PromoTableViewCell.swift in Sources */,
@@ -2289,6 +2288,7 @@
 				0FC4FC191B0FAA6400CF7148 /* Promo.swift in Sources */,
 				15ABAD531DB5489D00481E8E /* GATracker.swift in Sources */,
 				0F9883901AD2AB6000F750F0 /* Refund.swift in Sources */,
+				76FB70661E783D00008935DF /* MPCheckoutTestAction.swift in Sources */,
 				76EC48041C862AD70086FA53 /* PaymentMethodSearchitemTest.swift in Sources */,
 				766012F01CF284A600897F9D /* WebViewController.swift in Sources */,
 				15ABAD5C1DB5489D00481E8E /* PaymentTrackInfo.swift in Sources */,

--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		76134ABB1C5BED2300A1BAF1 /* OfflinePaymentMethodCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 76134AB71C5BED2300A1BAF1 /* OfflinePaymentMethodCell.xib */; };
 		76151B871C73C025007DF0E3 /* InstructionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76151B861C73C025007DF0E3 /* InstructionsService.swift */; };
 		76151B881C73C025007DF0E3 /* InstructionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76151B861C73C025007DF0E3 /* InstructionsService.swift */; };
+		761765751E8303280070855D /* MercadoPagoCheckoutTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761765741E8303280070855D /* MercadoPagoCheckoutTest.swift */; };
 		7619E93B1DF05E2900CEFAC1 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E93A1DF05E2900CEFAC1 /* Array+Extension.swift */; };
 		7619E9451DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */; };
 		7619E9461DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */; };
@@ -524,10 +525,10 @@
 		76FD248A1C5BFEA1008C5DC0 /* TextFieldsEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FD24781C5BFEA1008C5DC0 /* TextFieldsEffects.swift */; };
 		CC8AA1501DC5612300503910 /* UILabel+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8AA14F1DC5612300503910 /* UILabel+Additions.swift */; };
 		CCDD005D1DC52E4200858CF8 /* PaymentMethodSearch.plist in Resources */ = {isa = PBXBuildFile; fileRef = CCDD005C1DC52E4100858CF8 /* PaymentMethodSearch.plist */; };
-		FC190A381E53879F003ACBE0 /* IdentificationTypes.plist in Resources */ = {isa = PBXBuildFile; fileRef = FC190A371E53879F003ACBE0 /* IdentificationTypes.plist */; };
-		FC190A391E53879F003ACBE0 /* IdentificationTypes.plist in Resources */ = {isa = PBXBuildFile; fileRef = FC190A371E53879F003ACBE0 /* IdentificationTypes.plist */; };
 		FC114D6B1E6DECEF00640196 /* Cellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC114D6A1E6DECEF00640196 /* Cellable.swift */; };
 		FC114D6C1E6DECEF00640196 /* Cellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC114D6A1E6DECEF00640196 /* Cellable.swift */; };
+		FC190A381E53879F003ACBE0 /* IdentificationTypes.plist in Resources */ = {isa = PBXBuildFile; fileRef = FC190A371E53879F003ACBE0 /* IdentificationTypes.plist */; };
+		FC190A391E53879F003ACBE0 /* IdentificationTypes.plist in Resources */ = {isa = PBXBuildFile; fileRef = FC190A371E53879F003ACBE0 /* IdentificationTypes.plist */; };
 		FCAA97001E6A0E0D000612F6 /* AdditionalStepViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAA96FF1E6A0E0D000612F6 /* AdditionalStepViewModel.swift */; };
 		FCAA97011E6A0E0D000612F6 /* AdditionalStepViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAA96FF1E6A0E0D000612F6 /* AdditionalStepViewModel.swift */; };
 		FCBF132D1E71D6A60092B756 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCBF132C1E71D6A60092B756 /* Updatable.swift */; };
@@ -753,6 +754,7 @@
 		76134AB61C5BED2300A1BAF1 /* OfflinePaymentMethodCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OfflinePaymentMethodCell.swift; sourceTree = "<group>"; };
 		76134AB71C5BED2300A1BAF1 /* OfflinePaymentMethodCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OfflinePaymentMethodCell.xib; sourceTree = "<group>"; };
 		76151B861C73C025007DF0E3 /* InstructionsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionsService.swift; sourceTree = "<group>"; };
+		761765741E8303280070855D /* MercadoPagoCheckoutTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoCheckoutTest.swift; sourceTree = "<group>"; };
 		7619E93A1DF05E2900CEFAC1 /* Array+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
 		7619E9441DF1B5D300CEFAC1 /* PaymentOptionDrawable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentOptionDrawable.swift; sourceTree = "<group>"; };
 		761B89391C625C130015D0BE /* MercadoPagoUIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MercadoPagoUIViewController.swift; sourceTree = "<group>"; };
@@ -875,11 +877,11 @@
 		76FD24781C5BFEA1008C5DC0 /* TextFieldsEffects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldsEffects.swift; sourceTree = "<group>"; };
 		CC8AA14F1DC5612300503910 /* UILabel+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UILabel+Additions.swift"; sourceTree = "<group>"; };
 		CCDD005C1DC52E4100858CF8 /* PaymentMethodSearch.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PaymentMethodSearch.plist; sourceTree = "<group>"; };
+		FC114D6A1E6DECEF00640196 /* Cellable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cellable.swift; sourceTree = "<group>"; };
 		FC1841CC1E7722E100EEBD18 /* es-UY */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-UY"; path = "es-UY.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		FC1841CD1E77238500EEBD18 /* es-VE */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-VE"; path = "es-VE.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		FC190A371E53879F003ACBE0 /* IdentificationTypes.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = IdentificationTypes.plist; path = MercadoPagoSDK/IdentificationTypes.plist; sourceTree = "<group>"; };
 		FC814BF31E54BEE100475474 /* es-PE */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-PE"; path = "es-PE.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		FC114D6A1E6DECEF00640196 /* Cellable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cellable.swift; sourceTree = "<group>"; };
 		FCAA96FF1E6A0E0D000612F6 /* AdditionalStepViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdditionalStepViewModel.swift; sourceTree = "<group>"; };
 		FCBF132C1E71D6A60092B756 /* Updatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Updatable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1356,7 +1358,6 @@
 				4BAA55E31DAFFBAC00501061 /* AdditionalStep */,
 				157704B31DCBA1500038C550 /* SecurityCodeViewController.swift */,
 				157704B41DCBA1500038C550 /* SecurityCodeViewController.xib */,
-
 			);
 			name = Revamp;
 			sourceTree = "<group>";
@@ -1504,6 +1505,7 @@
 		76294CED1E72186600CEAE6D /* MercadoPagoCheckout */ = {
 			isa = PBXGroup;
 			children = (
+				761765741E8303280070855D /* MercadoPagoCheckoutTest.swift */,
 				76FB70651E783D00008935DF /* MPCheckoutTestAction.swift */,
 				76294CF01E721BC600CEAE6D /* MercadoPagoCheckoutViewModelTest.swift */,
 				765E7CAE1E736A32003AE4CD /* WalletIntegrationTest.swift */,
@@ -2279,6 +2281,7 @@
 				76EC47DE1C85E9CC0086FA53 /* IssuerTest.swift in Sources */,
 				4B53C5FA1E4B3FDD00D6190A /* PaymentData.swift in Sources */,
 				15DA7E5F1CD92C670068896E /* IdentificationViewController.swift in Sources */,
+				761765751E8303280070855D /* MercadoPagoCheckoutTest.swift in Sources */,
 				7622E3331DF5F04700490C4E /* CallForAuthTableViewCell.swift in Sources */,
 				0F9883861AD2AB6000F750F0 /* PayerCost.swift in Sources */,
 				15B8B1AC1E71DE750065DF50 /* DiscountCoupon.swift in Sources */,

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -37,13 +37,6 @@ open class MercadoPagoCheckout: NSObject {
         executeNextStep()
     }
     
-    public func getRootViewController() -> UIViewController {
-        MercadoPagoCheckout.firstViewControllerPushed = false
-        self.pushRootLoading()
-        self.start()
-        return self.currentLoadingView!
-    }
-    
     func executeNextStep(){
         switch self.viewModel.nextStep() {
         case .SEARCH_PREFERENCE :

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -306,7 +306,6 @@ open class MercadoPagoCheckout: NSObject {
 
     
     func collectPaymentData() {
-        if self.viewModel.reviewAndConfirm {
             let checkoutVC = CheckoutViewController(viewModel: self.viewModel.checkoutViewModel(), callbackPaymentData: {(paymentData : PaymentData) -> Void in
                 self.viewModel.updateCheckoutModel(paymentData: paymentData)
                 if paymentData.paymentMethod == nil && MercadoPagoCheckoutViewModel.changePaymentMethodCallback != nil {
@@ -330,11 +329,6 @@ open class MercadoPagoCheckout: NSObject {
                 self.cleanNavigationStack()
             }
             CATransaction.commit();
-        } else {
-            // Caso en que RyC esté deshabilitada
-            self.executePaymentDataCallback()
-        }
-
     }
 	
 	func cleanNavigationStack () {
@@ -462,7 +456,12 @@ open class MercadoPagoCheckout: NSObject {
         ReviewScreenPreference.clear()
         PaymentResultScreenPreference.clear()
         DecorationPreference.applyAppNavBarDecorationPreferencesTo(navigationController: self.navigationController)
-        if let payment = self.viewModel.payment, let paymentCallback = MercadoPagoCheckoutViewModel.paymentCallback {
+        
+        
+        
+        if self.viewModel.paymentData.isComplete() && !MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable() && MercadoPagoCheckoutViewModel.paymentDataCallback != nil {
+            MercadoPagoCheckoutViewModel.paymentDataCallback!(self.viewModel.paymentData)
+        } else if let payment = self.viewModel.payment, let paymentCallback = MercadoPagoCheckoutViewModel.paymentCallback {
             paymentCallback(payment)
         } else if let callback = MercadoPagoCheckoutViewModel.callback {
             callback()
@@ -477,6 +476,8 @@ open class MercadoPagoCheckout: NSObject {
                 self.navigationController.setNavigationBarHidden(false, animated: false)
             })
         }
+        
+        MercadoPagoCheckoutViewModel.flowPreference = FlowPreference()
     }
     
     

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -19,6 +19,7 @@ open class MercadoPagoCheckout: NSObject {
     
     internal static var firstViewControllerPushed = false
     private var rootViewController : UIViewController?
+    private var sdkRootViewController : MercadoPagoUIViewController?
     
     public init(checkoutPreference : CheckoutPreference, paymentData : PaymentData? = nil, discount: DiscountCoupon? = nil, navigationController : UINavigationController, paymentResult: PaymentResult? = nil) {
         viewModel = MercadoPagoCheckoutViewModel(checkoutPreference : checkoutPreference, paymentData: paymentData, paymentResult: paymentResult, discount : discount)
@@ -323,12 +324,10 @@ open class MercadoPagoCheckout: NSObject {
                     self.executeNextStep()
                 }
             })
-            self.navigationController.pushViewController(checkoutVC, animated: true);
-            CATransaction.begin();
-            CATransaction.setCompletionBlock {
-                self.cleanNavigationStack()
-            }
-            CATransaction.commit();
+        
+        self.pushViewController(viewController: checkoutVC, animated: true, completion: {
+            self.cleanNavigationStack()
+        })
     }
 	
 	func cleanNavigationStack () {
@@ -337,6 +336,8 @@ open class MercadoPagoCheckout: NSObject {
         var  newNavigationStack = self.navigationController.viewControllers.filter {!$0.isKind(of:MercadoPagoUIViewController.self) || $0.isKind(of:CheckoutViewController.self);
         }
         self.navigationController.viewControllers = newNavigationStack;
+        // Actualizar rootVC de sdk
+        self.sdkRootViewController = self.navigationController.viewControllers[0] as? MercadoPagoUIViewController
         
 	}
 	
@@ -514,7 +515,23 @@ open class MercadoPagoCheckout: NSObject {
     }
     
     private func pushViewController(viewController: UIViewController,
-                                   animated: Bool) {
+                                    animated: Bool,
+                                    completion : (() -> Swift.Void)? = nil) {
+        
+        viewController.hidesBottomBarWhenPushed = true
+        CATransaction.begin()
+        CATransaction.setCompletionBlock {
+            if !viewController.isKind(of: MPXLoadingViewController.self) && self.sdkRootViewController == nil {
+                self.sdkRootViewController = viewController as? MercadoPagoUIViewController
+                self.sdkRootViewController!.callbackCancel = {
+                    self.finish()
+                }
+                if let _ = completion {
+                    completion!()
+                }
+            }
+        }
+        CATransaction.commit();
         self.navigationController.pushViewController(viewController, animated: animated)
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -116,6 +116,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     public func cardFormManager() -> CardViewModelManager{
         let paymentPreference = PaymentPreference()
         paymentPreference.defaultPaymentTypeId = self.paymentOptionSelected?.getId()
+        // TODO : está bien que la paymentPreference se cree desde cero? puede que vengan exclusiones de entrada ya?
         return CardViewModelManager(amount : self.getAmount(), paymentMethods: search?.paymentMethods, paymentSettings : paymentPreference)
     }
     
@@ -322,7 +323,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
         }
         
         if self.search!.getPaymentOptionsCount() == 1 {
-            if self.search!.groups.count == 1 {
+            if !Array.isNullOrEmpty(self.search!.groups) && self.search!.groups.count == 1 {
                 self.updateCheckoutModel(paymentOptionSelected: self.search!.groups[0])
             } else {
                 let customOption = self.search!.customerPaymentMethods![0] as! PaymentMethodOption

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -208,13 +208,8 @@ open class MercadoPagoCheckoutViewModel: NSObject {
         
         if self.paymentOptionSelected!.isCustomerPaymentMethod() {
             self.findAndCompletePaymentMethodFor(paymentMethodId: paymentOptionSelected.getId())
-            if self.paymentOptionSelected!.getId() == PaymentTypeId.ACCOUNT_MONEY.rawValue {
-                //self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
-            }
-        
         } else if !paymentOptionSelected.isCard() && !paymentOptionSelected.hasChildren() {
             self.paymentData.paymentMethod = Utils.findPaymentMethod(self.availablePaymentMethods!, paymentMethodId: paymentOptionSelected.getId())
-            //self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
         }
         
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -68,10 +68,6 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     var customPaymentOptions : [CardInformation]?
     
     var rootVC = true
-    
-    var next : CheckoutStep = .SEARCH_PAYMENT_METHODS
-    
-    let cardViewRect = CGRect(x: 0, y: 0, width: 100, height: 30)
 
     var paymentData = PaymentData()
     var payment : Payment?
@@ -86,7 +82,6 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     private var needLoadPreference : Bool = false
     internal var readyToPay : Bool = false
     private var checkoutComplete = false
-    internal var reviewAndConfirm = false
     internal var initWithPaymentData = false
     
     init(checkoutPreference : CheckoutPreference, paymentData : PaymentData?, paymentResult: PaymentResult?, discount: DiscountCoupon?) {
@@ -94,7 +89,6 @@ open class MercadoPagoCheckoutViewModel: NSObject {
         if let pm = paymentData{
             if pm.isComplete() {
                 self.paymentData = pm
-                self.reviewAndConfirm = true
                 self.initWithPaymentData = true
             }
         }
@@ -215,12 +209,12 @@ open class MercadoPagoCheckoutViewModel: NSObject {
         if self.paymentOptionSelected!.isCustomerPaymentMethod() {
             self.findAndCompletePaymentMethodFor(paymentMethodId: paymentOptionSelected.getId())
             if self.paymentOptionSelected!.getId() == PaymentTypeId.ACCOUNT_MONEY.rawValue {
-                self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
+                //self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
             }
         
         } else if !paymentOptionSelected.isCard() && !paymentOptionSelected.hasChildren() {
             self.paymentData.paymentMethod = Utils.findPaymentMethod(self.availablePaymentMethods!, paymentMethodId: paymentOptionSelected.getId())
-            self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
+            //self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
         }
         
     }
@@ -232,7 +226,6 @@ open class MercadoPagoCheckoutViewModel: NSObject {
             needLoadPreference = false
             return .SEARCH_PREFERENCE
         }
-        
         
         if hasError() {
             return .ERROR
@@ -254,7 +247,12 @@ open class MercadoPagoCheckoutViewModel: NSObject {
             return .PAYMENT_METHOD_SELECTION
         }
         
-        if reviewAndConfirm {
+        if readyToPay {
+            readyToPay = false
+            return .POST_PAYMENT
+        }
+
+        if needReviewAndConfirm() {
             return .REVIEW_AND_CONFIRM
         }
         
@@ -293,12 +291,8 @@ open class MercadoPagoCheckoutViewModel: NSObject {
             return .CREATE_CARD_TOKEN
         }
         
-        if readyToPay {
-            readyToPay = false
-            return .POST_PAYMENT
-        }
         
-        return .REVIEW_AND_CONFIRM
+        return .FINISH
 
 
     }
@@ -346,12 +340,12 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     
     
     public func updateCheckoutModel(token : Token) {
-        let lastForDigits = self.paymentData.token?.lastFourDigits
+        
         self.paymentData.token = token
-        if lastForDigits != nil {
-           self.paymentData.token?.lastFourDigits = lastForDigits
+        let lastFourDigits = self.paymentData.token!.lastFourDigits
+        if lastFourDigits != nil {
+           self.paymentData.token?.lastFourDigits = lastFourDigits
         }
-        self.reviewAndConfirm = MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
     }
 
     public class func createMPPayment(_ email : String, preferenceId : String, paymentData : PaymentData, customerId : String? = nil) -> MPPayment {
@@ -383,7 +377,6 @@ open class MercadoPagoCheckoutViewModel: NSObject {
             self.rootPaymentMethodOptions = paymentMethodOptions
         }
         self.paymentMethodOptions = self.rootPaymentMethodOptions
-        self.next = .PAYMENT_METHOD_SELECTION
     }
     
     func updateCheckoutModel(paymentData: PaymentData){
@@ -401,7 +394,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
         } else {
             self.readyToPay = true
         }
-        self.reviewAndConfirm = false
+    
     }
     
     public func updateCheckoutModel(payment : Payment) {

--- a/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NextStepHelper.swift
@@ -144,8 +144,25 @@ extension MercadoPagoCheckoutViewModel {
         return self.paymentData.token == nil && pm.isCard()
     }
     
+    func needReviewAndConfirm() -> Bool {
+        
+        guard let _ = self.paymentOptionSelected else {
+            return false
+        }
+        
+        if paymentData.isComplete() {
+            return MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable()
+        }
+        
+        return false
+    }
+    
     func shouldShowCongrats() -> Bool {
-        return self.payment != nil || self.paymentResult != nil
+        if (self.payment != nil || self.paymentResult != nil) {
+            self.setIsCheckoutComplete(isCheckoutComplete: true)
+            return true
+        }
+        return false
     }
     
     func shouldExitCheckout() -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/Payment.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Payment.swift
@@ -83,16 +83,16 @@ open class Payment : NSObject {
             payment.currencyId = currencyId
         }
         if let moneyReleaseDate = JSONHandler.attemptParseToString(json["money_release_date"]){
-            payment.moneyReleaseDate = getDateFromString(moneyReleaseDate)
+            payment.moneyReleaseDate = Utils.getDateFromString(moneyReleaseDate)
         }
         if let dateCreated = JSONHandler.attemptParseToString(json["date_created"]){
-            payment.dateCreated = getDateFromString(dateCreated)
+            payment.dateCreated = Utils.getDateFromString(dateCreated)
         }
         if let dateLastUpdated = JSONHandler.attemptParseToString(json["date_last_updated"]){
-            payment.dateLastUpdated = getDateFromString(dateLastUpdated)
+            payment.dateLastUpdated = Utils.getDateFromString(dateLastUpdated)
         }
         if let dateApproved = JSONHandler.attemptParseToString(json["date_approved"]){
-            payment.dateApproved = getDateFromString(dateApproved)
+            payment.dateApproved = Utils.getDateFromString(dateApproved)
         }
         if let _description = JSONHandler.attemptParseToString(json["description"]){
             payment._description = _description
@@ -198,16 +198,6 @@ open class Payment : NSObject {
         ]
         
         return JSONHandler.jsonCoding(obj)
-    }
-    
-    open class func getDateFromString(_ string: String!) -> Date! {
-        if string == nil {
-            return nil
-        }
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        var dateArr = string.characters.split {$0 == "T"}.map(String.init)
-        return dateFormatter.date(from: dateArr[0])
     }
     
     open func isRejected() -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentData.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentData.swift
@@ -38,7 +38,7 @@ public class PaymentData: NSObject {
         
         if paymentMethod!.isCard() && (token == nil || payerCost == nil) {
             
-            if paymentMethod.paymentTypeId == "debit_card" && token != nil{
+            if paymentMethod.paymentTypeId == PaymentTypeId.DEBIT_CARD.rawValue && token != nil{
                 return true
             }
             return false

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearch.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSearch.swift
@@ -80,14 +80,16 @@ open class PaymentMethodSearch: Equatable {
  
     func getPaymentOptionsCount() -> Int {
         let customOptionsCount = (self.customerPaymentMethods != nil) ? self.customerPaymentMethods!.count : 0
-        return customOptionsCount + self.groups.count
+        let groupsOptionsCount = (self.groups != nil) ? self.groups!.count : 0
+        return customOptionsCount + groupsOptionsCount
     }
     
 }
 
 public func ==(obj1: PaymentMethodSearch, obj2: PaymentMethodSearch) -> Bool {
     let areEqual =
-    obj1.groups == obj2.groups &&
+        ((obj1.groups == nil && obj2.groups == nil) ||
+    obj1.groups == obj2.groups) &&
     obj1.paymentMethods == obj2.paymentMethods
     return areEqual
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CardViewModelManagerTest.swift
@@ -14,6 +14,8 @@ class CardViewModelManagerTest: BaseTest {
     
     override func setUp() {
         super.setUp()
+        // Retomar valor default
+        CardFormViewController.showBankDeals = true
     }
     
     override func tearDown() {
@@ -130,6 +132,8 @@ class CardViewModelManagerTest: BaseTest {
         self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentSettings: nil)
         self.cardFormManager!.promos = [MockBuilder.buildPromo()]
         let result = self.cardFormManager!.showBankDeals()
+        
+        
         XCTAssertTrue(result)
     }
     
@@ -233,14 +237,14 @@ class CardViewModelManagerTest: BaseTest {
     
     func testBuildSavedCardToken(){
         let customerCard = MockBuilder.buildCard()
-     /*   self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: customerCard, token: nil, paymentSettings: nil)
-        self.cardFormManager?.buildSavedCardToken("cvv")
+        self.cardFormManager = CardViewModelManager(amount: 10, paymentMethods: nil, paymentMethod: nil, customerCard: customerCard, token: nil, paymentSettings: nil)
+        self.cardFormManager!.buildSavedCardToken("cvv")
         
         let savedCardToken = self.cardFormManager!.cardToken as! SavedCardToken
         let savedCardtokenCardId = savedCardToken.cardId
-        //XCTAssertEqual(savedCardtokenCardId, customerCard.idCard)
+        XCTAssertEqual(savedCardtokenCardId, customerCard.getCardId())
         XCTAssertEqual(savedCardToken.securityCode, "cvv")
-        XCTAssertEqual(savedCardToken.securityCodeRequired, customerCard.isSecurityCodeRequired())*/
+        XCTAssertEqual(savedCardToken.securityCodeRequired, customerCard.isSecurityCodeRequired())
     }
     
     func testIsValidInputCVV() {

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewControllerTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewControllerTest.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class CheckoutViewControllerTest: BaseTest {
     
- /*   var checkoutViewController : MockCheckoutViewController?
+    var checkoutViewController : MockCheckoutViewController?
     var preference : CheckoutPreference?
     var selectedPaymentMethod : PaymentMethod?
     var selectedPayerCost : PayerCost?
@@ -20,13 +20,13 @@ class CheckoutViewControllerTest: BaseTest {
     
     override func setUp() {
         super.setUp()
-        self.checkoutViewController = MockCheckoutViewController(preferenceId: MockBuilder.PREF_ID_NO_EXCLUSIONS, callback: { (payment) in
-            
-        })
+//        self.checkoutViewController = MockCheckoutViewController(preferenceId: MockBuilder.PREF_ID_NO_EXCLUSIONS, callback: { (payment) in
+//            
+//        })
 
     }
     
-    override func tearDown() {
+/*    override func tearDown() {
         super.tearDown()
     }
     
@@ -477,6 +477,21 @@ class CheckoutViewModelTest : BaseTest {
         let preference = MockBuilder.buildCheckoutPreference()
         self.instance!.preference = preference
         XCTAssertTrue(self.instance!.isPreferenceLoaded())
+    }
+    
+    func testGetTotalAmount() {
+        let paymentMethodCreditCard = MockBuilder.buildPaymentMethod("master", name: "master", paymentTypeId: PaymentTypeId.CREDIT_CARD.rawValue)
+        self.instance!.paymentData.paymentMethod = paymentMethodCreditCard
+        self.instance!.paymentData.payerCost = MockBuilder.buildPayerCost()
+        self.instance!.paymentData.payerCost!.totalAmount = 10
+        var totalAmount = self.instance!.getTotalAmount()
+        XCTAssertEqual(totalAmount, self.instance!.paymentData.payerCost!.totalAmount)
+        
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        self.instance!.preference = checkoutPreference
+        self.instance!.paymentData.payerCost = nil
+        totalAmount = self.instance!.getTotalAmount()
+        XCTAssertEqual(totalAmount, checkoutPreference.getAmount())
     }
     
     func testShouldDisplayNoRate(){

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MPCheckoutTestAction.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MPCheckoutTestAction.swift
@@ -25,7 +25,6 @@ class MPCheckoutTestAction: NSObject {
     static func selectAccountMoney(mpCheckout : MercadoPagoCheckout){
         let accountMoneyOption = MockBuilder.buildCustomerPaymentMethod("account_money", paymentMethodId : "account_money")
         mpCheckout.viewModel.updateCheckoutModel(paymentOptionSelected: accountMoneyOption as! PaymentMethodOption)
-        
     }
     
     static func selectCreditCardOption(mpCheckout : MercadoPagoCheckout){
@@ -33,5 +32,9 @@ class MPCheckoutTestAction: NSObject {
         mpCheckout.viewModel.paymentOptionSelected = creditCardOption
     }
     
+    static func selectCustomerCardOption(mpCheckout : MercadoPagoCheckout){
+        let customerCardOption = MockBuilder.buildCustomerPaymentMethod("customerCardId", paymentMethodId: "visa")
+        mpCheckout.viewModel.updateCheckoutModel(paymentOptionSelected: customerCardOption as! PaymentMethodOption)
+    }
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MPCheckoutTestAction.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MPCheckoutTestAction.swift
@@ -44,13 +44,16 @@ class MPCheckoutTestAction: NSObject {
     
     static func loadGroupsInViewModel(mpCheckoutViewModel : MercadoPagoCheckoutViewModel) {
         
+        
         let accountMoneyOption = MockBuilder.buildCustomerPaymentMethod("account_money", paymentMethodId : "account_money")
         let customerCardOption = MockBuilder.buildCustomerPaymentMethod("customerCardId", paymentMethodId: "visa")
         let creditCardOption = MockBuilder.buildPaymentMethodSearchItem("credit_card", type: PaymentMethodSearchItemType.PAYMENT_TYPE)
+        let offlineOption = MockBuilder.buildPaymentMethodSearchItem("off", type: PaymentMethodSearchItemType.PAYMENT_METHOD)
         let paymentMethodVisa = MockBuilder.buildPaymentMethod("visa")
         let paymentMethodAM = MockBuilder.buildPaymentMethod("account_money", paymentTypeId: "account_money")
+        let offlinePaymentMethod = MockBuilder.buildPaymentMethod("off", paymentTypeId : PaymentTypeId.TICKET.rawValue)
         
-        let paymentMethodSearchMock = MockBuilder.buildPaymentMethodSearch(groups : [creditCardOption], paymentMethods : [paymentMethodVisa, paymentMethodAM], customOptions : [customerCardOption, accountMoneyOption])
+        let paymentMethodSearchMock = MockBuilder.buildPaymentMethodSearch(groups : [creditCardOption, offlineOption], paymentMethods : [paymentMethodVisa, paymentMethodAM, offlinePaymentMethod], customOptions : [customerCardOption, accountMoneyOption])
         mpCheckoutViewModel.updateCheckoutModel(paymentMethodSearch: paymentMethodSearchMock)
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MPCheckoutTestAction.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MPCheckoutTestAction.swift
@@ -12,6 +12,38 @@ class MPCheckoutTestAction: NSObject {
 
     
     static func loadGroupsInViewModel(mpCheckout : MercadoPagoCheckout) {
+        MPCheckoutTestAction.loadGroupsInViewModel(mpCheckoutViewModel : mpCheckout.viewModel)
+    }
+    
+    static func selectAccountMoney(mpCheckout : MercadoPagoCheckout){
+        MPCheckoutTestAction.selectAccountMoney(mpCheckoutViewModel: mpCheckout.viewModel)
+    }
+    
+    static func selectCreditCardOption(mpCheckout : MercadoPagoCheckout){
+        MPCheckoutTestAction.selectCreditCardOption(mpCheckoutViewModel : mpCheckout.viewModel)
+    }
+    
+    static func selectCustomerCardOption(mpCheckout : MercadoPagoCheckout){
+        MPCheckoutTestAction.selectCustomerCardOption(mpCheckoutViewModel: mpCheckout.viewModel)
+    }
+    
+    static func selectAccountMoney(mpCheckoutViewModel : MercadoPagoCheckoutViewModel){
+        let accountMoneyOption = MockBuilder.buildCustomerPaymentMethod("account_money", paymentMethodId : "account_money")
+        mpCheckoutViewModel.updateCheckoutModel(paymentOptionSelected: accountMoneyOption as! PaymentMethodOption)
+    }
+    
+    static func selectCreditCardOption(mpCheckoutViewModel : MercadoPagoCheckoutViewModel){
+        let creditCardOption = MockBuilder.buildPaymentMethodSearchItem("credit_card", type: PaymentMethodSearchItemType.PAYMENT_TYPE)
+        mpCheckoutViewModel.paymentOptionSelected = creditCardOption
+    }
+    
+    static func selectCustomerCardOption(mpCheckoutViewModel : MercadoPagoCheckoutViewModel){
+        let customerCardOption = MockBuilder.buildCustomerPaymentMethod("customerCardId", paymentMethodId: "visa")
+        mpCheckoutViewModel.updateCheckoutModel(paymentOptionSelected: customerCardOption as! PaymentMethodOption)
+    }
+    
+    static func loadGroupsInViewModel(mpCheckoutViewModel : MercadoPagoCheckoutViewModel) {
+        
         let accountMoneyOption = MockBuilder.buildCustomerPaymentMethod("account_money", paymentMethodId : "account_money")
         let customerCardOption = MockBuilder.buildCustomerPaymentMethod("customerCardId", paymentMethodId: "visa")
         let creditCardOption = MockBuilder.buildPaymentMethodSearchItem("credit_card", type: PaymentMethodSearchItemType.PAYMENT_TYPE)
@@ -19,22 +51,7 @@ class MPCheckoutTestAction: NSObject {
         let paymentMethodAM = MockBuilder.buildPaymentMethod("account_money", paymentTypeId: "account_money")
         
         let paymentMethodSearchMock = MockBuilder.buildPaymentMethodSearch(groups : [creditCardOption], paymentMethods : [paymentMethodVisa, paymentMethodAM], customOptions : [customerCardOption, accountMoneyOption])
-        mpCheckout.viewModel.updateCheckoutModel(paymentMethodSearch: paymentMethodSearchMock)
-    }
-    
-    static func selectAccountMoney(mpCheckout : MercadoPagoCheckout){
-        let accountMoneyOption = MockBuilder.buildCustomerPaymentMethod("account_money", paymentMethodId : "account_money")
-        mpCheckout.viewModel.updateCheckoutModel(paymentOptionSelected: accountMoneyOption as! PaymentMethodOption)
-    }
-    
-    static func selectCreditCardOption(mpCheckout : MercadoPagoCheckout){
-        let creditCardOption = MockBuilder.buildPaymentMethodSearchItem("credit_card", type: PaymentMethodSearchItemType.PAYMENT_TYPE)
-        mpCheckout.viewModel.paymentOptionSelected = creditCardOption
-    }
-    
-    static func selectCustomerCardOption(mpCheckout : MercadoPagoCheckout){
-        let customerCardOption = MockBuilder.buildCustomerPaymentMethod("customerCardId", paymentMethodId: "visa")
-        mpCheckout.viewModel.updateCheckoutModel(paymentOptionSelected: customerCardOption as! PaymentMethodOption)
+        mpCheckoutViewModel.updateCheckoutModel(paymentMethodSearch: paymentMethodSearchMock)
     }
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutTest.swift
@@ -1,0 +1,197 @@
+//
+//  MercadoPagoCheckoutTest.swift
+//  MercadoPagoSDK
+//
+//  Created by Maria cristina rodriguez on 3/17/17.
+//  Copyright © 2017 MercadoPago. All rights reserved.
+//
+
+import XCTest
+
+class MercadoPagoCheckoutTest: BaseTest {
+    
+    var mpCheckout : MercadoPagoCheckout?
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        self.mpCheckout = nil
+    }
+    
+    /********************************/
+    /***** Init checkout tests ******/
+    /********************************/
+    
+    func testInit_withCheckoutPreference() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        XCTAssertNotNil(self.mpCheckout!.viewModel)
+        XCTAssertNotNil(self.mpCheckout!.viewModel.checkoutPreference)
+        XCTAssertFalse(self.mpCheckout!.viewModel.paymentData.isComplete())
+        XCTAssertNil(self.mpCheckout!.viewModel.paymentResult)
+        XCTAssertEqual(self.mpCheckout!.navigationController, navControllerInstance)
+        
+    }
+    
+    func testInit_withPaymentData() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let paymentMethod = MockBuilder.buildPaymentMethod("visa")
+        let paymentData = MockBuilder.buildPaymentData(paymentMethod: paymentMethod)
+        paymentData.payerCost = MockBuilder.buildPayerCost()
+        paymentData.token = MockBuilder.buildToken()
+        let navControllerInstance = UINavigationController()
+        
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, paymentData : paymentData, navigationController: navControllerInstance)
+        
+        XCTAssertNotNil(self.mpCheckout!.viewModel)
+        XCTAssertNotNil(self.mpCheckout!.viewModel.checkoutPreference)
+        XCTAssertEqual(self.mpCheckout!.viewModel.paymentData.paymentMethod, paymentMethod)
+        XCTAssertNil(self.mpCheckout!.viewModel.paymentResult)
+        XCTAssertEqual(self.mpCheckout!.navigationController, navControllerInstance)
+    }
+    
+    func testInit_withPaymentResult() {
+        
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let paymentMethod = MockBuilder.buildPaymentMethod("visa")
+        let paymentData = MockBuilder.buildPaymentData(paymentMethod: paymentMethod)
+        paymentData.payerCost = MockBuilder.buildPayerCost()
+        paymentData.token = MockBuilder.buildToken()
+        
+        let navControllerInstance = UINavigationController()
+        let paymentResult = MockBuilder.buildPaymentResult(paymentMethodId: "visa")
+        
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, paymentData : paymentData, navigationController: navControllerInstance, paymentResult : paymentResult)
+        
+        XCTAssertNotNil(self.mpCheckout!.viewModel)
+        XCTAssertNotNil(self.mpCheckout!.viewModel.checkoutPreference)
+        XCTAssertEqual(self.mpCheckout!.viewModel.paymentData.paymentMethod, paymentMethod)
+        XCTAssertNotNil(self.mpCheckout!.viewModel.paymentResult)
+        XCTAssertEqual(self.mpCheckout!.navigationController, navControllerInstance)
+    }
+    
+    /*******************************************/
+    /***** Display view controllers tests ******/
+    /*******************************************/
+    
+    func testCollectPaymentMethods(){
+        
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        
+        MPCheckoutTestAction.loadGroupsInViewModel(mpCheckout: self.mpCheckout!)
+        
+        self.mpCheckout?.collectPaymentMethods()
+        
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.paymentMethod)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.payerCost)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.token)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.issuer)
+        XCTAssertEqual(self.mpCheckout?.navigationController.viewControllers.count, 1)
+        let lastVC = self.mpCheckout!.navigationController.viewControllers[0]
+        XCTAssertTrue(lastVC.isKind(of: PaymentVaultViewController.self))
+    }
+    
+    func testCollectCard(){
+        
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        
+        self.mpCheckout?.collectCard()
+        
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.paymentMethod)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.payerCost)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.token)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.issuer)
+        XCTAssertEqual(self.mpCheckout?.navigationController.viewControllers.count, 1)
+        let lastVC = self.mpCheckout!.navigationController.viewControllers[0]
+        XCTAssertTrue(lastVC.isKind(of: CardFormViewController.self))
+    }
+    
+    func testCollectIdentification() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        
+        self.mpCheckout?.collectIdentification()
+        
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.paymentMethod)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.payerCost)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.token)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.issuer)
+        XCTAssertEqual(self.mpCheckout?.navigationController.viewControllers.count, 1)
+        let lastVC = self.mpCheckout!.navigationController.viewControllers[0]
+        XCTAssertTrue(lastVC.isKind(of: IdentificationViewController.self))
+    }
+    
+    func testCollectCreditDebit() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        
+        self.mpCheckout?.collectCreditDebit()
+        
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.paymentMethod)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.payerCost)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.token)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.issuer)
+        XCTAssertEqual(self.mpCheckout?.navigationController.viewControllers.count, 1)
+        let lastVC = self.mpCheckout!.navigationController.viewControllers[0]
+        XCTAssertTrue(lastVC.isKind(of: AdditionalStepViewController.self))
+    }
+    
+    func testStartIssuersScreen() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        
+        self.mpCheckout?.collectCreditDebit()
+        
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.paymentMethod)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.payerCost)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.token)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.issuer)
+        XCTAssertEqual(self.mpCheckout?.navigationController.viewControllers.count, 1)
+        let lastVC = self.mpCheckout!.navigationController.viewControllers[0]
+        XCTAssertTrue(lastVC.isKind(of: AdditionalStepViewController.self))
+    }
+    
+    func testStartPayerCostScreen(){
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        
+        self.mpCheckout?.collectCreditDebit()
+        
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.paymentMethod)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.payerCost)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.token)
+        XCTAssertNil(self.mpCheckout?.viewModel.paymentData.issuer)
+        XCTAssertEqual(self.mpCheckout?.navigationController.viewControllers.count, 1)
+        let lastVC = self.mpCheckout!.navigationController.viewControllers[0]
+        XCTAssertTrue(lastVC.isKind(of: AdditionalStepViewController.self))
+    }
+    
+    func testCollectPaymentData(){
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        
+        MPCheckoutTestAction.loadGroupsInViewModel(mpCheckout: self.mpCheckout!)
+        MPCheckoutTestAction.selectAccountMoney(mpCheckout: self.mpCheckout!)
+        
+        self.mpCheckout?.collectPaymentData()
+        
+        XCTAssertNotNil(self.mpCheckout?.viewModel.paymentData.paymentMethod)
+        XCTAssertEqual(self.mpCheckout?.navigationController.viewControllers.count, 1)
+        let lastVC = self.mpCheckout!.navigationController.viewControllers[0]
+        XCTAssertTrue(lastVC.isKind(of: CheckoutViewController.self))
+    }
+    
+}

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutViewModelTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutViewModelTest.swift
@@ -16,7 +16,6 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     }
     
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
     
@@ -385,7 +384,55 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
 
         
     }
-
+    
+    /****************************************************/
+    /********** ViewModel Builders Tests ****************/
+    /****************************************************/
+    
+    func testHasError(){
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        
+        XCTAssertFalse(mpCheckout.viewModel.hasError())
+        
+        let error = MPSDKError()
+        MercadoPagoCheckoutViewModel.error = error
+        
+        XCTAssertTrue(mpCheckout.viewModel.hasError())
+        
+        MercadoPagoCheckoutViewModel.error = nil
+        
+    }
+    
+    func testIssuerViewModel(){
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil)
+        
+        // Simular installments
+        let issuer = MockBuilder.buildIssuer()
+        mpCheckoutViewModel.issuers = [issuer]
+        mpCheckoutViewModel.installment = MockBuilder.buildInstallment()
+        
+        let issuerVM = mpCheckoutViewModel.issuerViewModel()
+        XCTAssertTrue(issuerVM.isKind(of: IssuerAdditionalStepViewModel.self))
+        XCTAssertEqual(issuerVM.amount, checkoutPreference.getAmount())
+        
+    }
+    
+    func testPayerCostViewModel(){
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil)
+        
+        let issuer = MockBuilder.buildIssuer()
+        mpCheckoutViewModel.issuers = [issuer]
+        mpCheckoutViewModel.installment = MockBuilder.buildInstallment()
+        
+        let payerCostVM = mpCheckoutViewModel.payerCostViewModel()
+        XCTAssertTrue(payerCostVM.isKind(of: PayerCostAdditionalStepViewModel.self))
+        XCTAssertEqual(payerCostVM.amount, checkoutPreference.getAmount())
+        
+        
+    }
     
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutViewModelTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutViewModelTest.swift
@@ -542,6 +542,46 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
          XCTAssertEqual(mpCheckoutViewModel.paymentOptionSelected!.getId(), accountMoneyOption.getCardId())
         
     }
+    
+    func testUpdateCheckoutModel_paymentData() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil, discount : nil)
+        
+        let paymentMethod = MockBuilder.buildPaymentMethod("visa")
+        let paymentData = MockBuilder.buildPaymentData(paymentMethod: paymentMethod)
+        mpCheckoutViewModel.updateCheckoutModel(paymentData: paymentData)
+        
+        XCTAssertTrue(mpCheckoutViewModel.readyToPay)
+        
+        paymentData.paymentMethod = nil
+        mpCheckoutViewModel.updateCheckoutModel(paymentData: paymentData)
+        
+        XCTAssertNil(mpCheckoutViewModel.paymentOptionSelected)
+        XCTAssertNil(mpCheckoutViewModel.search)
+        XCTAssertNil(mpCheckoutViewModel.issuers)
+        XCTAssertNil(mpCheckoutViewModel.installment)
+        XCTAssertNil(mpCheckoutViewModel.cardToken)
+        XCTAssertTrue(mpCheckoutViewModel.rootVC)
+        XCTAssertFalse(mpCheckoutViewModel.initWithPaymentData)
+        
+    }
+    
+    func testHandleCustomerPaymentMethod() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil, discount : nil)
+        
+        MPCheckoutTestAction.loadGroupsInViewModel(mpCheckoutViewModel: mpCheckoutViewModel)
+        
+        MPCheckoutTestAction.selectAccountMoney(mpCheckoutViewModel: mpCheckoutViewModel)
+        
+        mpCheckoutViewModel.handleCustomerPaymentMethod()
+        
+        XCTAssertEqual(mpCheckoutViewModel.paymentData.paymentMethod._id, "account_money")
+        
+        MPCheckoutTestAction.selectCustomerCardOption(mpCheckoutViewModel: mpCheckoutViewModel)
+        
+        XCTAssertEqual(mpCheckoutViewModel.paymentData.paymentMethod._id, "visa")
+    }
 
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutViewModelTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutViewModelTest.swift
@@ -404,9 +404,45 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
         
     }
     
+    func testCardFormManager() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        
+        let cardFormManager = mpCheckout.viewModel.cardFormManager()
+        XCTAssertTrue(cardFormManager.isKind(of: CardViewModelManager.self))
+        XCTAssertEqual(cardFormManager.amount, checkoutPreference.getAmount())
+    }
+    
+    func testPaymentVaultViewModel() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        
+        MPCheckoutTestAction.loadGroupsInViewModel(mpCheckout: mpCheckout)
+        
+        let paymentVaultVM = mpCheckout.viewModel.paymentVaultViewModel()
+        
+        XCTAssertTrue(paymentVaultVM.isKind(of: PaymentVaultViewModel.self))
+        XCTAssertEqual(paymentVaultVM.amount, checkoutPreference.getAmount())
+        XCTAssertEqual(paymentVaultVM.paymentPreference, checkoutPreference.paymentPreference)
+        XCTAssertEqual(paymentVaultVM.paymentPreference, checkoutPreference.paymentPreference)
+    }
+    
+    func testDebitCreditViewModel() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        
+        MPCheckoutTestAction.loadGroupsInViewModel(mpCheckout: mpCheckout)
+        
+        let debitCreditVM = mpCheckout.viewModel.debitCreditViewModel()
+        
+        XCTAssertTrue(debitCreditVM.isKind(of: CardTypeAdditionalStepViewModel.self))
+        XCTAssertEqual(debitCreditVM.amount, checkoutPreference.getAmount())
+    
+    }
+    
     func testIssuerViewModel(){
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil)
+        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil, discount : nil)
         
         // Simular installments
         let issuer = MockBuilder.buildIssuer()
@@ -421,7 +457,7 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     
     func testPayerCostViewModel(){
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil)
+        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil, discount : nil)
         
         let issuer = MockBuilder.buildIssuer()
         mpCheckoutViewModel.issuers = [issuer]
@@ -434,5 +470,78 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
         
     }
     
+    
+    /************************************************************/
+    /********** Update View Model Behavior Tests ****************/
+    /************************************************************/
+   
+    func testUpdateCheckoutModel_paymentMethodSearch() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil, discount : nil)
+        
+        
+        
+        let accountMoneyOption = MockBuilder.buildCustomerPaymentMethod("account_money", paymentMethodId : "account_money")
+        let customerCardOption = MockBuilder.buildCustomerPaymentMethod("customerCardId", paymentMethodId: "visa")
+        let creditCardOption = MockBuilder.buildPaymentMethodSearchItem("credit_card", type: PaymentMethodSearchItemType.PAYMENT_TYPE)
+        let paymentMethodVisa = MockBuilder.buildPaymentMethod("visa")
+        let paymentMethodAM = MockBuilder.buildPaymentMethod("account_money", paymentTypeId: "account_money")
+        
+        let paymentMethodSearchMock = MockBuilder.buildPaymentMethodSearch(groups : [creditCardOption], paymentMethods : [paymentMethodVisa, paymentMethodAM], customOptions : [customerCardOption, accountMoneyOption])
+        
+        mpCheckoutViewModel.updateCheckoutModel(paymentMethodSearch: paymentMethodSearchMock)
+        
+        XCTAssertNotNil(mpCheckoutViewModel.search)
+        XCTAssertEqual(mpCheckoutViewModel.search, paymentMethodSearchMock)
+     //   XCTAssertEqual(mpCheckoutViewModel.rootPaymentMethodOptions, mpCheckoutViewModel.paymentMethodOptions)
+        XCTAssertEqual(mpCheckoutViewModel.availablePaymentMethods!, paymentMethodSearchMock.paymentMethods)
+     //   XCTAssertEqual(mpCheckoutViewModel.customPaymentOptions, paymentMethodSearchMock.customerPaymentMethods)
+        
+    }
+    
+    func testUpdateCheckoutModel_paymentMethodSearchOneOption() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil, discount : nil)
+        
+        let creditCardOption = MockBuilder.buildPaymentMethodSearchItem("credit_card", type: PaymentMethodSearchItemType.PAYMENT_TYPE)
+        let paymentMethodVisa = MockBuilder.buildPaymentMethod("visa")
+
+        
+        let paymentMethodSearchMock = MockBuilder.buildPaymentMethodSearch(groups : [creditCardOption], paymentMethods : [paymentMethodVisa])
+        
+        mpCheckoutViewModel.updateCheckoutModel(paymentMethodSearch: paymentMethodSearchMock)
+        
+        XCTAssertNotNil(mpCheckoutViewModel.search)
+        XCTAssertEqual(mpCheckoutViewModel.search, paymentMethodSearchMock)
+        //   XCTAssertEqual(mpCheckoutViewModel.rootPaymentMethodOptions, mpCheckoutViewModel.paymentMethodOptions)
+        XCTAssertEqual(mpCheckoutViewModel.availablePaymentMethods!, paymentMethodSearchMock.paymentMethods)
+        XCTAssertNil(mpCheckoutViewModel.customPaymentOptions)
+        
+        XCTAssertEqual(mpCheckoutViewModel.paymentOptionSelected!.getId(), creditCardOption.getId())
+        
+    }
+    
+    func testUpdateCheckoutModel_paymentMethodSearchCustomOption() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckoutViewModel  = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData : nil, paymentResult : nil, discount : nil)
+        
+        let accountMoneyOption = MockBuilder.buildCustomerPaymentMethod("account_money", paymentMethodId : "account_money")
+        let paymentMethodAM = MockBuilder.buildPaymentMethod("account_money", paymentTypeId: "account_money")
+        
+        
+        let paymentMethodSearchMock = MockBuilder.buildPaymentMethodSearch(groups : nil, paymentMethods : [paymentMethodAM], customOptions : [accountMoneyOption])
+        
+        mpCheckoutViewModel.updateCheckoutModel(paymentMethodSearch: paymentMethodSearchMock)
+        
+        XCTAssertNotNil(mpCheckoutViewModel.search)
+        XCTAssertEqual(mpCheckoutViewModel.search, paymentMethodSearchMock)
+        //   XCTAssertEqual(mpCheckoutViewModel.rootPaymentMethodOptions, mpCheckoutViewModel.paymentMethodOptions)
+        XCTAssertEqual(mpCheckoutViewModel.availablePaymentMethods!, paymentMethodSearchMock.paymentMethods)
+        
+        
+         XCTAssertEqual(mpCheckoutViewModel.paymentOptionSelected!.getId(), accountMoneyOption.getCardId())
+        
+    }
+
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/NextStepHelperTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/NextStepHelperTest.swift
@@ -1,0 +1,65 @@
+//
+//  NextStepHelperTest.swift
+//  MercadoPagoSDK
+//
+//  Created by Maria cristina rodriguez on 3/22/17.
+//  Copyright © 2017 MercadoPago. All rights reserved.
+//
+
+import XCTest
+
+class NextStepHelperTest: BaseTest {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testShowConfirm() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckoutViewModel = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData: nil, paymentResult: nil, discount: nil)
+        XCTAssertFalse(mpCheckoutViewModel.showConfirm())
+        
+        mpCheckoutViewModel.paymentData.paymentMethod = MockBuilder.buildPaymentMethod("account_money")
+        XCTAssertTrue(mpCheckoutViewModel.showConfirm())
+        
+        mpCheckoutViewModel.paymentData.paymentMethod = MockBuilder.buildPaymentMethod("visa")
+        mpCheckoutViewModel.paymentData.token = MockBuilder.buildToken()
+        mpCheckoutViewModel.paymentData.payerCost = MockBuilder.buildPayerCost()
+        
+        XCTAssertTrue(mpCheckoutViewModel.showConfirm())
+    }
+    
+    
+    func testSetPaymentOptionSelected() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let mpCheckoutViewModel = MercadoPagoCheckoutViewModel(checkoutPreference: checkoutPreference, paymentData: nil, paymentResult: nil, discount: nil)
+        
+        MercadoPagoContext.setAccountMoneyAvailable(accountMoneyAvailable: true)
+        MPCheckoutTestAction.loadGroupsInViewModel(mpCheckoutViewModel: mpCheckoutViewModel)
+        
+        // Account_money
+        mpCheckoutViewModel.paymentData.paymentMethod = MockBuilder.buildPaymentMethod("account_money", paymentTypeId : "account_money")
+        mpCheckoutViewModel.setPaymentOptionSelected()
+        XCTAssertNotNil(mpCheckoutViewModel.paymentOptionSelected)
+        XCTAssertEqual(mpCheckoutViewModel.paymentOptionSelected!.getId(), "account_money")
+        
+        // Visa
+        mpCheckoutViewModel.paymentData.paymentMethod = MockBuilder.buildPaymentMethod("visa")
+        mpCheckoutViewModel.setPaymentOptionSelected()
+        XCTAssertNotNil(mpCheckoutViewModel.paymentOptionSelected)
+        XCTAssertEqual(mpCheckoutViewModel.paymentOptionSelected!.getId(), "credit_card")
+        
+        // Medio off
+        mpCheckoutViewModel.paymentData.paymentMethod = MockBuilder.buildPaymentMethod("off", paymentTypeId: "ticket")
+        mpCheckoutViewModel.setPaymentOptionSelected()
+        XCTAssertNotNil(mpCheckoutViewModel.paymentOptionSelected)
+        XCTAssertEqual(mpCheckoutViewModel.paymentOptionSelected!.getId(), "off")
+    }
+    
+}

--- a/MercadoPagoSDK/MercadoPagoSDKTests/PaymentMethodSearchTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/PaymentMethodSearchTest.swift
@@ -11,5 +11,54 @@ import XCTest
 class PaymentMethodSearchTest: BaseTest {
     
 
+    func testPaymentOptionsCount() {
+        let customOption = MockBuilder.buildCustomerPaymentMethod("id", paymentMethodId: "paymentMethodId")
+        let anotherCustomOption = MockBuilder.buildCustomerPaymentMethod("anotherId", paymentMethodId: "paymentMethodId")
+        
+        let customOptions = [customOption, anotherCustomOption]
+        
+        let paymentOption = MockBuilder.buildPaymentMethodSearchItem("id")
+        let anotherPaymentOption = MockBuilder.buildPaymentMethodSearchItem("anotherId")
+        let anotherMorePaymentOption = MockBuilder.buildPaymentMethodSearchItem("anotherId")
+        
+        let paymentOptions = [paymentOption, anotherPaymentOption, anotherMorePaymentOption]
+        
+        let paymentMethodSearch = PaymentMethodSearch()
+        paymentMethodSearch.groups = paymentOptions
+        paymentMethodSearch.customerPaymentMethods = customOptions
+        
+        XCTAssertEqual(paymentMethodSearch.getPaymentOptionsCount(), 5)
+        
+    }
     
+    
+    func testOnlyCustomOptions() {
+        let customOption = MockBuilder.buildCustomerPaymentMethod("id", paymentMethodId: "paymentMethodId")
+        let anotherCustomOption = MockBuilder.buildCustomerPaymentMethod("anotherId", paymentMethodId: "paymentMethodId")
+        
+        let customOptions = [customOption, anotherCustomOption]
+        let paymentMethodSearch = PaymentMethodSearch()
+        paymentMethodSearch.customerPaymentMethods = customOptions
+        
+        XCTAssertEqual(paymentMethodSearch.getPaymentOptionsCount(), 2)
+        
+    }
+    
+    func testOnlyPaymentOptionsCount() {
+
+        
+        
+        let paymentOption = MockBuilder.buildPaymentMethodSearchItem("id")
+        let anotherPaymentOption = MockBuilder.buildPaymentMethodSearchItem("anotherId")
+        let anotherMorePaymentOption = MockBuilder.buildPaymentMethodSearchItem("anotherId")
+        
+        let paymentOptions = [paymentOption, anotherPaymentOption,anotherMorePaymentOption]
+        
+        let paymentMethodSearch = PaymentMethodSearch()
+        paymentMethodSearch.groups = paymentOptions
+        
+        XCTAssertEqual(paymentMethodSearch.getPaymentOptionsCount(), 3)
+        
+    }
+
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/WalletIntegrationTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/WalletIntegrationTest.swift
@@ -27,7 +27,8 @@ class WalletIntegrationTest: BaseTest {
         var fp = FlowPreference()
         fp.disableReviewAndConfirmScreen()
         MercadoPagoCheckout.setFlowPreference(fp)
-
+        MercadoPagoContext.setAccountMoneyAvailable(accountMoneyAvailable: true)
+        
         // Inicia Checkout con preferencia
         let preference = MockBuilder.buildCheckoutPreference()
         let mpCheckout = MercadoPagoCheckout(checkoutPreference: preference, navigationController: UINavigationController())
@@ -52,8 +53,11 @@ class WalletIntegrationTest: BaseTest {
             localPaymentData = paymentData
         }
         
-        mpCheckout.collectPaymentData()
         step = mpCheckout.viewModel.nextStep()
+        XCTAssertEqual(step, CheckoutStep.FINISH)
+        
+        // Ejecutar finish => paymentDataCallback
+        mpCheckout.executeNextStep()
         waitForExpectations(timeout: 10, handler: nil)
         
         // Se habilita RyC


### PR DESCRIPTION
Fix #695 #751 

##  Cambios introducidos : 
- Se deja finish como step final siempre que se sale del flujo, ya sea cancelando o yendo hacia atrás (se guarda referencia de primer vc correspondiente a la sdk)
- Siempre que se entra con un paymentData completo se redirige a RyC
- Se reinicia FlowPreference en step de finish. De caso contrario al volver a entrar a la sdk se usa el último valor asignado anteriormente. @edentorres  @demtej 
- Se agregan tests unitarios para asegurar funcionalidad previa. Se agrega test de WalletIntegration que simula parte del flujo de Wallet

### Revisión
- [x] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [NA] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [X] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
