### PR TITLE
Fix bug en el wording de la celda Offline de RyC

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
@@ -87,7 +87,15 @@ class OfflinePaymentMethodCell: UITableViewCell {
             if complementaryTitle.existsLocalized() {
                 attributedTitle.append(NSAttributedString(string : complementaryTitle.localized, attributes: [NSFontAttributeName: Utils.getFont(size: 20), NSForegroundColorAttributeName: UIColor.px_grayBaseText()]))
             }
-            attributedTitle.append(NSAttributedString(string : paymentMethodOption.getDescription(), attributes: [NSFontAttributeName: Utils.getFont(size: 20), NSForegroundColorAttributeName: UIColor.px_grayBaseText()]))
+            var paymentMethodName = "ryc_payment_method_" + paymentMethodOption.getId()
+            
+            if paymentMethodName.existsLocalized() {
+                paymentMethodName = paymentMethodName.localized
+            } else {
+                paymentMethodName = paymentMethodOption.getDescription()
+            }
+            
+            attributedTitle.append(NSAttributedString(string : paymentMethodName, attributes: [NSFontAttributeName: Utils.getFont(size: 20), NSForegroundColorAttributeName: UIColor.px_grayBaseText()]))
             
             self.acreditationTimeLabel.attributedText = NSMutableAttributedString(string: paymentMethodOption.getComment(), attributes: [NSFontAttributeName: Utils.getFont(size: 12)])
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
@@ -217,6 +217,9 @@
 "ryc_complementary_banamex_atm"="ATM of ";
 "ryc_complementary_redlink_atm"="ATM of ";
 
+"ryc_payment_method_redlink_atm" = "Red Link";
+"ryc_payment_method_redlink_bank_transfer" = "Red Link";
+
 
 //Discount
 "Código de descuento"="Discount code";

--- a/MercadoPagoSDK/MercadoPagoSDK/es-CO.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/es-CO.lproj/Localizable.strings
@@ -214,6 +214,10 @@
 "ryc_complementary_banamex_atm"="cajero automático de ";
 "ryc_complementary_redlink_atm"="cajero automático de ";
 
+"ryc_payment_method_redlink_atm" = "Red Link";
+"ryc_payment_method_redlink_bank_transfer" = "Red Link";
+
+
 //Discount
 "Código de descuento"="Código de descuento";
 "Canejar"="Canejar";
@@ -230,6 +234,7 @@
 "Recuerda desbloquear tu tarjeta antes de confirmar el pago."="Recuerda desbloquear tu tarjeta antes de confirmar el pago.";
 "desbloquear tu tarjeta"="desbloquear tu tarjeta";
 "Desbloqueo de Tarjeta"="Desbloqueo de Tarjeta";
+
 
 //Administrador de tarjetas
 "¿Con qué tarjeta?"="¿Con qué tarjeta?";

--- a/MercadoPagoSDK/MercadoPagoSDK/es-MX.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/es-MX.lproj/Localizable.strings
@@ -203,6 +203,9 @@
 "ryc_complementary_banamex_atm"="cajero automático de ";
 "ryc_complementary_redlink_atm"="cajero automático de ";
 
+"ryc_payment_method_redlink_atm" = "Red Link";
+"ryc_payment_method_redlink_bank_transfer" = "Red Link";
+
 //Discount
 "Código de descuento"="Código de descuento";
 "Canejar"="Canejar";

--- a/MercadoPagoSDK/MercadoPagoSDK/es-PE.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/es-PE.lproj/Localizable.strings
@@ -216,6 +216,9 @@
 "ryc_complementary_banamex_atm"="cajero automático de ";
 "ryc_complementary_redlink_atm"="cajero automático de ";
 
+"ryc_payment_method_redlink_atm" = "Red Link";
+"ryc_payment_method_redlink_bank_transfer" = "Red Link";
+
 //Discount
 "Código de descuento"="Código de descuento";
 "Canejar"="Canejar";
@@ -232,6 +235,7 @@
 "Recuerda desbloquear tu tarjeta antes de confirmar el pago."="Recuerda desbloquear tu tarjeta antes de confirmar el pago.";
 "desbloquear tu tarjeta"="desbloquear tu tarjeta";
 "Desbloqueo de Tarjeta"="Desbloqueo de Tarjeta";
+
 
 //Administrador de tarjetas
 "¿Con qué tarjeta?"="¿Con qué tarjeta?";

--- a/MercadoPagoSDK/MercadoPagoSDK/es-UY.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/es-UY.lproj/Localizable.strings
@@ -217,6 +217,9 @@
 "ryc_complementary_banamex_atm"="cajero automático de ";
 "ryc_complementary_redlink_atm"="cajero automático de ";
 
+"ryc_payment_method_redlink_atm" = "Red Link";
+"ryc_payment_method_redlink_bank_transfer" = "Red Link";
+
 //Discount
 "Código de descuento"="Código de descuento";
 "Canejar"="Canejar";
@@ -233,6 +236,7 @@
 "Recuerda desbloquear tu tarjeta antes de confirmar el pago."="Recuerda desbloquear tu tarjeta antes de confirmar el pago.";
 "desbloquear tu tarjeta"="desbloquear tu tarjeta";
 "Desbloqueo de Tarjeta"="Desbloqueo de Tarjeta";
+
 
 //Administrador de tarjetas
 "¿Con qué tarjeta?"="¿Con qué tarjeta?";

--- a/MercadoPagoSDK/MercadoPagoSDK/es-VE.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/es-VE.lproj/Localizable.strings
@@ -217,6 +217,10 @@
 "ryc_complementary_banamex_atm"="cajero automático de ";
 "ryc_complementary_redlink_atm"="cajero automático de ";
 
+"ryc_payment_method_redlink_atm" = "Red Link";
+"ryc_payment_method_redlink_bank_transfer" = "Red Link";
+
+
 //Discount
 "Código de descuento"="Código de descuento";
 "Canejar"="Canejar";
@@ -233,6 +237,7 @@
 "Recuerda desbloquear tu tarjeta antes de confirmar el pago."="Recuerda desbloquear tu tarjeta antes de confirmar el pago.";
 "desbloquear tu tarjeta"="desbloquear tu tarjeta";
 "Desbloqueo de Tarjeta"="Desbloqueo de Tarjeta";
+
 
 //Administrador de tarjetas
 "¿Con qué tarjeta?"="¿Con qué tarjeta?";

--- a/MercadoPagoSDK/MercadoPagoSDK/es.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/es.lproj/Localizable.strings
@@ -214,6 +214,9 @@
 "ryc_complementary_banamex_atm"="cajero automático de ";
 "ryc_complementary_redlink_atm"="cajero automático de ";
 
+"ryc_payment_method_redlink_atm" = "Red Link";
+"ryc_payment_method_redlink_bank_transfer" = "Red Link";
+
 //Discount
 "Código de descuento"="Código de descuento";
 "Canejar"="Canejar";

--- a/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
@@ -213,6 +213,9 @@
 "ryc_complementary_banamex_atm"="caixa eletrônico de ";
 "ryc_complementary_redlink_atm"="caixa eletrônico de ";
 
+"ryc_payment_method_redlink_atm" = "Red Link";
+"ryc_payment_method_redlink_bank_transfer" = "Red Link";
+
 
 //Discount
 "Código de descuento"="Código de desconto";


### PR DESCRIPTION
Fix #920

##  Cambios introducidos : 
- Se cambia el texto en Revisa y Confirma, "Pagaras $X en un cajero automatico de Cajero Automatico" por  "Pagaras $X en un cajero automatico de Red Link"

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
