### PR TITLE
Fix spacing in groups

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
@@ -378,11 +378,12 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
         let availableWidth = view.frame.width - paddingSpace
         
         titleCellHeight = 82
-        if indexPath.section == 0 {
+        if isHeaderSection(section: indexPath.section) {
             return CGSize(width : view.frame.width, height : titleCellHeight)
         }
-        
-       
+        if isCouponSection(section: indexPath.section) {
+            return CGSize(width : view.frame.width, height : 84)
+        }
         
         let widthPerItem = availableWidth / itemsPerRow
         return CGSize(width: widthPerItem, height: maxHegithRow(indexPath:indexPath)  )
@@ -432,6 +433,9 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
     public func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         insetForSectionAt section: Int) -> UIEdgeInsets {
+        if isCouponSection(section: section){
+            return UIEdgeInsetsMake(0, 0, 0, 0)
+        }
         return UIEdgeInsetsMake(8, 8, 8, 8)
 
     }


### PR DESCRIPTION
Fix #793 

##  Cambios introducidos : 
- Se saca el espacio entre la celda de cupones y de los items en PaymentVault

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
