### PR TITLE
Remove 1x in RyC & Congrats

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/ApprovedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ApprovedTableViewCell.swift
@@ -89,31 +89,28 @@ class ApprovedTableViewCell: UITableViewCell {
     }
     
     func fillInstallmentLabel(amount: Double, payerCost: PayerCost? = nil, currency: Currency) {
-        var installmentNumber = ""
-        
-        if payerCost != nil && payerCost?.installments != 0 {
-            installmentNumber = "\(payerCost!.installments) x "
-        }
-        
-        let total = payerCost != nil ? payerCost!.installmentAmount : amount
-        
-        if amount != 0 {
-            
-            let totalAmount = Utils.getAttributedAmount(total, thousandSeparator: String(currency.thousandsSeparator), decimalSeparator: String(currency.decimalSeparator), currencySymbol: String(currency.symbol), color:UIColor.black, fontSize: 24, centsFontSize: 11, baselineOffset:11)
-            let installmentLabel = NSMutableAttributedString(string: installmentNumber, attributes: [NSFontAttributeName: Utils.getFont(size: 24)])
+
+        if payerCost != nil {
+            let attributedInstallment = Utils.getTransactionInstallmentsDescription(String(describing : payerCost!.installments), currency: currency, installmentAmount: payerCost!.installmentAmount, color:UIColor.black, fontSize: 24, centsFontSize: 11, baselineOffset:11)
+            self.installments.attributedText  = attributedInstallment
+        } else if amount != 0 {
+            let totalAmount = Utils.getAttributedAmount(amount, thousandSeparator: String(currency.thousandsSeparator), decimalSeparator: String(currency.decimalSeparator), currencySymbol: String(currency.symbol), color:UIColor.black, fontSize: 24, centsFontSize: 11, baselineOffset:11)
+            let installmentLabel = NSMutableAttributedString(string: "", attributes: [NSFontAttributeName: Utils.getFont(size: 24)])
             installmentLabel.append(totalAmount)
             self.installments.attributedText =  installmentLabel
+
         }
+        
     }
     
     func fillInterestLabel(payerCost: PayerCost) {
-        if payerCost.installments > 1 && payerCost.installmentRate == 0 {
+        if !payerCost.hasInstallmentsRate() {
             installmentRate.text = "Sin interés".localized
         }
     }
     
     func fillTotalLabel(payerCost: PayerCost, currency: Currency) {
-        if payerCost.totalAmount != 0 && payerCost.installments != 0{
+        if payerCost.totalAmount > 0 && payerCost.hasInstallmentsRate() {
             let attributedTotal = NSMutableAttributedString(attributedString: NSAttributedString(string: "( ", attributes: [NSForegroundColorAttributeName : UIColor.black, NSFontAttributeName: Utils.getFont(size: 16)]))
             attributedTotal.append(Utils.getAttributedAmount(payerCost.totalAmount, thousandSeparator: String(currency.thousandsSeparator), decimalSeparator: String(currency.decimalSeparator), currencySymbol: String(currency.symbol), color: UIColor.black, fontSize:16, baselineOffset:4))
             attributedTotal.append(NSAttributedString(string: " )", attributes: [NSForegroundColorAttributeName : UIColor.black, NSFontAttributeName: Utils.getFont(size: 16)]))

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -713,7 +713,7 @@ open class CheckoutViewModel {
     }
     
     func shouldShowInstallmentSummary() -> Bool {
-        return isPaymentMethodSelectedCard() && self.paymentData.paymentMethod.paymentTypeId != "debit_card"
+        return isPaymentMethodSelectedCard() && self.paymentData.paymentMethod.paymentTypeId != "debit_card" && paymentData.payerCost != nil && paymentData.payerCost!.hasInstallmentsRate()
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
@@ -49,11 +49,14 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
         if let payerCost = payerCost {
             self.paymentDescription.attributedText = Utils.getTransactionInstallmentsDescription(String(payerCost.installments),currency:currency, installmentAmount: payerCost.installmentAmount, additionalString: NSAttributedString(string : ""), color: UIColor.black, fontSize : 24, centsFontSize: 12, baselineOffset: 9)
             let attributedAmount = Utils.getAttributedAmount(amount, currency: currency, color : UIColor.px_grayBaseText(), fontSize : 16, baselineOffset : 4)
-            let attributedAmountFinal = NSMutableAttributedString(string : "(")
-            attributedAmountFinal.append(attributedAmount)
-            attributedAmountFinal.append(NSAttributedString(string : ")"))
-            self.totalAmountLabel.attributedText = attributedAmountFinal
-            self.totalAmountLabel.attributedText = attributedAmountFinal
+            
+            if payerCost.installments > 1 {
+                let attributedAmountFinal = NSMutableAttributedString(string : "(")
+                attributedAmountFinal.append(attributedAmount)
+                attributedAmountFinal.append(NSAttributedString(string : ")"))
+                self.totalAmountLabel.attributedText = attributedAmountFinal
+                self.totalAmountLabel.attributedText = attributedAmountFinal
+            }
         } else {
              self.paymentDescription.attributedText = Utils.getAttributedAmount(amount, thousandSeparator: currency.thousandsSeparator, decimalSeparator: currency.decimalSeparator, currencySymbol: currency.symbol, color: UIColor.black, fontSize: 24, centsFontSize: 12, baselineOffset: 9)
             self.totalAmountLabel.text = ""

--- a/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Utils.swift
@@ -123,7 +123,10 @@ class Utils {
         
         let stringToWrite = NSMutableAttributedString()
         
-        stringToWrite.append(NSMutableAttributedString(string: installments + "x ", attributes: descriptionAttributes))
+        let installmentsValue = Int(installments)
+        if  installmentsValue > 1 {
+            stringToWrite.append(NSMutableAttributedString(string: installments + "x ", attributes: descriptionAttributes))
+        }
         
 
         stringToWrite.append(Utils.getAttributedAmount(installmentAmount, thousandSeparator: currency.getThousandsSeparatorOrDefault(), decimalSeparator: currency.getDecimalSeparatorOrDefault(), currencySymbol: currency.getCurrencySymbolOrDefault() , color:color, fontSize : fontSize, centsFontSize: centsFontSize, baselineOffset : baselineOffset))


### PR DESCRIPTION
##  Cambios introducidos : 
- Se remueve texto innecesario de "1x" en caso que el pago sea en una cuota única. También se oculta el label con el precio con interés para una cuota.

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [NA] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
