### PR TITLE
Remove line in discountCell in PaymentResult

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/ApprovedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ApprovedTableViewCell.swift
@@ -69,10 +69,10 @@ class ApprovedTableViewCell: UITableViewCell {
         if let discount = paymentResult.paymentData?.discount {
             let screenSize : CGRect = UIScreen.main.bounds
             let screenWidth = screenSize.width
-            let discountBody = DiscountBodyCell(frame: CGRect(x: 0, y: 0, width : screenWidth, height : 84), coupon:discount, amount:(checkoutPreference?.getAmount())!)
+            let discountBody = DiscountBodyCell(frame: CGRect(x: 0, y: 0, width : screenWidth, height : 84), coupon:discount, amount:(checkoutPreference?.getAmount())!, addBorder: false)
             discountViewContent.addSubview(discountBody)
-        } else
-        {
+        
+        } else {
              discountViewContent.frame = CGRect(x: 0, y: 0, width: 0, height: 0)
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/DiscountBodyCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/DiscountBodyCell.swift
@@ -14,7 +14,7 @@ class DiscountBodyCell: UIView {
     var coupon: DiscountCoupon?
     var amount: Double!
     
-    init(frame: CGRect, coupon: DiscountCoupon?, amount:Double) {
+    init(frame: CGRect, coupon: DiscountCoupon?, amount:Double, addBorder: Bool = true) {
         super.init(frame: frame)
         self.coupon = coupon
         self.amount = amount
@@ -23,7 +23,9 @@ class DiscountBodyCell: UIView {
         }else{
             loadCouponView()
         }
-        self.layer.addBorder(edge: UIRectEdge.bottom, color: UIColor.px_grayLight(), thickness: 0.5)
+        if addBorder {
+            self.layer.addBorder(edge: UIRectEdge.bottom, color: UIColor.px_grayLight(), thickness: 0.5)
+        }
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -371,7 +371,7 @@ open class MercadoPagoCheckout: NSObject {
 
         let congratsViewController : UIViewController
         if (PaymentTypeId.isOnlineType(paymentTypeId: self.viewModel.paymentData.paymentMethod.paymentTypeId)) {
-            congratsViewController = PaymentResultViewController(paymentResult: self.viewModel.paymentResult!, checkoutPreference: self.viewModel.checkoutPreference, discount: self.viewModel.paymentData.discount, callback: { (state : MPStepBuilder.CongratsState) in
+            congratsViewController = PaymentResultViewController(paymentResult: self.viewModel.paymentResult!, checkoutPreference: self.viewModel.checkoutPreference, callback: { (state : MPStepBuilder.CongratsState) in
                 self.finish()
             })
         } else {

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewController.swift
@@ -75,9 +75,9 @@ open class PaymentResultViewController: MercadoPagoUIViewController, UITableView
         MPTracker.trackPaymentEvent(self.viewModel.paymentResult.paymentData?.token?._id, mpDelegate: MercadoPagoContext.sharedInstance, paymentInformer: self.viewModel, flavor: Flavor(rawValue: "3"), action: "CREATE_PAYMENT", result:nil)
     }
 
-    init(paymentResult: PaymentResult, checkoutPreference: CheckoutPreference, discount: DiscountCoupon? = nil, callback : @escaping (_ status : MPStepBuilder.CongratsState) -> Void){
+    init(paymentResult: PaymentResult, checkoutPreference: CheckoutPreference, callback : @escaping (_ status : MPStepBuilder.CongratsState) -> Void){
         super.init(nibName: "PaymentResultViewController", bundle : bundle)
-        self.viewModel = PaymentResultViewModel(paymentResult: paymentResult, checkoutPreference: checkoutPreference, discount:discount , callback: callback)
+        self.viewModel = PaymentResultViewModel(paymentResult: paymentResult, checkoutPreference: checkoutPreference,  callback: callback)
     }
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
@@ -13,10 +13,8 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
     var paymentResult: PaymentResult!
     var callback: ( _ status : MPStepBuilder.CongratsState) -> Void
     var checkoutPreference: CheckoutPreference?
-    var discount : DiscountCoupon?
     
-    init(paymentResult: PaymentResult, checkoutPreference: CheckoutPreference,discount : DiscountCoupon? = nil, callback : @escaping ( _ status : MPStepBuilder.CongratsState) -> Void) {
-        self.discount = discount
+    init(paymentResult: PaymentResult, checkoutPreference: CheckoutPreference, callback : @escaping ( _ status : MPStepBuilder.CongratsState) -> Void) {
         self.paymentResult = paymentResult
         self.callback = callback
         self.checkoutPreference = checkoutPreference


### PR DESCRIPTION
Fix #804

##  Cambios introducidos : 
- Se saca la linea separadora en de la celda de cupones en la pantalla de pago aprobado
- Se saca la variable de cupones del paymentResultViewModel

### Revisión
- [X] Todos los textos se encuentran localizables
- [ ] No se introducen warnings al proyecto
- [X] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
