### PR TITLE
PayerCost FirstRow description Deleted

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PayerCostRowTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PayerCostRowTableViewCell.swift
@@ -16,7 +16,8 @@ class PayerCostRowTableViewCell: UITableViewCell {
     func fillCell(payerCost : PayerCost) {
         let currency = MercadoPagoContext.getCurrency()
         if payerCost.installments == 1 {
-            interestDescription.attributedText = NSAttributedString(string : "".localized)
+            self.interestDescription.clearAttributedText()
+            
         } else if (payerCost.hasInstallmentsRate()){
             let attributedTotal = NSMutableAttributedString(attributedString: NSAttributedString(string: "(", attributes: [NSForegroundColorAttributeName : UIColor.px_grayLight()]))
             attributedTotal.append(Utils.getAttributedAmount(payerCost.totalAmount, currency: currency, color : UIColor.px_grayLight(), fontSize: 15, baselineOffset:3))

--- a/MercadoPagoSDK/MercadoPagoSDK/PayerCostRowTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PayerCostRowTableViewCell.swift
@@ -15,7 +15,9 @@ class PayerCostRowTableViewCell: UITableViewCell {
     
     func fillCell(payerCost : PayerCost) {
         let currency = MercadoPagoContext.getCurrency()
-        if (payerCost.hasInstallmentsRate() || payerCost.installments == 1){
+        if payerCost.installments == 1 {
+            interestDescription.attributedText = NSAttributedString(string : "".localized)
+        } else if (payerCost.hasInstallmentsRate()){
             let attributedTotal = NSMutableAttributedString(attributedString: NSAttributedString(string: "(", attributes: [NSForegroundColorAttributeName : UIColor.px_grayLight()]))
             attributedTotal.append(Utils.getAttributedAmount(payerCost.totalAmount, currency: currency, color : UIColor.px_grayLight(), fontSize: 15, baselineOffset:3))
             attributedTotal.append(NSAttributedString(string: ")", attributes: [NSForegroundColorAttributeName : UIColor.px_grayLight()]))

--- a/MercadoPagoSDK/MercadoPagoSDK/UILabel+Additions.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UILabel+Additions.swift
@@ -23,6 +23,10 @@ extension UILabel{
         
         return label.frame.height
     }
+    
+    open func clearAttributedText() {
+        self.attributedText = NSAttributedString(string : "")
+    }
 }
 
 extension NSAttributedString {


### PR DESCRIPTION
Fix #909 

##  Cambios introducidos : 
- Se borro el texto con el total en la primera row de la pantalla de payer cost

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [x] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada


![screen shot 2017-04-20 at 3 14 24 pm](https://cloud.githubusercontent.com/assets/23138661/25246081/eb1eddb4-25dc-11e7-91f8-4510d1c2c52a.png)
 
