### PR TITLE
[WIP] Add init with checkoutPreferenceId

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -22,8 +22,32 @@ open class MercadoPagoCheckout: NSObject {
     
 
     
-    public init(checkoutPreference : CheckoutPreference, paymentData : PaymentData? = nil, navigationController : UINavigationController, paymentResult: PaymentResult? = nil) {
-        viewModel = MercadoPagoCheckoutViewModel(checkoutPreference : checkoutPreference, paymentData: paymentData, paymentResult: paymentResult)
+    public init(checkoutPreference : CheckoutPreference, paymentData : PaymentData? = nil, paymentDataCallback : @escaping (_ paymentData : PaymentData) -> Void, navigationController : UINavigationController) {
+        viewModel = MercadoPagoCheckoutViewModel(checkoutPreference : checkoutPreference, paymentData: paymentData, paymentResult: nil)
+        MercadoPagoCheckout.setPaymentDataConfirmCallback(paymentDataConfirmCallback: paymentDataCallback)
+        DecorationPreference.saveNavBarStyleFor(navigationController: navigationController)
+        self.navigationController = navigationController
+        
+        if self.navigationController.viewControllers.count > 0 {
+            let  newNavigationStack = self.navigationController.viewControllers.filter {!$0.isKind(of:MercadoPagoUIViewController.self) || $0.isKind(of:CheckoutViewController.self);
+            }
+            viewControllerBase = newNavigationStack.last
+        }
+    }
+    public init(checkoutPreference : CheckoutPreference, paymentData : PaymentData? = nil, exitCallback : @escaping (Void) -> Void, navigationController : UINavigationController) {
+        viewModel = MercadoPagoCheckoutViewModel(checkoutPreference : checkoutPreference, paymentData: paymentData, paymentResult: nil)
+        MercadoPagoCheckout.setCallback(callback: exitCallback)
+        DecorationPreference.saveNavBarStyleFor(navigationController: navigationController)
+        self.navigationController = navigationController
+        
+        if self.navigationController.viewControllers.count > 0 {
+            let  newNavigationStack = self.navigationController.viewControllers.filter {!$0.isKind(of:MercadoPagoUIViewController.self) || $0.isKind(of:CheckoutViewController.self);
+            }
+            viewControllerBase = newNavigationStack.last
+        }
+    }
+    public init(checkoutPreferenceId : String, paymentData : PaymentData? = nil, paymentResult: PaymentResult? = nil, navigationController : UINavigationController) {
+        viewModel = MercadoPagoCheckoutViewModel(checkoutPreferenceId : checkoutPreferenceId, paymentData: paymentData, paymentResult: paymentResult)
         DecorationPreference.saveNavBarStyleFor(navigationController: navigationController)
         self.navigationController = navigationController
         
@@ -253,7 +277,7 @@ open class MercadoPagoCheckout: NSObject {
     }
     
     func createSavedCardToken(cardInformation: CardInformation, securityCode: String) {
-        self.presentLoading()
+        //self.presentLoading()
         
         let cardInformation = self.viewModel.paymentOptionSelected as! CardInformation
         let saveCardToken = SavedCardToken(card: cardInformation, securityCode: securityCode, securityCodeRequired: true)
@@ -264,7 +288,7 @@ open class MercadoPagoCheckout: NSObject {
             }
             self.viewModel.updateCheckoutModel(token: token)
             self.executeNextStep()
-            self.dismissLoading()
+            //self.dismissLoading()
         }, failure: { (error) in
             self.viewModel.errorInputs(error: MPSDKError.convertFrom(error), errorCallback: { (Void) in
                 self.createCardToken()

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -99,6 +99,19 @@ open class MercadoPagoCheckoutViewModel: NSObject {
             }
         }
         self.paymentResult = paymentResult
+    }
+    init(checkoutPreferenceId : String, paymentData : PaymentData?, paymentResult: PaymentResult?) {
+        self.checkoutPreference = CheckoutPreference()
+        self.checkoutPreference._id = checkoutPreferenceId
+        
+        if let pm = paymentData{
+            if pm.isComplete() {
+                self.paymentData = pm
+                self.reviewAndConfirm = true
+                self.initWithPaymentData = true
+            }
+        }
+        self.paymentResult = paymentResult
         if !String.isNullOrEmpty(self.checkoutPreference._id) {
             // Cargar información de preferencia en caso que tenga id
             needLoadPreference = true

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -59,13 +59,13 @@
     [self setReviewScreenPreference];
     
     //Setear flowPreference
-    [self finishFlowBeforeRYC];
+    //[self finishFlowBeforeRYC];
     
     
     ///  PASO 2: SETEAR CHECKOUTPREF, PAYMENTDATA Y PAYMENTRESULT
     
     // Setear una preferencia hecha a mano
-    [self setCheckoutPref_WithId];
+    [self setCheckoutPref_CardsNotExcluded];
     
     // Setear PaymentData
     //[self setPaymentData];
@@ -86,7 +86,13 @@
     //[self setVoidCallback];
     
     
-    [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:self.paymentData navigationController:self.navigationController paymentResult:self.paymentResult] start];
+[[[MercadoPagoCheckout alloc]initWithCheckoutPreference:self.pref paymentData:self.paymentData paymentDataCallback:^(PaymentData * paymentData) {
+    NSLog(@"PaymentMethod: %@", paymentData.paymentMethod._id);
+    NSLog(@"Token_id: %@", paymentData.token._id);
+    NSLog(@"Installemtns: %ld", paymentData.payerCost.installments);
+    NSLog(@"Issuer_id: %@", paymentData.issuer._id);
+} navigationController: self.navigationController] start];
+    //[[[MercadoPagoCheckout alloc]initWithCheckoutPreferenceId:@"150216849-68645cbb-dfe6-4410-bfd6-6e5aa33d8a33" paymentData:self.paymentData paymentResult:self.paymentResult navigationController:self.navigationController] start];
     
 }
 
@@ -150,7 +156,7 @@
         [flowPreference enableReviewAndConfirmScreen];
         [MercadoPagoCheckout setFlowPreference:flowPreference];
         
-        [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:paymentData navigationController:self.navigationController paymentResult:nil] start];
+    [[[MercadoPagoCheckout alloc]initWithCheckoutPreferenceId:@"150216849-68645cbb-dfe6-4410-bfd6-6e5aa33d8a33" paymentData:paymentData paymentResult:nil navigationController:self.navigationController] start];
         
     }];
 }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
@@ -99,7 +99,7 @@ CheckoutPreference *pref;
     pd.issuer._id = [NSNumber numberWithInt:200];
     
     
-    [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:pd navigationController:self.navigationController paymentResult:nil] start];
+    //[[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:pd navigationController:self.navigationController paymentResult:nil] start];
 
     
 }
@@ -114,7 +114,7 @@ CheckoutPreference *pref;
     
     [MainExamplesViewController setPaymentDataCallback];
     
-    [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:nil navigationController:self.navigationController paymentResult:nil] start];
+    //[[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:nil navigationController:self.navigationController paymentResult:nil] start];
 
 }
 
@@ -141,7 +141,7 @@ CheckoutPreference *pref;
     pd.issuer = nil;//[[Issuer alloc] init];
      PaymentResult *paymentResult = [[PaymentResult alloc] initWithStatus:@"approved" statusDetail:@"approved" paymentData:pd payerEmail:nil id:nil statementDescription:nil];
     
-    [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:pd navigationController:self.navigationController paymentResult:paymentResult] start];
+    //[[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:pd navigationController:self.navigationController paymentResult:paymentResult] start];
 
 }
 


### PR DESCRIPTION
Fix #787 

##  Cambios introducidos : 
- Se agrega otro init de MercadoPagoCheckout, uno con prefId y otro con una pref hecha a mano

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
