### PR TITLE
Se deshabilita la seleccion de la celda de SecodaryButton en PaymentResult

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/SecondaryExitButtonTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecondaryExitButtonTableViewCell.swift
@@ -17,6 +17,7 @@ class SecondaryExitButtonTableViewCell: CallbackCancelTableViewCell {
         // Initialization code
         button.layer.cornerRadius = 3
         self.button.titleLabel?.font = Utils.getFont(size: 16)
+        self.selectionStyle = .none
     }
     
     open func fillCell(paymentResult: PaymentResult){


### PR DESCRIPTION
Fix #877 

##  Cambios introducidos : 
- Se deja de poder seleccionar la celda que contiene el secodary button en Payment Result

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
