### PR TITLE
Refactor de preferencias de pantallas

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/ApprovedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ApprovedTableViewCell.swift
@@ -32,17 +32,17 @@ class ApprovedTableViewCell: UITableViewCell {
         setFonts()
     }
     
-    func fillCell(paymentResult: PaymentResult, checkoutPreference: CheckoutPreference?){
+    func fillCell(paymentResult: PaymentResult, checkoutPreference: CheckoutPreference?, paymentResultScreenPreference: PaymentResultScreenPreference){
         
         let currency = MercadoPagoContext.getCurrency()
         
-        if !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPaymentIdDisable(){
+        if !paymentResultScreenPreference.isPaymentIdDisable(){
             fillID(id: paymentResult._id)
         } else {
             idInstallmentConstraint.constant = 0
         }
         
-        if !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isAmountDisable(){
+        if !paymentResultScreenPreference.isAmountDisable(){
             if let payerCost = paymentResult.paymentData?.payerCost {
                 fillInstallmentLabel(amount: payerCost.totalAmount, payerCost: payerCost, currency: currency)
                 fillInterestLabel(payerCost: payerCost)
@@ -59,7 +59,7 @@ class ApprovedTableViewCell: UITableViewCell {
             paymentMethodTotalConstraint.constant = 0
         }
         
-        if !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPaymentMethodDisable() {
+        if !paymentResultScreenPreference.isPaymentMethodDisable() {
             
             fillPaymentMethodIcon(paymentMethod: paymentResult.paymentData?.paymentMethod)
             

--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewController.swift
@@ -317,11 +317,11 @@ open class CheckoutViewController: MercadoPagoUIScrollViewController, UITableVie
     }
     
     private func getCustomAdditionalCell(indexPath: IndexPath) -> UITableViewCell{
-        return makeCellWith(customCell: ReviewScreenPreference.additionalInfoCells[indexPath.row], indentifier: "CustomAppCell")
+        return makeCellWith(customCell: MercadoPagoCheckoutViewModel.reviewScreenPreference.additionalInfoCells[indexPath.row], indentifier: "CustomAppCell")
     }
     
     private func getCustomItemCell(indexPath: IndexPath) -> UITableViewCell{
-        return makeCellWith(customCell: ReviewScreenPreference.customItemCells[indexPath.row], indentifier: "CustomItemCell")
+        return makeCellWith(customCell: MercadoPagoCheckoutViewModel.reviewScreenPreference.customItemCells[indexPath.row], indentifier: "CustomItemCell")
     }
     
     private func makeCellWith(customCell : MPCustomCell, indentifier : String) -> UITableViewCell {
@@ -579,7 +579,7 @@ open class CheckoutViewModel: NSObject {
             return ConfirmPaymentTableViewCell.ROW_HEIGHT
             
         } else if self.isItemCellFor(indexPath: indexPath) {
-            return hasCustomItemCells() ? ReviewScreenPreference.customItemCells[indexPath.row].getHeight() : PurchaseItemDetailTableViewCell.getCellHeight(item: self.preference!.items[indexPath.row])
+            return hasCustomItemCells() ? MercadoPagoCheckoutViewModel.reviewScreenPreference.customItemCells[indexPath.row].getHeight() : PurchaseItemDetailTableViewCell.getCellHeight(item: self.preference!.items[indexPath.row])
             
         } else if self.isPaymentMethodCellFor(indexPath: indexPath) {
             if isPaymentMethodSelectedCard() {
@@ -588,7 +588,7 @@ open class CheckoutViewModel: NSObject {
             return OfflinePaymentMethodCell.ROW_HEIGHT
         
         } else if self.isAddtionalCustomCellsFor(indexPath: indexPath) {
-            return ReviewScreenPreference.additionalInfoCells[indexPath.row].getHeight()
+            return MercadoPagoCheckoutViewModel.reviewScreenPreference.additionalInfoCells[indexPath.row].getHeight()
             
         } else if isTermsAndConditionsViewCellFor(indexPath: indexPath) {
             return TermsAndConditionsViewCell.getCellHeight()
@@ -630,21 +630,21 @@ open class CheckoutViewModel: NSObject {
     }
     
     func numberOfCustomAdditionalCells() -> Int {
-        if !Array.isNullOrEmpty(ReviewScreenPreference.additionalInfoCells) {
-            return ReviewScreenPreference.additionalInfoCells.count
+        if !Array.isNullOrEmpty(MercadoPagoCheckoutViewModel.reviewScreenPreference.additionalInfoCells) {
+            return MercadoPagoCheckoutViewModel.reviewScreenPreference.additionalInfoCells.count
         }
         return 0
     }
     
     func numberOfCustomItemCells() -> Int {
         if hasCustomItemCells() {
-            return ReviewScreenPreference.customItemCells.count
+            return MercadoPagoCheckoutViewModel.reviewScreenPreference.customItemCells.count
         }
         return 0
     }
     
     func hasCustomItemCells() -> Bool {
-        return !Array.isNullOrEmpty(ReviewScreenPreference.customItemCells)
+        return !Array.isNullOrEmpty(MercadoPagoCheckoutViewModel.reviewScreenPreference.customItemCells)
     }
     
     func numberOfSummaryRows() -> Int{

--- a/MercadoPagoSDK/MercadoPagoSDK/FooterTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/FooterTableViewCell.swift
@@ -18,11 +18,11 @@ class FooterTableViewCell: CallbackCancelTableViewCell {
         self.button.titleLabel?.font = Utils.getFont(size: 16)
         self.selectionStyle = .none
     }
-    func fillCell(paymentResult: PaymentResult){
+    func fillCell(paymentResult: PaymentResult, paymentResultScreenPreference: PaymentResultScreenPreference){
         if paymentResult.statusDetail.contains("cc_rejected_bad_filled"){
             self.button.setTitle("Cancelar pago".localized, for: UIControlState.normal)
         } else{
-            self.button.setTitle(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getExitButtonTitle(), for: UIControlState.normal)
+            self.button.setTitle(paymentResultScreenPreference.getExitButtonTitle(), for: UIControlState.normal)
         }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/HeaderCongratsTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/HeaderCongratsTableViewCell.swift
@@ -28,19 +28,19 @@ class HeaderCongratsTableViewCell: UITableViewCell, TimerDelegate {
         subtitle.text = ""
     }
     
-    func fillCell(paymentResult: PaymentResult, paymentMethod: PaymentMethod?, color: UIColor){
+    func fillCell(paymentResult: PaymentResult, paymentMethod: PaymentMethod?, color: UIColor, paymentResultScreenPreference: PaymentResultScreenPreference){
         
         view.backgroundColor = color
         
 		if paymentResult.status == "approved" {
-			icon.image = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getHeaderApprovedIcon()
-            title.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedTitle()
-            subtitle.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedSubtitle()
+			icon.image = paymentResultScreenPreference.getHeaderApprovedIcon()
+            title.text = paymentResultScreenPreference.getApprovedTitle()
+            subtitle.text = paymentResultScreenPreference.getApprovedSubtitle()
             
         } else if paymentResult.status == "in_process" {
-            icon.image = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getHeaderPendingIcon()
-            title.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingTitle()
-            subtitle.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingSubtitle()
+            icon.image = paymentResultScreenPreference.getHeaderPendingIcon()
+            title.text = paymentResultScreenPreference.getPendingTitle()
+            subtitle.text = paymentResultScreenPreference.getPendingSubtitle()
             
         } else if paymentResult.statusDetail == "cc_rejected_call_for_authorize" {
             icon.image = MercadoPago.getImage("MPSDK_payment_result_c4a")
@@ -65,12 +65,12 @@ class HeaderCongratsTableViewCell: UITableViewCell, TimerDelegate {
             }
      
         } else {
-            icon.image = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getHeaderRejectedIcon()
+            icon.image = paymentResultScreenPreference.getHeaderRejectedIcon()
             var title = (paymentResult.statusDetail + "_title")
             if !title.existsLocalized() {
-                if !String.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedTitle()) {
-                    self.title.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedTitle()
-                    subtitle.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedSubtitle()
+                if !String.isNullOrEmpty(paymentResultScreenPreference.getRejectedTitle()) {
+                    self.title.text = paymentResultScreenPreference.getRejectedTitle()
+                    subtitle.text = paymentResultScreenPreference.getRejectedSubtitle()
                 } else {
                     self.title.text = "Uy, no pudimos procesar el pago".localized
                 }
@@ -91,7 +91,7 @@ class HeaderCongratsTableViewCell: UITableViewCell, TimerDelegate {
                 self.addSubview(timerLabel!)
             }
             
-            messageError.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedIconSubtext()
+            messageError.text = paymentResultScreenPreference.getRejectedIconSubtext()
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/InstructionsViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/InstructionsViewController.swift
@@ -19,6 +19,7 @@ open class InstructionsViewController: MercadoPagoUIViewController, UITableViewD
     var bundle = MercadoPago.getBundle()
     var color:UIColor?
     var instructionsInfo: InstructionsInfo?
+    var paymentResultScreenPreference: PaymentResultScreenPreference!
     
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -65,11 +66,12 @@ open class InstructionsViewController: MercadoPagoUIViewController, UITableViewD
             self.tableView.reloadData()
         }
     }
-    public init(paymentResult : PaymentResult, callback : @escaping ( _ status : PaymentResult.CongratsState) -> Void) {
+    public init(paymentResult : PaymentResult, callback : @escaping ( _ status : PaymentResult.CongratsState) -> Void, paymentResultScreenPreference: PaymentResultScreenPreference = PaymentResultScreenPreference()) {
         
         self.callback = callback
         super.init(nibName: "InstructionsViewController", bundle: bundle)
         self.paymentResult = paymentResult
+        self.paymentResultScreenPreference = paymentResultScreenPreference
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -128,7 +130,7 @@ open class InstructionsViewController: MercadoPagoUIViewController, UITableViewD
                 let footerNib = self.tableView.dequeueReusableCell(withIdentifier: "footerNib") as! FooterTableViewCell
                 footerNib.selectionStyle = .none
                 footerNib.setCallbackStatus(callback: callback, status: PaymentResult.CongratsState.ok)
-                footerNib.fillCell(paymentResult: paymentResult)
+                footerNib.fillCell(paymentResult: paymentResult, paymentResultScreenPreference: paymentResultScreenPreference)
                 ViewUtils.drawBottomLine(y: footerNib.contentView.frame.minY, width: UIScreen.main.bounds.width, inView: footerNib.contentView)
                 return footerNib
             }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -499,13 +499,9 @@ open class MercadoPagoCheckout: NSObject {
     }
     
     func finish(){
-        
-        ReviewScreenPreference.clear()
-        PaymentResultScreenPreference.clear()
         DecorationPreference.applyAppNavBarDecorationPreferencesTo(navigationController: self.navigationController)
         
         removeRootLoading()
-        
         
         if self.viewModel.paymentData.isComplete() && !MercadoPagoCheckoutViewModel.flowPreference.isReviewAndConfirmScreenEnable() && MercadoPagoCheckoutViewModel.paymentDataCallback != nil {
             MercadoPagoCheckoutViewModel.paymentDataCallback!(self.viewModel.paymentData)

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -610,8 +610,8 @@ extension MercadoPagoCheckout {
         MercadoPagoCheckoutViewModel.paymentResultScreenPreference = paymentResultScreenPreference
     }
     
-    open static func setReviewScreenPreference(_ reviewScreenPreference: ReviewScreenPreference){
-        MercadoPagoCheckoutViewModel.reviewScreenPreference = reviewScreenPreference
+    open func setReviewScreenPreference(_ reviewScreenPreference: ReviewScreenPreference){
+        self.viewModel.reviewScreenPreference = reviewScreenPreference
     }
     
     open static func setPaymentDataCallback(paymentDataCallback : @escaping (_ paymentData : PaymentData) -> Void) {

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -454,7 +454,7 @@ open class MercadoPagoCheckout: NSObject {
 
         let congratsViewController : UIViewController
         if (PaymentTypeId.isOnlineType(paymentTypeId: self.viewModel.paymentData.paymentMethod.paymentTypeId)) {
-            congratsViewController = PaymentResultViewController(paymentResult: self.viewModel.paymentResult!, checkoutPreference: self.viewModel.checkoutPreference, callback: { (state : PaymentResult.CongratsState) in
+            congratsViewController = PaymentResultViewController(paymentResult: self.viewModel.paymentResult!, checkoutPreference: self.viewModel.checkoutPreference, paymentResultScreenPreference: self.viewModel.paymentResultScreenPreference, callback: { (state : PaymentResult.CongratsState) in
                 if state == PaymentResult.CongratsState.call_FOR_AUTH {
                     self.navigationController.setNavigationBarHidden(false, animated: false)
                     self.viewModel.prepareForClone()
@@ -463,16 +463,16 @@ open class MercadoPagoCheckout: NSObject {
                     self.navigationController.setNavigationBarHidden(false, animated: false)
                     self.viewModel.prepareForNewSelection()
                     self.executeNextStep()
-
+                    
                 }else{
                     self.finish()
                 }
-
+                
             })
         } else {
             congratsViewController = InstructionsViewController(paymentResult: self.viewModel.paymentResult!,  callback: { (state :PaymentResult.CongratsState) in
                 self.finish()
-            })
+            }, paymentResultScreenPreference: self.viewModel.paymentResultScreenPreference)
         }
         self.pushViewController(viewController : congratsViewController, animated: true)
     }
@@ -606,8 +606,8 @@ extension MercadoPagoCheckout {
         MercadoPagoCheckoutViewModel.flowPreference = flowPreference
     }
     
-    open static func setPaymentResultScreenPreference(_ paymentResultScreenPreference: PaymentResultScreenPreference){
-        MercadoPagoCheckoutViewModel.paymentResultScreenPreference = paymentResultScreenPreference
+    open func setPaymentResultScreenPreference(_ paymentResultScreenPreference: PaymentResultScreenPreference){
+        self.viewModel.paymentResultScreenPreference = paymentResultScreenPreference
     }
     
     open func setReviewScreenPreference(_ reviewScreenPreference: ReviewScreenPreference){

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -39,7 +39,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     internal static var servicePreference = ServicePreference()
     internal static var decorationPreference = DecorationPreference()
     internal static var flowPreference = FlowPreference()
-    internal static var reviewScreenPreference = ReviewScreenPreference()
+    var reviewScreenPreference = ReviewScreenPreference()
     internal static var paymentResultScreenPreference = PaymentResultScreenPreference()
     
     internal static var paymentDataCallback : ((PaymentData) -> Void)?
@@ -179,7 +179,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     
 
     public func checkoutViewModel() -> CheckoutViewModel {
-        let checkoutViewModel = CheckoutViewModel(checkoutPreference: self.checkoutPreference, paymentData : self.paymentData, paymentOptionSelected : self.paymentOptionSelected!, discount: paymentData.discount)
+        let checkoutViewModel = CheckoutViewModel(checkoutPreference: self.checkoutPreference, paymentData : self.paymentData, paymentOptionSelected : self.paymentOptionSelected!, discount: paymentData.discount, reviewScreenPreference: reviewScreenPreference)
         return checkoutViewModel
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -40,7 +40,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     internal static var decorationPreference = DecorationPreference()
     internal static var flowPreference = FlowPreference()
     var reviewScreenPreference = ReviewScreenPreference()
-    internal static var paymentResultScreenPreference = PaymentResultScreenPreference()
+    var paymentResultScreenPreference = PaymentResultScreenPreference()
     
     internal static var paymentDataCallback : ((PaymentData) -> Void)?
     internal static var paymentDataConfirmCallback : ((PaymentData) -> Void)?

--- a/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
@@ -61,7 +61,7 @@ class OfflinePaymentMethodCell: UITableViewCell {
         super.setSelected(selected, animated: animated)
     }
     
-    internal func fillCell(_ paymentMethodOption : PaymentMethodOption, amount : Double, paymentMethod : PaymentMethod, currency : Currency) {
+    internal func fillCell(_ paymentMethodOption : PaymentMethodOption, amount : Double, paymentMethod : PaymentMethod, currency : Currency, reviewScreenPreference: ReviewScreenPreference = ReviewScreenPreference()) {
         
         let attributedAmount = Utils.getAttributedAmount(amount, currency: currency, color : UIColor.black)
         var attributedTitle = NSMutableAttributedString(string : "Pagáras ".localized, attributes: [NSFontAttributeName: Utils.getFont(size: 20), NSForegroundColorAttributeName: UIColor.px_grayBaseText()])
@@ -94,7 +94,7 @@ class OfflinePaymentMethodCell: UITableViewCell {
 
         self.paymentMethodDescription.attributedText = attributedTitle
 		
-		if MercadoPagoCheckoutViewModel.reviewScreenPreference.isChangeMethodOptionEnabled() {
+		if reviewScreenPreference.isChangeMethodOptionEnabled() {
    			self.changePaymentButton.setTitleColor(UIColor.primaryColor(), for: UIControlState.normal)			
 			self.changePaymentButton.titleLabel?.font = Utils.getFont(size: 18)
 			self.changePaymentButton.setTitle("Cambiar medio de pago".localized, for: .normal)

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
@@ -39,7 +39,7 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
         super.setSelected(selected, animated: animated)
     }
     
-    func fillCell(paymentData: PaymentData, amount : Double) {
+    func fillCell(paymentData: PaymentData, amount : Double, reviewScreenPreference: ReviewScreenPreference = ReviewScreenPreference()) {
         
         fillIcon()
         
@@ -49,7 +49,7 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
         
         fillCFT(payerCost: paymentData.payerCost)
         
-        fillChangePaymentMethodButton()
+        fillChangePaymentMethodButton(reviewScreenPreference: reviewScreenPreference)
         
         fillSeparatorLine(payerCost: paymentData.payerCost)
         
@@ -91,8 +91,8 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
         }
     }
     
-    func fillChangePaymentMethodButton() {
-        if MercadoPagoCheckoutViewModel.reviewScreenPreference.isChangeMethodOptionEnabled() {
+    func fillChangePaymentMethodButton(reviewScreenPreference: ReviewScreenPreference) {
+        if reviewScreenPreference.isChangeMethodOptionEnabled() {
             self.selectOtherPaymentMethodButton.setTitle("Cambiar medio de pago".localized, for: .normal)
             self.selectOtherPaymentMethodButton.titleLabel?.font = Utils.getFont(size: self.noRateLabel.font.pointSize)
             self.selectOtherPaymentMethodButton.setTitleColor(UIColor.primaryColor(), for: UIControlState.normal)
@@ -146,7 +146,7 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
         return false
     }
     
-    public static func getCellHeight(payerCost : PayerCost? = nil) -> CGFloat {
+    public static func getCellHeight(payerCost : PayerCost? = nil, reviewScreenPreference: ReviewScreenPreference = ReviewScreenPreference()) -> CGFloat {
         
         var cellHeight = DEFAULT_ROW_HEIGHT
         
@@ -154,7 +154,7 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
             cellHeight += 20
         }
         
-        if !MercadoPagoCheckoutViewModel.reviewScreenPreference.isChangeMethodOptionEnabled() {
+        if reviewScreenPreference.isChangeMethodOptionEnabled() {
             cellHeight -= 64
         }
         

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultScreenPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultScreenPreference.swift
@@ -43,17 +43,17 @@ open class PaymentResultScreenPreference: NSObject {
     
     var exitButtonTitle = "Continuar".localized
 	
-	  var statusBackgroundColor : UIColor?
+    var statusBackgroundColor : UIColor?
 
-	  var hideApprovedPaymentBodyCell = false
+    var hideApprovedPaymentBodyCell = false
     var hideContentCell = false
     var hideAmount = false
     var hidePaymentId = false
     var hidePaymentMethod = false
     
-    internal static var pendingAdditionalInfoCells = [MPCustomCell]()
-    internal static var approvedAdditionalInfoCells = [MPCustomCell]()
-    internal static var approvedSubHeaderCells = [MPCustomCell]()
+    var pendingAdditionalInfoCells = [MPCustomCell]()
+    var approvedAdditionalInfoCells = [MPCustomCell]()
+    var approvedSubHeaderCells = [MPCustomCell]()
     
     // Sets de Approved
     
@@ -218,23 +218,18 @@ open class PaymentResultScreenPreference: NSObject {
     
     //Custom Rows
     
-    open static func setCustomPendingCells(customCells : [MPCustomCell]) {
-        PaymentResultScreenPreference.pendingAdditionalInfoCells = customCells
+    open func setCustomPendingCells(customCells : [MPCustomCell]) {
+        self.pendingAdditionalInfoCells = customCells
     }
     
-    open static func setCustomsApprovedCell(customCells : [MPCustomCell]) {
-        PaymentResultScreenPreference.approvedAdditionalInfoCells = customCells
+    open func setCustomsApprovedCell(customCells : [MPCustomCell]) {
+        self.approvedAdditionalInfoCells = customCells
     }
     
-    open static func setCustomApprovedSubHeaderCell(customCells: [MPCustomCell]) {
-        PaymentResultScreenPreference.approvedSubHeaderCells = customCells
+    open func setCustomApprovedSubHeaderCell(customCells: [MPCustomCell]) {
+        self.approvedSubHeaderCells = customCells
     }
     
-    open static func clear() {
-        PaymentResultScreenPreference.approvedAdditionalInfoCells = [MPCustomCell]()
-        PaymentResultScreenPreference.pendingAdditionalInfoCells = [MPCustomCell]()
-        PaymentResultScreenPreference.approvedSubHeaderCells = [MPCustomCell]()
-    }
     
     //Approved
     

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewController.swift
@@ -86,12 +86,12 @@ open class PaymentResultViewController: MercadoPagoUIViewController, UITableView
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if viewModel.isAdditionalCustomCellFor(indexPath: indexPath){
             if viewModel.inProcess(){
-                return PaymentResultScreenPreference.pendingAdditionalInfoCells[indexPath.row].getHeight()
+                return MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingAdditionalInfoCells[indexPath.row].getHeight()
             } else if viewModel.approved(){
-                return PaymentResultScreenPreference.approvedAdditionalInfoCells[indexPath.row].getHeight()
+                return MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedAdditionalInfoCells[indexPath.row].getHeight()
             }
         } else if viewModel.isCustomSubHeaderCellFor(indexPath: indexPath){
-            return PaymentResultScreenPreference.approvedSubHeaderCells[indexPath.row].getHeight()
+            return MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSubHeaderCells[indexPath.row].getHeight()
         }
         return UITableViewAutomaticDimension
         
@@ -189,13 +189,13 @@ open class PaymentResultViewController: MercadoPagoUIViewController, UITableView
     private func getAdditionalCustomCell(indexPath: IndexPath) -> UITableViewCell {
         
         if self.viewModel.inProcess(){
-            let customCell = PaymentResultScreenPreference.pendingAdditionalInfoCells[indexPath.row]
+            let customCell = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingAdditionalInfoCells[indexPath.row]
             customCell.setDelegate(delegate: self)
             let cell = customCell.getTableViewCell()
             cell.selectionStyle = .none
             return cell
         } else {
-            let customCell = PaymentResultScreenPreference.approvedAdditionalInfoCells[indexPath.row]
+            let customCell = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedAdditionalInfoCells[indexPath.row]
             customCell.setDelegate(delegate: self)
             let cell = customCell.getTableViewCell()
             cell.selectionStyle = .none
@@ -206,7 +206,7 @@ open class PaymentResultViewController: MercadoPagoUIViewController, UITableView
     private func getCustomSubHeaderCell(indexPath: IndexPath) -> UITableViewCell {
         
         if self.viewModel.approved(){
-            let customCell = PaymentResultScreenPreference.approvedSubHeaderCells[indexPath.row]
+            let customCell = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSubHeaderCells[indexPath.row]
             customCell.setDelegate(delegate: self)
             let cell = customCell.getTableViewCell()
             cell.selectionStyle = .none

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
@@ -224,17 +224,17 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
     }
     
     func numberOfCustomAdditionalCells() -> Int {
-        if !Array.isNullOrEmpty(PaymentResultScreenPreference.pendingAdditionalInfoCells) && inProcess(){
-            return PaymentResultScreenPreference.pendingAdditionalInfoCells.count
-        } else if !Array.isNullOrEmpty(PaymentResultScreenPreference.approvedAdditionalInfoCells) && approved() {
-            return PaymentResultScreenPreference.approvedAdditionalInfoCells.count
+        if !Array.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingAdditionalInfoCells) && inProcess(){
+            return MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingAdditionalInfoCells.count
+        } else if !Array.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedAdditionalInfoCells) && approved() {
+            return MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedAdditionalInfoCells.count
         }
         return 0
     }
     
     func numberOfCustomSubHeaderCells() -> Int {
-        if !Array.isNullOrEmpty(PaymentResultScreenPreference.approvedSubHeaderCells) && approved() {
-            return PaymentResultScreenPreference.approvedSubHeaderCells.count
+        if !Array.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSubHeaderCells) && approved() {
+            return MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSubHeaderCells.count
         }
         return 0
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
@@ -14,10 +14,13 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
     var callback: ( _ status : PaymentResult.CongratsState) -> Void
     var checkoutPreference: CheckoutPreference?
     
-    init(paymentResult: PaymentResult, checkoutPreference: CheckoutPreference, callback : @escaping ( _ status : PaymentResult.CongratsState) -> Void) {
+    var paymentResultScreenPreference = PaymentResultScreenPreference()
+    
+    init(paymentResult: PaymentResult, checkoutPreference: CheckoutPreference, callback : @escaping ( _ status : PaymentResult.CongratsState) -> Void, paymentResultScreenPreference: PaymentResultScreenPreference = PaymentResultScreenPreference()) {
         self.paymentResult = paymentResult
         self.callback = callback
         self.checkoutPreference = checkoutPreference
+        self.paymentResultScreenPreference = paymentResultScreenPreference
     }
     open func methodId() -> String!{
         return paymentResult.paymentData?.paymentMethod._id ?? ""
@@ -44,7 +47,7 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
     }
     
     func getColor() -> UIColor{
-        if let color = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.statusBackgroundColor {
+        if let color = paymentResultScreenPreference.statusBackgroundColor {
             return color;
         } else if approved() {
             return UIColor.px_greenCongrats()
@@ -141,7 +144,7 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
         //approved case
         let precondition = indexPath.section == 2 && approved()
         //if row at index 0 exists and approved body is not disabled, row 0 should display approved body
-        let case1 = !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() && indexPath.row == 0;
+        let case1 = !paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() && indexPath.row == 0;
         return precondition && case1
     }
     
@@ -149,7 +152,7 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
         //approved case
         let precondition = indexPath.section == 2 && approved()
         //if row at index 0 exists and approved body is disabled, row 0 should display email row
-        let case1 = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() && indexPath.row == 0;
+        let case1 = paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() && indexPath.row == 0;
         //if row at index 1 exists, row 1 should display email row
         let case2 = indexPath.row == 1;
         return precondition && (case1 || case2)
@@ -198,11 +201,11 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
             return numberOfCustomSubHeaderCells()
             
         } else if isSecondaryExitButtonCellFor(indexPath: IndexPath(row: 0, section: section)){
-            if approved() && MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSecondaryExitButtonCallback != nil {
+            if approved() && paymentResultScreenPreference.approvedSecondaryExitButtonCallback != nil {
                 return 1
-            } else if inProcess() && !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPendingSecondaryExitButtonDisable() {
+            } else if inProcess() && !paymentResultScreenPreference.isPendingSecondaryExitButtonDisable() {
                 return 1
-            } else if rejected() && !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isRejectedSecondaryExitButtonDisable() {
+            } else if rejected() && !paymentResultScreenPreference.isRejectedSecondaryExitButtonDisable() {
                 return 1
             }
             return 0
@@ -212,29 +215,29 @@ class PaymentResultViewModel : NSObject, MPPaymentTrackInformer {
     
     func numberOfCellInBody() -> Int {
         if approved() {
-            let approvedBodyAdd = !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() ? 1 : 0;
+            let approvedBodyAdd = !paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() ? 1 : 0;
             let emailCellAdd = !String.isNullOrEmpty(paymentResult.payerEmail) ? 1 : 0;
             return approvedBodyAdd + emailCellAdd;
             
         } else {
             let callForAuthAdd = callForAuth() ? 1 : 0;
-            let selectAnotherCellAdd = !MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isContentCellDisable() ? 1 : 0
+            let selectAnotherCellAdd = !paymentResultScreenPreference.isContentCellDisable() ? 1 : 0
             return callForAuthAdd + selectAnotherCellAdd;
         }
     }
     
     func numberOfCustomAdditionalCells() -> Int {
-        if !Array.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingAdditionalInfoCells) && inProcess(){
-            return MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingAdditionalInfoCells.count
-        } else if !Array.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedAdditionalInfoCells) && approved() {
-            return MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedAdditionalInfoCells.count
+        if !Array.isNullOrEmpty(paymentResultScreenPreference.pendingAdditionalInfoCells) && inProcess(){
+            return paymentResultScreenPreference.pendingAdditionalInfoCells.count
+        } else if !Array.isNullOrEmpty(paymentResultScreenPreference.approvedAdditionalInfoCells) && approved() {
+            return paymentResultScreenPreference.approvedAdditionalInfoCells.count
         }
         return 0
     }
     
     func numberOfCustomSubHeaderCells() -> Int {
-        if !Array.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSubHeaderCells) && approved() {
-            return MercadoPagoCheckoutViewModel.paymentResultScreenPreference.approvedSubHeaderCells.count
+        if !Array.isNullOrEmpty(paymentResultScreenPreference.approvedSubHeaderCells) && approved() {
+            return paymentResultScreenPreference.approvedSubHeaderCells.count
         }
         return 0
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/RejectedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/RejectedTableViewCell.swift
@@ -26,7 +26,7 @@ class RejectedTableViewCell: UITableViewCell {
         self.selectionStyle = .none
     }
     
-    func fillCell (paymentResult: PaymentResult){
+    func fillCell (paymentResult: PaymentResult, paymentResultScreenPreference: PaymentResultScreenPreference){
         
         if paymentResult.status == "rejected" {
             
@@ -45,18 +45,18 @@ class RejectedTableViewCell: UITableViewCell {
                 let title = (paymentResult.statusDetail + "_subtitle_" + paymentTypeId!)
                 
                 if !title.existsLocalized() {
-                    if MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isRejectedContentTitleDisable() {
+                    if paymentResultScreenPreference.isRejectedContentTitleDisable() {
                         self.title.text = ""
                         self .titleSubtitleCoinstraint.constant = 0
-                    } else if String.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedContetTitle()) {
-                        self.title.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedContetTitle()
+                    } else if String.isNullOrEmpty(paymentResultScreenPreference.getRejectedContetTitle()) {
+                        self.title.text = paymentResultScreenPreference.getRejectedContetTitle()
                     }
                     
-                    if MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isRejectedContentTextDisable() {
+                    if paymentResultScreenPreference.isRejectedContentTextDisable() {
                         self.subtitile.text = ""
                         self .titleSubtitleCoinstraint.constant = 0
-                    } else if !String.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedContentText()) {
-                        self.subtitile.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedContentText()
+                    } else if !String.isNullOrEmpty(paymentResultScreenPreference.getRejectedContentText()) {
+                        self.subtitile.text = paymentResultScreenPreference.getRejectedContentText()
                     }
 
                 } else {
@@ -64,15 +64,15 @@ class RejectedTableViewCell: UITableViewCell {
                 }
             }
         } else if paymentResult.status == "in_process" {
-            self.title.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingContetTitle()
+            self.title.text = paymentResultScreenPreference.getPendingContetTitle()
             
-            if MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPendingContentTextDisable() {
+            if paymentResultScreenPreference.isPendingContentTextDisable() {
                 self.subtitile.text = ""
                 self .titleSubtitleCoinstraint.constant = 0
                 
             } else {
-                if !String.isNullOrEmpty(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingContentText()) {
-                    self.subtitile.text = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingContentText()
+                if !String.isNullOrEmpty(paymentResultScreenPreference.getPendingContentText()) {
+                    self.subtitile.text = paymentResultScreenPreference.getPendingContentText()
                     
                 } else if paymentResult.statusDetail == "pending_contingency"{
                     self.subtitile.text = "En menos de 1 hora te enviaremos por e-mail el resultado.".localized

--- a/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenPreference.swift
@@ -18,8 +18,8 @@ open class ReviewScreenPreference: NSObject {
     
     private var summaryRows = [SummaryRow]()
     
-    internal static var additionalInfoCells = [MPCustomCell]()
-    internal static var customItemCells = [MPCustomCell]()
+    var additionalInfoCells = [MPCustomCell]()
+    var customItemCells = [MPCustomCell]()
     
     open func setTitle(title : String){
         self.title = title
@@ -73,19 +73,12 @@ open class ReviewScreenPreference: NSObject {
         return summaryRows
     }
 	
-    open static func setCustomItemCell(customCell : [MPCustomCell]) {
-        ReviewScreenPreference.customItemCells = customCell
+    open func setCustomItemCell(customCell : [MPCustomCell]) {
+        self.customItemCells = customCell
     }
     
-    open static func setAddionalInfoCells(customCells : [MPCustomCell]) {
-        ReviewScreenPreference.additionalInfoCells = customCells
+    open func setAddionalInfoCells(customCells : [MPCustomCell]) {
+        self.additionalInfoCells = customCells
     }
-    
-    open static func clear() {
-        ReviewScreenPreference.customItemCells = [MPCustomCell]()
-        ReviewScreenPreference.additionalInfoCells = [MPCustomCell]()
-    }
-    
-    
     
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/SecondaryExitButtonTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/SecondaryExitButtonTableViewCell.swift
@@ -11,6 +11,7 @@ import UIKit
 class SecondaryExitButtonTableViewCell: CallbackCancelTableViewCell {
     
     @IBOutlet weak var button: UIButton!
+    var paymentResultScreenPreference: PaymentResultScreenPreference?
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -20,40 +21,42 @@ class SecondaryExitButtonTableViewCell: CallbackCancelTableViewCell {
         self.selectionStyle = .none
     }
     
-    open func fillCell(paymentResult: PaymentResult){
+    open func fillCell(paymentResult: PaymentResult, paymentResultScreenPreference: PaymentResultScreenPreference){
+        self.paymentResultScreenPreference = paymentResultScreenPreference
+        
         if paymentResult.statusDetail.contains("cc_rejected_bad_filled"){
             status = PaymentResult.CongratsState.cancel_RECOVER
             self.button.setTitle("Ingresalo nuevamente".localized, for: UIControlState.normal)
         }
         if paymentResult.status == "approved"{
-            self.button.setTitle(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedSecondaryButtonText(), for: .normal)
+            self.button.setTitle(paymentResultScreenPreference.getApprovedSecondaryButtonText(), for: .normal)
             self.button.addTarget(self, action: #selector(approvedCallback), for: .touchUpInside)
         } else if paymentResult.status == "rejected" {
-            self.button.setTitle(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedSecondaryButtonText(), for: .normal)
+            self.button.setTitle(paymentResultScreenPreference.getRejectedSecondaryButtonText(), for: .normal)
                 self.button.addTarget(self, action: #selector(rejectedCallback), for: .touchUpInside)
         } else {
-            self.button.setTitle(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingSecondaryButtonText(), for: .normal)
+            self.button.setTitle(paymentResultScreenPreference.getPendingSecondaryButtonText(), for: .normal)
                 self.button.addTarget(self, action: #selector(pendingCallback), for: .touchUpInside)
         }
         
     }
     
     func rejectedCallback(){
-        if let paymentResult = paymentResult, let customCallback = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedSecondaryButtonCallback(){
+        if let paymentResult = paymentResult, let customCallback = paymentResultScreenPreference?.getRejectedSecondaryButtonCallback(){
             customCallback(paymentResult)
         } else {
             invokeCallback()
         }
     }
     func pendingCallback(){
-        if let paymentResult = paymentResult, let customCallback = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingSecondaryButtonCallback(){
+        if let paymentResult = paymentResult, let customCallback = paymentResultScreenPreference?.getPendingSecondaryButtonCallback(){
             customCallback(paymentResult)
         } else {
             invokeCallback()
         }
     }
     func approvedCallback(){
-        if let paymentResult = paymentResult, let customCallback = MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedSecondaryButtonCallback(){
+        if let paymentResult = paymentResult, let customCallback = paymentResultScreenPreference?.getApprovedSecondaryButtonCallback(){
             customCallback(paymentResult)
         } else {
             invokeCallback()

--- a/MercadoPagoSDK/MercadoPagoSDKTests/PaymentResultScreenPreferenceTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/PaymentResultScreenPreferenceTest.swift
@@ -11,84 +11,96 @@ import XCTest
 class PaymentResultScreenPreferenceTest: BaseTest {
     
     let paymentResultScreenPreference = PaymentResultScreenPreference()
+    var mpCheckout : MercadoPagoCheckout! = nil
+    
+    override func setUp() {
+        super.setUp()
+        self.createCheckout()
+    }
+    
+    func createCheckout() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+    }
     
     func testSetTitle() {
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedTitle(), "¡Listo, se acreditó tu pago!".localized)
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingTitle(), "Estamos procesando el pago".localized)
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedTitle(), "Uy, no pudimos procesar el pago".localized)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getApprovedTitle(), "¡Listo, se acreditó tu pago!".localized)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingTitle(), "Estamos procesando el pago".localized)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedTitle(), "Uy, no pudimos procesar el pago".localized)
         
         paymentResultScreenPreference.setApprovedTitle(title: "1")
         paymentResultScreenPreference.setPendingTitle(title: "2")
         paymentResultScreenPreference.setRejectedTitle(title: "3")
         
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedTitle(), "1")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingTitle(), "2")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedTitle(), "3")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getApprovedTitle(), "1")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingTitle(), "2")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedTitle(), "3")
     }
     
     func testSetSubtitle() {
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedSubtitle(), "")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingSubtitle(), "")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedSubtitle(), "")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getApprovedSubtitle(), "")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingSubtitle(), "")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedSubtitle(), "")
         
         paymentResultScreenPreference.setApprovedSubtitle(subtitle: "1")
         paymentResultScreenPreference.setPendingSubtitle(subtitle: "2")
         paymentResultScreenPreference.setRejectedSubtitle(subtitle: "3")
         
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedSubtitle(), "1")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingSubtitle(), "2")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedSubtitle(), "3")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getApprovedSubtitle(), "1")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingSubtitle(), "2")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedSubtitle(), "3")
     }
     
     func testSetContentTitle() {
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingContetTitle(), "¿Qué puedo hacer?".localized)
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedContetTitle(), "¿Qué puedo hacer?".localized)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingContetTitle(), "¿Qué puedo hacer?".localized)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedContetTitle(), "¿Qué puedo hacer?".localized)
         
         paymentResultScreenPreference.setPendingContentTitle(title: "1")
         paymentResultScreenPreference.setRejectedContentTitle(title: "2")
         
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingContetTitle(), "1")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedContetTitle(), "2")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingContetTitle(), "1")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedContetTitle(), "2")
     }
     
     func testSetContentText() {
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingContentText(), "")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedContentText(), "")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingContentText(), "")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedContentText(), "")
         
         paymentResultScreenPreference.setPendingContentText(text: "1")
         paymentResultScreenPreference.setRejectedContentText(text: "2")
         
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingContentText(), "1")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedContentText(), "2")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingContentText(), "1")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedContentText(), "2")
     }
     
     func testSetIconSubtext() {
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedIconSubtext(), "Algo salió mal… ".localized)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedIconSubtext(), "Algo salió mal… ".localized)
         
         paymentResultScreenPreference.setRejectedIconSubtext(text: "lala")
         
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedIconSubtext(), "lala")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedIconSubtext(), "lala")
     }
     
     func testSetSecondaryExitButton() {
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedSecondaryButtonText(), "")
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedSecondaryButtonCallback() == nil)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getApprovedSecondaryButtonText(), "")
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.getApprovedSecondaryButtonCallback() == nil)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingSecondaryButtonText(), "Pagar con otro medio".localized)
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingSecondaryButtonCallback() == nil)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingSecondaryButtonText(), "Pagar con otro medio".localized)
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingSecondaryButtonCallback() == nil)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedSecondaryButtonText(), "Pagar con otro medio".localized)
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedSecondaryButtonCallback() == nil)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedSecondaryButtonText(), "Pagar con otro medio".localized)
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedSecondaryButtonCallback() == nil)
         
         paymentResultScreenPreference.setApprovedSecondaryExitButton(callback: { (paymentResult) in
             
@@ -102,114 +114,114 @@ class PaymentResultScreenPreferenceTest: BaseTest {
             
         }, text: "3")
         
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedSecondaryButtonText(), "1")
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getApprovedSecondaryButtonCallback() != nil)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getApprovedSecondaryButtonText(), "1")
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.getApprovedSecondaryButtonCallback() != nil)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingSecondaryButtonText(), "2")
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getPendingSecondaryButtonCallback() != nil)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingSecondaryButtonText(), "2")
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.getPendingSecondaryButtonCallback() != nil)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedSecondaryButtonText(), "3")
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getRejectedSecondaryButtonCallback() != nil)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedSecondaryButtonText(), "3")
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.getRejectedSecondaryButtonCallback() != nil)
     }
     
     func testSetHeaderIcon() {
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingIconName, "MPSDK_payment_result_pending")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingIconBundle, MercadoPago.getBundle())
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.pendingIconName, "MPSDK_payment_result_pending")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.pendingIconBundle, MercadoPago.getBundle())
 
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.rejectedIconName, "MPSDK_payment_result_error")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.rejectedIconBundle, MercadoPago.getBundle())
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.rejectedIconName, "MPSDK_payment_result_error")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.rejectedIconBundle, MercadoPago.getBundle())
         
         paymentResultScreenPreference.setPendingHeaderIcon(name: "lala", bundle: Bundle.main)
         paymentResultScreenPreference.setRejectedHeaderIcon(name: "lalala", bundle: Bundle.main)
         
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingIconName, "lala")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.pendingIconBundle, Bundle.main)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.pendingIconName, "lala")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.pendingIconBundle, Bundle.main)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.rejectedIconName, "lalala")
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.rejectedIconBundle, Bundle.main)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.rejectedIconName, "lalala")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.rejectedIconBundle, Bundle.main)
 
     }
     
     func testDisableSecondaryButton() {
-        XCTAssertFalse(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPendingSecondaryExitButtonDisable())
-        XCTAssertFalse(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isRejectedSecondaryExitButtonDisable())
+        XCTAssertFalse(self.mpCheckout.viewModel.paymentResultScreenPreference.isPendingSecondaryExitButtonDisable())
+        XCTAssertFalse(self.mpCheckout.viewModel.paymentResultScreenPreference.isRejectedSecondaryExitButtonDisable())
         
         paymentResultScreenPreference.disablePendingSecondaryExitButton()
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPendingSecondaryExitButtonDisable())
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.isPendingSecondaryExitButtonDisable())
         
         paymentResultScreenPreference.disableRejectdSecondaryExitButton()
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isRejectedSecondaryExitButtonDisable())
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.isRejectedSecondaryExitButtonDisable())
     }
     
     func testDisableContentText() {
-        XCTAssertFalse(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPendingContentTextDisable())
-        XCTAssertFalse(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isRejectedContentTextDisable())
+        XCTAssertFalse(self.mpCheckout.viewModel.paymentResultScreenPreference.isPendingContentTextDisable())
+        XCTAssertFalse(self.mpCheckout.viewModel.paymentResultScreenPreference.isRejectedContentTextDisable())
         
         paymentResultScreenPreference.disablePendingContentText()
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPendingContentTextDisable())
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.isPendingContentTextDisable())
         
         paymentResultScreenPreference.disableRejectedContentText()
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isRejectedContentTextDisable())
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.isRejectedContentTextDisable())
     }
     
     func testDisableContentTitle() {
-        XCTAssertFalse(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isRejectedContentTitleDisable())
+        XCTAssertFalse(self.mpCheckout.viewModel.paymentResultScreenPreference.isRejectedContentTitleDisable())
         
         paymentResultScreenPreference.disableRejectedContentTitle()
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isRejectedContentTitleDisable())
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.isRejectedContentTitleDisable())
     }
     
     func testSetExitTitle() {
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getExitButtonTitle(), "Continuar".localized)
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getExitButtonTitle(), "Continuar".localized)
         
         paymentResultScreenPreference.setExitButtonTitle(title: "lala")
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.getExitButtonTitle(), "lala")
+        XCTAssertEqual(self.mpCheckout.viewModel.paymentResultScreenPreference.getExitButtonTitle(), "lala")
         
     }
     
     func testApprovedBodyDisables() {
-        XCTAssertFalse(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isAmountDisable())
-        XCTAssertFalse(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPaymentMethodDisable())
-        XCTAssertFalse(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPaymentIdDisable())
+        XCTAssertFalse(self.mpCheckout.viewModel.paymentResultScreenPreference.isAmountDisable())
+        XCTAssertFalse(self.mpCheckout.viewModel.paymentResultScreenPreference.isPaymentMethodDisable())
+        XCTAssertFalse(self.mpCheckout.viewModel.paymentResultScreenPreference.isPaymentIdDisable())
         
         paymentResultScreenPreference.disableApprovedAmount()
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isAmountDisable())
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.isAmountDisable())
         
         paymentResultScreenPreference.disableApprovedPaymentMethodInfo()
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPaymentMethodDisable())
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.isPaymentMethodDisable())
         
         paymentResultScreenPreference.disableApprovedReceipt()
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isPaymentIdDisable())
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.isPaymentIdDisable())
     }
     
     func testDisableChangePaymentMethodCell() {
-        XCTAssertFalse(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isContentCellDisable())
+        XCTAssertFalse(self.mpCheckout.viewModel.paymentResultScreenPreference.isContentCellDisable())
         
         paymentResultScreenPreference.disableContentCell()
-        MercadoPagoCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
+        self.mpCheckout.setPaymentResultScreenPreference(paymentResultScreenPreference)
         
-        XCTAssert(MercadoPagoCheckoutViewModel.paymentResultScreenPreference.isContentCellDisable())
+        XCTAssert(self.mpCheckout.viewModel.paymentResultScreenPreference.isContentCellDisable())
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/ReviewScreenPreferenceTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/ReviewScreenPreferenceTest.swift
@@ -21,7 +21,8 @@ class ReviewScreenPreferenceTest: BaseTest {
     func createCheckout() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)    }
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+    }
 
     func testSetTitle() {
         

--- a/MercadoPagoSDK/MercadoPagoSDKTests/ReviewScreenPreferenceTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/ReviewScreenPreferenceTest.swift
@@ -11,15 +11,26 @@ import XCTest
 class ReviewScreenPreferenceTest: BaseTest {
     
     let reviewScreenPreference = ReviewScreenPreference()
+    var mpCheckout : MercadoPagoCheckout! = nil
     
+    override func setUp() {
+        super.setUp()
+        self.createCheckout()
+    }
+    
+    func createCheckout() {
+        let checkoutPreference = MockBuilder.buildCheckoutPreference()
+        let navControllerInstance = UINavigationController()
+        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)    }
+
     func testSetTitle() {
         
         XCTAssertEqual(reviewScreenPreference.getTitle(), "Confirma tu compra".localized)
         
         reviewScreenPreference.setTitle(title: "1")
-        MercadoPagoCheckout.setReviewScreenPreference(reviewScreenPreference)
+        self.mpCheckout.setReviewScreenPreference(reviewScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.reviewScreenPreference.getTitle(), "1")
+        XCTAssertEqual(self.mpCheckout.viewModel.reviewScreenPreference.getTitle(), "1")
     }
     
     func testSetProductDetail() {
@@ -27,9 +38,9 @@ class ReviewScreenPreferenceTest: BaseTest {
         XCTAssertEqual(reviewScreenPreference.getProductsTitle(), "Productos".localized)
         
         reviewScreenPreference.setProductsDetail(productsTitle: "1")
-        MercadoPagoCheckout.setReviewScreenPreference(reviewScreenPreference)
+        self.mpCheckout.setReviewScreenPreference(reviewScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.reviewScreenPreference.getProductsTitle(), "1")
+        XCTAssertEqual(self.mpCheckout.viewModel.reviewScreenPreference.getProductsTitle(), "1")
     }
     
     func testSetConfirmButtonText() {
@@ -37,9 +48,9 @@ class ReviewScreenPreferenceTest: BaseTest {
         XCTAssertEqual(reviewScreenPreference.getConfirmButtonText(), "Confirmar".localized)
         
         reviewScreenPreference.setConfirmButtonText(confirmButtonText: "1")
-        MercadoPagoCheckout.setReviewScreenPreference(reviewScreenPreference)
+        self.mpCheckout.setReviewScreenPreference(reviewScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.reviewScreenPreference.getConfirmButtonText(), "1")
+        XCTAssertEqual(self.mpCheckout.viewModel.reviewScreenPreference.getConfirmButtonText(), "1")
     }
     
     func testSetCancelButtonText() {
@@ -47,9 +58,9 @@ class ReviewScreenPreferenceTest: BaseTest {
         XCTAssertEqual(reviewScreenPreference.getCancelButtonTitle(), "Cancelar Pago".localized)
         
         reviewScreenPreference.setCancelButtonText(cancelButtonText: "1")
-        MercadoPagoCheckout.setReviewScreenPreference(reviewScreenPreference)
+        self.mpCheckout.setReviewScreenPreference(reviewScreenPreference)
         
-        XCTAssertEqual(MercadoPagoCheckoutViewModel.reviewScreenPreference.getCancelButtonTitle(), "1")
+        XCTAssertEqual(self.mpCheckout.viewModel.reviewScreenPreference.getCancelButtonTitle(), "1")
     }
     
     func testIsChangePaymentMethodDisable() {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -222,10 +222,10 @@
     //    } text:@"Ir a mi activdad"];
     //    [resultPreference disablePendingContentText];
     //    [resultPreference disableChangePaymentMethodOptionButton];
-    //    [resultPreference setPendingSecondaryExitButtonWithCallback:^(PaymentResult * paymentResult) {
-    //        NSLog(@"%@", paymentResult.status);
-    //        [self.navigationController popToRootViewControllerAnimated:NO];
-    //    } text:@"Ir a mi actividad"];
+        [resultPreference setPendingSecondaryExitButtonWithCallback:^(PaymentResult * paymentResult) {
+            NSLog(@"%@", paymentResult.status);
+            [self.navigationController popToRootViewControllerAnimated:NO];
+        } text:@"Ir a mi actividad"];
     //    [resultPreference setApprovedSecondaryExitButtonWithCallback:^(PaymentResult * paymentResult) {
     //        NSLog(@"%@", paymentResult.status);
     //        [self.navigationController popToRootViewControllerAnimated:NO];
@@ -254,7 +254,7 @@
     [resultPreference setCustomsApprovedCellWithCustomCells:[NSArray arrayWithObjects:dineroEnCuentaCustom, nil]];
     [resultPreference setCustomApprovedSubHeaderCellWithCustomCells:[NSArray arrayWithObjects:subHeader, nil]];
     
-    [MercadoPagoCheckout setPaymentResultScreenPreference:resultPreference];
+    [self.mpCheckout setPaymentResultScreenPreference:resultPreference];
     
 }
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -248,9 +248,9 @@
     MPCustomCell *subHeader = [[MPCustomCell alloc] initWithCell:header];
     
     
-    [PaymentResultScreenPreference setCustomPendingCellsWithCustomCells:[NSArray arrayWithObjects:subeCongrats, nil]];
-    [PaymentResultScreenPreference setCustomsApprovedCellWithCustomCells:[NSArray arrayWithObjects:dineroEnCuentaCustom, nil]];
-    [PaymentResultScreenPreference setCustomApprovedSubHeaderCellWithCustomCells:[NSArray arrayWithObjects:subHeader, nil]];
+    [resultPreference setCustomPendingCellsWithCustomCells:[NSArray arrayWithObjects:subeCongrats, nil]];
+    [resultPreference setCustomsApprovedCellWithCustomCells:[NSArray arrayWithObjects:dineroEnCuentaCustom, nil]];
+    [resultPreference setCustomApprovedSubHeaderCellWithCustomCells:[NSArray arrayWithObjects:subHeader, nil]];
     
     [MercadoPagoCheckout setPaymentResultScreenPreference:resultPreference];
     
@@ -288,7 +288,7 @@
     
     [reviewPreference setSummaryRowsWithSummaryRows:[NSArray arrayWithObjects:summaryRow, nil]];
     
-    [ReviewScreenPreference setAddionalInfoCellsWithCustomCells:[NSArray arrayWithObjects:customCargaSube2, customCargaSube, nil]];
+    [reviewPreference setAddionalInfoCellsWithCustomCells:[NSArray arrayWithObjects:customCargaSube2, customCargaSube, nil]];
 
     
     [MercadoPagoCheckout setReviewScreenPreference:reviewPreference];

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -52,14 +52,10 @@
     // Setear ServicePreference
     [self setServicePreference];
     
-    // Setear PaymentResultScreenPreference
-    [self setPaymentResultScreenPreference];
-    
-    //Setear ReviewScreenPrefernce
-    [self setReviewScreenPreference];
+
     
     //Setear flowPreference
-    [self finishFlowBeforeRYC];
+    //[self finishFlowBeforeRYC];
     
     
     ///  PASO 2: SETEAR CHECKOUTPREF, PAYMENTDATA Y PAYMENTRESULT
@@ -95,8 +91,14 @@
     dc.concept = @"Descuento de patito";
     dc.amount = 300;
     self.mpCheckout = [[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:self.paymentData discount:dc navigationController:self.navigationController paymentResult:self.paymentResult ];
+    
+    // Setear PaymentResultScreenPreference
+    [self setPaymentResultScreenPreference];
+    
+    //Setear ReviewScreenPrefernce
+    [self setReviewScreenPreference];
+    
     [self.mpCheckout start];
-
     
 }
 
@@ -116,7 +118,7 @@
         [reviewPreferenceUpdated setTitleWithTitle:@"Updated"];
         //[ReviewScreenPreference addCustomItemCellWithCustomCell:customCargaSube];
         //[ReviewScreenPreference addAddionalInfoCellWithCustomCell:customCargaSube];
-        [MercadoPagoCheckout setReviewScreenPreference:reviewPreferenceUpdated];
+        [self.mpCheckout setReviewScreenPreference:reviewPreferenceUpdated];
         //        UIViewController *vc = [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:paymentData navigationController:self.navigationController] getRootViewController];
         //[self.navigationController popToRootViewControllerAnimated:NO];
     }];
@@ -291,7 +293,7 @@
     [reviewPreference setAddionalInfoCellsWithCustomCells:[NSArray arrayWithObjects:customCargaSube2, customCargaSube, nil]];
 
     
-    [MercadoPagoCheckout setReviewScreenPreference:reviewPreference];
+    [self.mpCheckout setReviewScreenPreference:reviewPreference];
 }
 
 -(void)setServicePreference {
@@ -323,7 +325,7 @@
         // Cuando retorna de modal
         ReviewScreenPreference *reviewPreferenceUpdated = [[ReviewScreenPreference alloc] init];
         [reviewPreferenceUpdated setTitleWithTitle:@"Updated"];
-        [MercadoPagoCheckout setReviewScreenPreference:reviewPreferenceUpdated];
+        [self.mpCheckout setReviewScreenPreference:reviewPreferenceUpdated];
         
         //        UIViewController *vc = [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:paymentData navigationController:self.navigationController] getRootViewController];
         //


### PR DESCRIPTION
Fix #694 #897 

##  Cambios introducidos : 
- Se sacan las celdas custom como variables estaticas
- Se saca reviewScreenPreference y paymentResultScreenPreference como variables estaticas de MercadoPagoCheckout

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
