### PR TITLE
Remove extra line in summaryRow

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -709,7 +709,7 @@ open class CheckoutViewModel {
     }
     
     func shouldShowTotal() -> Bool {
-        return shouldShowInstallmentSummary() || numberOfSummaryRows() != 1
+        return shouldShowInstallmentSummary() || numberOfSummaryRows() > 1
     }
     
     func shouldShowInstallmentSummary() -> Bool {


### PR DESCRIPTION
Fix #811 

##  Cambios introducidos : 
- Se saca la linea extra del summaryRow

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
