### PR TITLE
Remove extra space between header and discount

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/DiscountBodyCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/DiscountBodyCell.swift
@@ -11,13 +11,15 @@ import UIKit
 class DiscountBodyCell: UIView {
 
     let margin : CGFloat = 5.0
+    var topMargin: CGFloat!
     var coupon: DiscountCoupon?
     var amount: Double!
     
-    init(frame: CGRect, coupon: DiscountCoupon?, amount:Double, addBorder: Bool = true) {
+    init(frame: CGRect, coupon: DiscountCoupon?, amount:Double, addBorder: Bool = true, topMargin: CGFloat = 20.0) {
         super.init(frame: frame)
         self.coupon = coupon
         self.amount = amount
+        self.topMargin = topMargin
         if (self.coupon == nil){
             loadNoCouponView()
         }else{
@@ -80,7 +82,7 @@ class DiscountBodyCell: UIView {
         guard let coupon = self.coupon else {
             return
         }
-        let tituloLabel = MPLabel(frame: CGRect(x: margin, y: 20, width: (frame.size.width - 2 * margin), height: 20) )
+        let tituloLabel = MPLabel(frame: CGRect(x: margin, y: topMargin, width: (frame.size.width - 2 * margin), height: 20) )
         tituloLabel.textAlignment = .center;
         let result = NSMutableAttributedString()
         let normalAttributes: [String:AnyObject] = [NSFontAttributeName : Utils.getFont(size: 16),NSForegroundColorAttributeName: UIColor.px_grayDark()]
@@ -115,16 +117,16 @@ class DiscountBodyCell: UIView {
         let widthlabelAmount = (discountAmountLabel.attributedText?.widthWithConstrainedHeight(height: 12))! + 8
         let totalViewWidth = widthlabelDiscount! + widthlabelAmount + 10 + 8 + 2 * margin
         var x = (screenWidth - totalViewWidth) / 2
-        let frameLabel = CGRect(x: x , y: (margin * 2 + 40), width: widthlabelDiscount!, height: 18)
+        let frameLabel = CGRect(x: x , y: (margin * 2 + topMargin + 20), width: widthlabelDiscount!, height: 18)
         detailLabel.frame = frameLabel
         x = x + widthlabelDiscount! + margin
-        let framePic = CGRect(x: x, y: (margin * 2 + 40), width: 10, height: 19)
+        let framePic = CGRect(x: x, y: (margin * 2 + topMargin + 20), width: 10, height: 19)
         picFlag.frame = framePic
         x = x + 10
-        let frameAmountLabel = CGRect(x: x , y: (margin * 2 + 40), width: widthlabelAmount, height: 19)
+        let frameAmountLabel = CGRect(x: x , y: (margin * 2 + topMargin + 20), width: widthlabelAmount, height: 19)
         discountAmountLabel.frame = frameAmountLabel
         x = x + widthlabelAmount + margin
-        let frameArrow = CGRect(x: x, y: 4 + (margin * 2 + 40), width: 8, height: 12)
+        let frameArrow = CGRect(x: x, y: 4 + (margin * 2 + topMargin + 20), width: 8, height: 12)
         rightArrow.frame = frameArrow
         self.addSubview(tituloLabel)
         self.addSubview(detailLabel)

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
@@ -353,7 +353,7 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
         }else if isCouponSection(section: indexPath.section){
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CouponCell",for: indexPath)
             cell.contentView.viewWithTag(1)?.removeFromSuperview()
-            let discountBody = DiscountBodyCell(frame: CGRect(x: 0, y: 0, width : view.frame.width, height : 84), coupon: self.viewModel.discount, amount:self.viewModel.amount)
+            let discountBody = DiscountBodyCell(frame: CGRect(x: 0, y: 0, width : view.frame.width, height : 84), coupon: self.viewModel.discount, amount:self.viewModel.amount, topMargin: 15)
             discountBody.tag = 1
             cell.contentView.addSubview(discountBody)
             return cell


### PR DESCRIPTION
Fix #806 

##  Cambios introducidos : 
- Se saca el espacio extra entre el header de grupos y la celda de cupon

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
