### PR TITLE
Fix missing parameter in congrats screen

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/RejectedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/RejectedTableViewCell.swift
@@ -60,7 +60,8 @@ class RejectedTableViewCell: UITableViewCell {
                     }
 
                 } else {
-                    self.subtitile.text = title.localized
+                    let paymentMethodName = paymentResult.paymentData!.paymentMethod.name.localized
+                    self.subtitile.text = (title.localized as NSString).replacingOccurrences(of: "%0", with: "\(paymentMethodName)")
                 }
             }
         } else if paymentResult.status == "in_process" {


### PR DESCRIPTION
##  Cambios introducidos : 

- En el caso de error de "cc_rejected_bad_filled_card_number", en la congrats se mostraba "El número de tu %0 es incorrecto." y faltaba reemplazar el %0

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [X] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
