### PR TITLE
Fix del flujo de back de AddiotionalStepViewController

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/AdditionalStepViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/AdditionalStepViewController.swift
@@ -22,7 +22,6 @@ open class AdditionalStepViewController: MercadoPagoUIScrollViewController, UITa
     
     override open func viewDidLoad() {
         super.viewDidLoad()
-        self.showLoading()
         tableView.tableFooterView = UIView()
         tableView.separatorStyle = .none
         loadMPStyles()
@@ -60,10 +59,9 @@ open class AdditionalStepViewController: MercadoPagoUIScrollViewController, UITa
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.title = ""
-        
+        self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancel)
         self.extendedLayoutIncludesOpaqueBars = true
         self.titleCellHeight = 44
-        self.hideLoading()
     }
     
     override func loadMPStyles(){

--- a/MercadoPagoSDK/MercadoPagoSDK/CardFormViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardFormViewController.swift
@@ -121,7 +121,7 @@ open class CardFormViewController: MercadoPagoUIViewController , UITextFieldDele
         
         if(callbackCancel != nil){
             self.navigationItem.leftBarButtonItem?.target = self
-            self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancel)
+            self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancelShowingNavBar)
         }
         
         textEditMaskFormater.emptyMaskElement = nil

--- a/MercadoPagoSDK/MercadoPagoSDK/IdentificationViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/IdentificationViewController.swift
@@ -192,7 +192,7 @@ open class IdentificationViewController: MercadoPagoUIViewController , UITextFie
     
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancel)
+        self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancelShowingNavBar)
         self.numberTextField.becomeFirstResponder()
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -177,6 +177,10 @@ open class MercadoPagoCheckout: NSObject {
             self.viewModel.updateCheckoutModel(issuer: issuer as! Issuer?)
             self.executeNextStep()
         })
+        issuerStep.callbackCancel = {
+            self.viewModel.issuers = nil
+            self.viewModel.paymentData.issuer = nil
+        }
         self.navigationController.pushViewController(issuerStep, animated: true)
     }
 
@@ -271,6 +275,10 @@ open class MercadoPagoCheckout: NSObject {
             self.viewModel.updateCheckoutModel(payerCost: payerCost as! PayerCost?)
             self.executeNextStep()
         })
+        payerCostStep.callbackCancel = {
+            self.viewModel.installment = nil
+            self.viewModel.paymentData.payerCost = nil
+        }
         self.pushViewController(viewController : payerCostStep, animated: true)
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoUIViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoUIViewController.swift
@@ -140,12 +140,18 @@ open class MercadoPagoUIViewController: UIViewController, UIGestureRecognizerDel
         DecorationPreference.applyAppNavBarDecorationPreferencesTo(navigationController: navController)
     }
     
-    internal func invokeCallbackCancel(){
+    internal func invokeCallbackCancelShowingNavBar(){
         if(self.callbackCancel != nil){
             self.showNavBar()
             self.callbackCancel!()
         }
 
+    }
+    internal func invokeCallbackCancel(){
+        if self.callbackCancel != nil {
+            self.callbackCancel!()
+        }
+        self.navigationController!.popViewController(animated: true)
     }
     
     override open func didReceiveMemoryWarning() {

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewController.swift
@@ -121,7 +121,7 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
         
         self.hideNavBar()
         if let button = self.navigationItem.leftBarButtonItem{
-               self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancel)
+               self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancelShowingNavBar)
         }
      
         self.navigationController!.navigationBar.shadowImage = nil
@@ -213,7 +213,7 @@ open class PaymentVaultViewController: MercadoPagoUIScrollViewController, UIColl
                 self.requestFailure(error, callback: {
                     self.navigationController!.dismiss(animated: true, completion: {})
                 }, callbackCancel: {
-                    self.invokeCallbackCancel()
+                    self.invokeCallbackCancelShowingNavBar()
                 })
             })
             


### PR DESCRIPTION
Fix #808 #809 

##  Cambios introducidos : 
- Se saca el loadind de additionalStepViewController.
- Se agrega un callback cancel en cuotas y en issuers que borran los datos buscados del servicio y los datos seleccionados por el usuario.

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
