### PR TITLE
Add subheader customCell

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultScreenPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultScreenPreference.swift
@@ -53,6 +53,7 @@ open class PaymentResultScreenPreference: NSObject {
     
     internal static var pendingAdditionalInfoCells = [MPCustomCell]()
     internal static var approvedAdditionalInfoCells = [MPCustomCell]()
+    internal static var approvedSubHeaderCells = [MPCustomCell]()
     
     // Sets de Approved
     
@@ -225,9 +226,14 @@ open class PaymentResultScreenPreference: NSObject {
         PaymentResultScreenPreference.approvedAdditionalInfoCells = customCells
     }
     
+    open static func setCustomApprovedSubHeaderCell(customCells: [MPCustomCell]) {
+        PaymentResultScreenPreference.approvedSubHeaderCells = customCells
+    }
+    
     open static func clear() {
         PaymentResultScreenPreference.approvedAdditionalInfoCells = [MPCustomCell]()
         PaymentResultScreenPreference.pendingAdditionalInfoCells = [MPCustomCell]()
+        PaymentResultScreenPreference.approvedSubHeaderCells = [MPCustomCell]()
     }
     
     //Approved

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewController.swift
@@ -90,13 +90,15 @@ open class PaymentResultViewController: MercadoPagoUIViewController, UITableView
             } else if viewModel.approved(){
                 return PaymentResultScreenPreference.approvedAdditionalInfoCells[indexPath.row].getHeight()
             }
+        } else if viewModel.isCustomSubHeaderCellFor(indexPath: indexPath){
+            return PaymentResultScreenPreference.approvedSubHeaderCells[indexPath.row].getHeight()
         }
         return UITableViewAutomaticDimension
         
     }
     
     open func numberOfSections(in tableView: UITableView) -> Int {
-        return 5
+        return 6
     }
     
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -116,16 +118,19 @@ open class PaymentResultViewController: MercadoPagoUIViewController, UITableView
         } else if viewModel.isCallForAuthFor(indexPath: indexPath) {
             return getCallForAuthCell()
             
-        } else if viewModel.isSelectOtherPaymentMethodCellFor(indexPath: indexPath){
+        } else if viewModel.isSelectOtherPaymentMethodCellFor(indexPath: indexPath) {
             if viewModel.callForAuth() {
                 return getOtherPaymentMethodCell(drawLine: true)
             }
             return getOtherPaymentMethodCell(drawLine: false)
             
-        } else if viewModel.isAdditionalCustomCellFor(indexPath: indexPath){
+        } else if viewModel.isAdditionalCustomCellFor(indexPath: indexPath) {
             return getAdditionalCustomCell(indexPath: indexPath)
         
-        } else if viewModel.isSecondaryExitButtonCellFor(indexPath: indexPath){
+        } else if viewModel.isCustomSubHeaderCellFor(indexPath: indexPath) {
+            return getCustomSubHeaderCell(indexPath: indexPath)
+        
+        } else if viewModel.isSecondaryExitButtonCellFor(indexPath: indexPath) {
             return getSecondaryExitButtonCell()
         
         } else if viewModel.isFooterCellFor(indexPath: indexPath){
@@ -145,7 +150,7 @@ open class PaymentResultViewController: MercadoPagoUIViewController, UITableView
         let footerNib = self.tableView.dequeueReusableCell(withIdentifier: "footerNib") as! FooterTableViewCell
         footerNib.setCallbackStatus(callback: self.viewModel.callback, status: MPStepBuilder.CongratsState.ok)
         footerNib.fillCell(paymentResult: self.viewModel.paymentResult)
-		var isSecondaryButtonDisplayed = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSecondaryExitButtonCallback != nil;
+		let isSecondaryButtonDisplayed = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSecondaryExitButtonCallback != nil;
         if self.viewModel.approved() && !isSecondaryButtonDisplayed {
             ViewUtils.drawBottomLine(y: footerNib.contentView.frame.minY, width: UIScreen.main.bounds.width, inView: footerNib.contentView)
         }
@@ -196,6 +201,18 @@ open class PaymentResultViewController: MercadoPagoUIViewController, UITableView
             cell.selectionStyle = .none
             return cell
         }
+    }
+    
+    private func getCustomSubHeaderCell(indexPath: IndexPath) -> UITableViewCell {
+        
+        if self.viewModel.approved(){
+            let customCell = PaymentResultScreenPreference.approvedSubHeaderCells[indexPath.row]
+            customCell.setDelegate(delegate: self)
+            let cell = customCell.getTableViewCell()
+            cell.selectionStyle = .none
+            return cell
+        }
+        return UITableViewCell()
     }
     
     private func getSecondaryExitButtonCell() -> UITableViewCell {

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
@@ -44,9 +44,9 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
     }
     
     func getColor() -> UIColor{
-		if let color = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.statusBackgroundColor {
-			return color;
-		} else if approved() {
+        if let color = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.statusBackgroundColor {
+            return color;
+        } else if approved() {
             return UIColor(red: 59, green: 194, blue: 128)
         } else if inProcess() {
             return UIColor(red: 255, green: 161, blue: 90)
@@ -54,8 +54,8 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
             return UIColor(red: 58, green: 184, blue: 239)
         } else if rejected(){
             return UIColor(red: 255, green: 89, blue: 89)
-		}
-		return UIColor(red: 255, green: 89, blue: 89)
+        }
+        return UIColor(red: 255, green: 89, blue: 89)
     }
     
     func callForAuth() ->Bool{
@@ -134,62 +134,69 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
     }
     
     func isFooterCellFor(indexPath: IndexPath) -> Bool {
-        return indexPath.section == 4
+        return indexPath.section == 5
     }
-
+    
     func isApprovedBodyCellFor(indexPath: IndexPath) -> Bool {
-		//approved case
-		let precondition = indexPath.section == 1 && approved()
-		//if row at index 0 exists and approved body is not disabled, row 0 should display approved body
-		let case1 = !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() && indexPath.row == 0;
+        //approved case
+        let precondition = indexPath.section == 2 && approved()
+        //if row at index 0 exists and approved body is not disabled, row 0 should display approved body
+        let case1 = !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() && indexPath.row == 0;
         return precondition && case1
     }
     
     func isEmailCellFor(indexPath: IndexPath) -> Bool {
-		//approved case
-		let precondition = indexPath.section == 1 && approved()
-		//if row at index 0 exists and approved body is disabled, row 0 should display email row
-		let case1 = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() && indexPath.row == 0;
-		//if row at index 1 exists, row 1 should display email row
-		let case2 = indexPath.row == 1;
-		return precondition && (case1 || case2)
+        //approved case
+        let precondition = indexPath.section == 2 && approved()
+        //if row at index 0 exists and approved body is disabled, row 0 should display email row
+        let case1 = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() && indexPath.row == 0;
+        //if row at index 1 exists, row 1 should display email row
+        let case2 = indexPath.row == 1;
+        return precondition && (case1 || case2)
     }
     
     
     func isCallForAuthFor(indexPath: IndexPath) -> Bool {
-		//non approved case
-		let precondition = indexPath.section == 1 && !approved()
-		//if row at index 0 exists and callForAuth is not disabled, row 0 should display callForAuth cell
-		let case1 = callForAuth() && indexPath.row == 0;
-		return precondition && case1
+        //non approved case
+        let precondition = indexPath.section == 2 && !approved()
+        //if row at index 0 exists and callForAuth is not disabled, row 0 should display callForAuth cell
+        let case1 = callForAuth() && indexPath.row == 0;
+        return precondition && case1
     }
-	
+    
     func isSelectOtherPaymentMethodCellFor(indexPath: IndexPath) -> Bool {
-		
-		//non approved case
-		let precondition = indexPath.section == 1 && !approved()
-		//if row at index 0 exists and callForAuth is disabled, row 0 should display select another payment row
-		let case1 = !callForAuth() && indexPath.row == 0;
-		//if row at index 1 exists, row 1 should display select another payment row
-		let case2 = indexPath.row == 1;
-		return precondition && (case1 || case2)
+        
+        //non approved case
+        let precondition = indexPath.section == 2 && !approved()
+        //if row at index 0 exists and callForAuth is disabled, row 0 should display select another payment row
+        let case1 = !callForAuth() && indexPath.row == 0;
+        //if row at index 1 exists, row 1 should display select another payment row
+        let case2 = indexPath.row == 1;
+        return precondition && (case1 || case2)
     }
     
     func isAdditionalCustomCellFor(indexPath: IndexPath) -> Bool {
-        return indexPath.section == 2
-    }
-	
-    func isSecondaryExitButtonCellFor(indexPath: IndexPath) -> Bool {
         return indexPath.section == 3
     }
     
+    func isSecondaryExitButtonCellFor(indexPath: IndexPath) -> Bool {
+        return indexPath.section == 4
+    }
+    
+    func isCustomSubHeaderCellFor(indexPath: IndexPath) -> Bool {
+        return indexPath.section == 1
+    }
+    
     func numberOfRowsInSection(section: Int) -> Int {
-        if section == 1 {
+        if section == 2 {
             return numberOfCellInBody()
-        
+            
         } else if isAdditionalCustomCellFor(indexPath: IndexPath(row: 0, section: section)) {
             return numberOfCustomAdditionalCells()
-        
+            
+        } else if isCustomSubHeaderCellFor(indexPath: IndexPath(row: 0, section: section)) {
+            return numberOfCustomSubHeaderCells()
+            
         } else if isSecondaryExitButtonCellFor(indexPath: IndexPath(row: 0, section: section)){
             if approved() && MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSecondaryExitButtonCallback != nil {
                 return 1
@@ -205,15 +212,15 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
     
     func numberOfCellInBody() -> Int {
         if approved() {
-			let approvedBodyAdd = !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() ? 1 : 0;
-			let emailCellAdd = !String.isNullOrEmpty(paymentResult.payerEmail) ? 1 : 0;
-			return approvedBodyAdd + emailCellAdd;
-			
-		} else {
-			let callForAuthAdd = callForAuth() ? 1 : 0;
-			let selectAnotherCellAdd = !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isContentCellDisable() ? 1 : 0
-			return callForAuthAdd + selectAnotherCellAdd;
-		}
+            let approvedBodyAdd = !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() ? 1 : 0;
+            let emailCellAdd = !String.isNullOrEmpty(paymentResult.payerEmail) ? 1 : 0;
+            return approvedBodyAdd + emailCellAdd;
+            
+        } else {
+            let callForAuthAdd = callForAuth() ? 1 : 0;
+            let selectAnotherCellAdd = !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isContentCellDisable() ? 1 : 0
+            return callForAuthAdd + selectAnotherCellAdd;
+        }
     }
     
     func numberOfCustomAdditionalCells() -> Int {
@@ -221,6 +228,13 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
             return PaymentResultScreenPreference.pendingAdditionalInfoCells.count
         } else if !Array.isNullOrEmpty(PaymentResultScreenPreference.approvedAdditionalInfoCells) && approved() {
             return PaymentResultScreenPreference.approvedAdditionalInfoCells.count
+        }
+        return 0
+    }
+    
+    func numberOfCustomSubHeaderCells() -> Int {
+        if !Array.isNullOrEmpty(PaymentResultScreenPreference.approvedSubHeaderCells) && approved() {
+            return PaymentResultScreenPreference.approvedSubHeaderCells.count
         }
         return 0
     }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/DineroEnCuentaTableViewCell.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/DineroEnCuentaTableViewCell.m
@@ -11,7 +11,7 @@
 @implementation DineroEnCuentaTableViewCell
 
 -(CGFloat)getHeight {
-    return (CGFloat)150;
+    return (CGFloat)50;
 }
 
 @end

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/DineroEnCuentaTableViewCell.xib
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/DineroEnCuentaTableViewCell.xib
@@ -4,36 +4,35 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="231" id="KGk-i7-Jjw" customClass="DineroEnCuentaTableViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="369" height="231"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="99" id="KGk-i7-Jjw" customClass="DineroEnCuentaTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="369" height="99"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="369" height="230"/>
+                <rect key="frame" x="0.0" y="0.0" width="369" height="99"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tambien Programaste esta recarga para el 15 de cada mes" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ni4-ir-WsY">
-                        <rect key="frame" x="32" y="28" width="305" height="145"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tambien Programaste esta recarga para el 15 de cada mes" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ni4-ir-WsY">
+                        <rect key="frame" x="20" y="39.5" width="329" height="19.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" red="0.40000000000000002" green="0.40000000000000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
+                <color key="backgroundColor" red="0.96862745098039216" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstItem="Ni4-ir-WsY" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="6sD-o7-99U"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="Ni4-ir-WsY" secondAttribute="bottom" constant="50" id="9r9-hM-vaK"/>
-                    <constraint firstItem="Ni4-ir-WsY" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="24" id="afW-5B-BRz"/>
-                    <constraint firstItem="Ni4-ir-WsY" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="20" id="mHK-PU-5Gg"/>
+                    <constraint firstItem="Ni4-ir-WsY" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="AyX-Bt-gaz"/>
+                    <constraint firstAttribute="trailing" secondItem="Ni4-ir-WsY" secondAttribute="trailing" constant="20" id="DbV-TE-Kxx"/>
+                    <constraint firstItem="Ni4-ir-WsY" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="H69-mO-475"/>
+                    <constraint firstItem="Ni4-ir-WsY" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="cMS-b0-PVy"/>
                 </constraints>
             </tableViewCellContentView>
-            <point key="canvasLocation" x="9.5" y="197.5"/>
+            <point key="canvasLocation" x="9.5" y="131.5"/>
         </tableViewCell>
     </objects>
 </document>

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -210,6 +210,7 @@
     [resultPreference setRejectedIconSubtextWithText:@"Uppss..."];
     [resultPreference setRejectedContentTextWithText:@"Vuelve más tarde"];
     [resultPreference setRejectedContentTitleWithTitle:@"¿Qué hago?"];
+    [resultPreference disableApprovedReceipt];
     //    [resultPreference disableRejectedContentTitle];
     //    [resultPreference disableRejectedContentText];
     //    [resultPreference setRejectedSecondaryExitButtonWithCallback:^(PaymentResult * paymentResult) {
@@ -237,10 +238,17 @@
     [dineroEnCuenta.button addTarget:self action:@selector(invokeCallbackPaymentResult:) forControlEvents:UIControlEventTouchUpInside];
     MPCustomCell *dineroEnCuentaCustom = [[MPCustomCell alloc] initWithCell:dineroEnCuenta];
     self.dineroEnCuentaCell = dineroEnCuentaCustom;
+
+    
+    DineroEnCuentaTableViewCell *header = [[[NSBundle mainBundle] loadNibNamed:@"DineroEnCuentaTableViewCell" owner:self options:nil] firstObject];
+    [header.button addTarget:self action:@selector(invokeCallbackPaymentResult:) forControlEvents:UIControlEventTouchUpInside];
+    
+    MPCustomCell *subHeader = [[MPCustomCell alloc] initWithCell:header];
     
     
     [PaymentResultScreenPreference setCustomPendingCellsWithCustomCells:[NSArray arrayWithObjects:subeCongrats, nil]];
     [PaymentResultScreenPreference setCustomsApprovedCellWithCustomCells:[NSArray arrayWithObjects:dineroEnCuentaCustom, nil]];
+    [PaymentResultScreenPreference setCustomApprovedSubHeaderCellWithCustomCells:[NSArray arrayWithObjects:subHeader, nil]];
     
     [MercadoPagoCheckout setPaymentResultScreenPreference:resultPreference];
     


### PR DESCRIPTION
Fix #813 

##  Cambios introducidos : 
- Se agrega la opcion de setear una custom cell abajo de header en congrats

Ejemplo:
`    [PaymentResultScreenPreference setCustomApprovedSubHeaderCellWithCustomCells:[NSArray arrayWithObjects:subHeader, nil]];`

### Revisión
- [ ] Todos los textos se encuentran localizables
- [ ] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [ ] No se agregan logs / prints innecesarios
- [ ] No se agregan comentarios basura

### Testeo
- [ ] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
