### PR TITLE
Add option to disable amount in custom summaryRows

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PurchaseSimpleDetailTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PurchaseSimpleDetailTableViewCell.swift
@@ -18,26 +18,30 @@ class PurchaseSimpleDetailTableViewCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        unitPrice.text = ""
+        titleLabel.text = ""
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
     }
     
-    internal func fillCell(_ title : String, amount : Double, currency : Currency, payerCost : PayerCost? = nil, addSeparatorLine : Bool = true, titleColor: UIColor = UIColor.px_grayDark(), amountColor: UIColor = UIColor.px_grayDark()){
+    internal func fillCell(_ title : String, amount : Double, currency : Currency, payerCost : PayerCost? = nil, addSeparatorLine : Bool = true, titleColor: UIColor = UIColor.px_grayDark(), amountColor: UIColor = UIColor.px_grayDark(), amountEnable: Bool = true){
         
         fillDescription(title: title, color: titleColor)
         
         self.removeFromSuperview()
         
-        fillAmount(amount: amount, color: amountColor, payerCost: payerCost, currency: currency)
+        if amountEnable {
+            fillAmount(amount: amount, color: amountColor, payerCost: payerCost, currency: currency)
+        }
         
         addSeperatorLine(addLine: addSeparatorLine)
     }
     
     internal func fillCell(summaryRow: SummaryRow, currency : Currency, payerCost : PayerCost? = nil){
         
-        fillCell(summaryRow.customDescription, amount: summaryRow.customAmount, currency: currency, addSeparatorLine: summaryRow.separatorLine, titleColor: summaryRow.colorDescription, amountColor: summaryRow.colorAmount)
+        fillCell(summaryRow.customDescription, amount: summaryRow.customAmount, currency: currency, addSeparatorLine: summaryRow.separatorLine, titleColor: summaryRow.colorDescription, amountColor: summaryRow.colorAmount, amountEnable: summaryRow.isAmountEnable())
     }
     
     func fillDescription(title: String, color: UIColor) {

--- a/MercadoPagoSDK/MercadoPagoSDK/SummaryRow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SummaryRow.swift
@@ -14,6 +14,7 @@ open class SummaryRow: NSObject {
     var colorDescription: UIColor = UIColor.px_grayDark()
     var colorAmount: UIColor = UIColor.px_grayDark()
     var separatorLine: Bool = true
+    var amountEnable = true
     
     public init(customDescription: String, descriptionColor: UIColor? , customAmount: Double, amountColor: UIColor?, separatorLine: Bool = true) {
         self.customDescription = customDescription
@@ -26,5 +27,17 @@ open class SummaryRow: NSObject {
         if let amountColor = amountColor {
             self.colorAmount = amountColor
         }
+    }
+    
+    open func disableAmount() {
+        amountEnable = false
+    }
+    
+    open func enableAmount() {
+        amountEnable = true
+    }
+    
+    open func isAmountEnable() -> Bool {
+        return amountEnable
     }
 }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -282,6 +282,8 @@
     
     SummaryRow *summaryRow = [[SummaryRow alloc] initWithCustomDescription:@"Comisión BACEN" descriptionColor: UIColor.brownColor customAmount:20.0 amountColor:UIColor.redColor separatorLine:YES];
     
+    [summaryRow disableAmount];
+    
     [reviewPreference setSummaryRowsWithSummaryRows:[NSArray arrayWithObjects:summaryRow, nil]];
     
     [ReviewScreenPreference setAddionalInfoCellsWithCustomCells:[NSArray arrayWithObjects:customCargaSube2, customCargaSube, nil]];


### PR DESCRIPTION
Fix #819 

##  Cambios introducidos : 
- Se añade la opción de deshabilitar el total en las summary Row

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [ ] Testeado en BETA con emulador
- [X] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
