### PR TITLE
Fixes para recarga recurrente

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -29,7 +29,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     
     @IBOutlet weak var checkoutTable: UITableView!
     
-    init(viewModel: CheckoutViewModel, callbackPaymentData : @escaping (PaymentData) -> Void,  callbackCancel : @escaping ((Void) -> Void), callbackConfirm : @escaping (PaymentData) -> Void) {
+   public init(viewModel: CheckoutViewModel, callbackPaymentData : @escaping (PaymentData) -> Void,  callbackCancel : @escaping ((Void) -> Void), callbackConfirm : @escaping (PaymentData) -> Void) {
         super.init(nibName: "CheckoutViewController", bundle: MercadoPago.getBundle())
         self.initCommon()
         self.viewModel = viewModel
@@ -478,7 +478,7 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     
 }
 
-open class CheckoutViewModel {
+open class CheckoutViewModel: NSObject {
     
     var shippingIncluded = false
     var freeShippingIncluded = false
@@ -494,14 +494,14 @@ open class CheckoutViewModel {
     
     public static var CUSTOMER_ID = ""
     
-    init(checkoutPreference : CheckoutPreference, paymentData : PaymentData, paymentOptionSelected : PaymentMethodOption, discount: DiscountCoupon? = nil) {
+    public init(checkoutPreference : CheckoutPreference, paymentData : PaymentData, paymentOptionSelected : PaymentMethodOption, discount: DiscountCoupon? = nil) {
         CheckoutViewModel.CUSTOMER_ID = ""
         self.preference = checkoutPreference
         self.paymentData = paymentData
         self.discount = discount
         self.paymentOptionSelected = paymentOptionSelected
-        
-        self.setSummaryRows()
+        super.init()
+        setSummaryRows()
     }
     
     func setSummaryRows() {

--- a/MercadoPagoSDK/MercadoPagoSDK/CustomerPaymentMethod.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CustomerPaymentMethod.swift
@@ -20,6 +20,17 @@ open class CustomerPaymentMethod: NSObject, CardInformation, PaymentMethodOption
     var paymentMethod : PaymentMethod!
     var card : Card?
     
+    public override init() {
+        super.init()
+    }
+    
+    public init(id: String, paymentMethodId: String, paymentMethodTypeId: String, description: String) {
+        self._id = id
+        self.paymentMethodId = paymentMethodId
+        self.paymentMethodTypeId = paymentMethodTypeId
+        self._description = description
+    }
+    
     open class func fromJSON(_ json : NSDictionary) -> CustomerPaymentMethod {
         let  customerPaymentMethod = CustomerPaymentMethod()
         


### PR DESCRIPTION
Fix #834

##  Cambios introducidos : 
- Se hacen públicos los inits de CheckoutViewController
- Se hereda CheckoutViewModel de NSObject
- Se hace publico un init de CustomPaymentMethod

### Revisión
- [ ] Todos los textos se encuentran localizables
- [ ] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [ ] No se agregan logs / prints innecesarios
- [ ] No se agregan comentarios basura

### Testeo
- [ ] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
