### PR TITLE
Add PK and AT to MercadoPagoCheckout init

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CardsAdminViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardsAdminViewController.swift
@@ -10,43 +10,39 @@ import UIKit
 
 open class CardsAdminViewController: MercadoPagoUIScrollViewController, UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
 
-    
     @IBOutlet weak var collectionSearch: UICollectionView!
-    
-    override open var screenName : String { get { return "CARDS_ADMIN" } }
-    
-    static let VIEW_CONTROLLER_NIB_NAME : String = "CardsAdminViewController"
-    
-    
-    var merchantBaseUrl : String!
-    var merchantAccessToken : String!
-    var publicKey : String!
-    var currency : Currency!
-    var defaultInstallments : Int?
-    var installments : Int?
-    var viewModel : CardsAdminViewModel!
-    
+
+    override open var screenName: String { get { return "CARDS_ADMIN" } }
+
+    static let VIEW_CONTROLLER_NIB_NAME: String = "CardsAdminViewController"
+
+    var merchantBaseUrl: String!
+    var merchantAccessToken: String!
+    var publicKey: String!
+    var currency: Currency!
+    var defaultInstallments: Int?
+    var installments: Int?
+    var viewModel: CardsAdminViewModel!
+
     var bundle = MercadoPago.getBundle()
-    
-    var titleSectionReference : PaymentVaultTitleCollectionViewCell!
-    
+
+    var titleSectionReference: PaymentVaultTitleCollectionViewCell!
+
     fileprivate var tintColor = true
 
-    
     fileprivate let sectionInsets = UIEdgeInsets(top: 50.0, left: 20.0, bottom: 50.0, right: 20.0)
-    
-    fileprivate var defaultOptionSelected = false;
-    
-    fileprivate var callback : ((_ selectedCard : Card? ) -> Void)!
 
-    
-    public init(viewModel : CardsAdminViewModel, callback : @escaping (_ selectedCard : Card?) -> Void) {
+    fileprivate var defaultOptionSelected = false
+
+    fileprivate var callback : ((_ selectedCard: Card? ) -> Void)!
+
+    public init(viewModel: CardsAdminViewModel, callback : @escaping (_ selectedCard: Card?) -> Void) {
         super.init(nibName: CardsAdminViewController.VIEW_CONTROLLER_NIB_NAME, bundle: bundle)
         self.initCommon()
         self.viewModel = viewModel
         self.callback = callback
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -55,48 +51,48 @@ open class CardsAdminViewController: MercadoPagoUIScrollViewController, UICollec
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-    
-    fileprivate func initCommon(){
-        
+
+    fileprivate func initCommon() {
+
         self.merchantAccessToken = MercadoPagoContext.merchantAccessToken()
         self.publicKey = MercadoPagoContext.publicKey()
         self.currency = MercadoPagoContext.getCurrency()
     }
-    
+
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         self.hideNavBar()
-        if let button = self.navigationItem.leftBarButtonItem{
+        if let button = self.navigationItem.leftBarButtonItem {
             self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancelShowingNavBar)
         }
-        
+
         self.navigationController!.navigationBar.shadowImage = nil
         self.extendedLayoutIncludesOpaqueBars = true
     }
-    
+
     open override func viewDidLoad() {
         super.viewDidLoad()
        // self.showLoading()
-        
+
         var upperFrame = self.collectionSearch.bounds
-        upperFrame.origin.y = -upperFrame.size.height + 10;
+        upperFrame.origin.y = -upperFrame.size.height + 10
         upperFrame.size.width = UIScreen.main.bounds.width
         let upperView = UIView(frame: upperFrame)
         upperView.backgroundColor = UIColor.primaryColor()
         collectionSearch.addSubview(upperView)
-        
+
         if self.title == nil || self.title!.isEmpty {
             self.title = self.viewModel.titleScreen
         }
-        
+
         self.registerAllCells()
-        
+
         if callbackCancel == nil {
             self.callbackCancel = {(Void) -> Void in
                 if self.navigationController?.viewControllers[0] == self {
                     self.dismiss(animated: true, completion: {
-                        
+
                     })
                 } else {
                     self.navigationController!.popViewController(animated: true)
@@ -115,98 +111,93 @@ open class CardsAdminViewController: MercadoPagoUIScrollViewController, UICollec
         self.hideNavBarCallback = self.hideNavBarCallbackDisplayTitle()
     }
 
-    fileprivate func registerAllCells(){
+    fileprivate func registerAllCells() {
         let collectionSearchCell = UINib(nibName: "PaymentSearchCollectionViewCell", bundle: self.bundle)
         self.collectionSearch.register(collectionSearchCell, forCellWithReuseIdentifier: "searchCollectionCell")
         let paymentVaultTitleCollectionViewCell = UINib(nibName: "PaymentVaultTitleCollectionViewCell", bundle: self.bundle)
         self.collectionSearch.register(paymentVaultTitleCollectionViewCell, forCellWithReuseIdentifier: "paymentVaultTitleCollectionViewCell")
     }
-    
-    
+
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
        return self.viewModel.numberOfSections()
     }
 
-    
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if self.viewModel.isCardsSection(section: indexPath.section) {
             collectionView.deselectItem(at: indexPath, animated: true)
-            if self.viewModel.isCardItemFor(indexPath: indexPath){
+            if self.viewModel.isCardItemFor(indexPath: indexPath) {
                 let card = self.viewModel.cards![indexPath.row]
                 callback(card)
-            }else if self.viewModel.isExtraOptionItemFor(indexPath: indexPath){
+            } else if self.viewModel.isExtraOptionItemFor(indexPath: indexPath) {
                 callback(nil)
             }
         }
     }
-    
+
     public func collectionView(_ collectionView: UICollectionView,
                                numberOfItemsInSection section: Int) -> Int {
         return self.viewModel.numberOfItemsInSection(section: section)
-        
+
     }
-    
+
     public func collectionView(_ collectionView: UICollectionView,
                                cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "searchCollectionCell",
-                                                      
+
                                                       for: indexPath) as! PaymentSearchCollectionViewCell
-        
+
         if self.viewModel.isHeaderSection(section: indexPath.section) {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "paymentVaultTitleCollectionViewCell",
-                                                          
+
                                                           for: indexPath) as! PaymentVaultTitleCollectionViewCell
              cell.title.text = self.viewModel.titleScreen
             self.titleSectionReference = cell
             titleCell = cell
             return cell
-        }else if self.viewModel.isCardItemFor(indexPath: indexPath){
+        } else if self.viewModel.isCardItemFor(indexPath: indexPath) {
             cell.fillCell(drawablePaymentOption: self.viewModel.cards![indexPath.row])
-        }else if self.viewModel.isExtraOptionItemFor(indexPath: indexPath){
+        } else if self.viewModel.isExtraOptionItemFor(indexPath: indexPath) {
             cell.fillCell(optionText:self.viewModel.extraOptionTitle!)
         }
 
         return cell
-        
+
     }
 
-    
     override func scrollPositionToShowNavBar () -> CGFloat {
         return titleCellHeight - navBarHeigth - statusBarHeigth
     }
-    
+
     public func collectionView(_ collectionView: UICollectionView,
                                layout collectionViewLayout: UICollectionViewLayout,
                                sizeForItemAt indexPath: IndexPath) -> CGSize {
-        
+
         return viewModel.sizeForItemAt(indexPath: indexPath)
     }
-    
 
-    
     public func collectionView(_ collectionView: UICollectionView,
                                layout collectionViewLayout: UICollectionViewLayout,
                                insetForSectionAt section: Int) -> UIEdgeInsets {
         return UIEdgeInsetsMake(8, 8, 8, 8)
-        
+
     }
-    
+
     public func collectionView(_ collectionView: UICollectionView,
                                layout collectionViewLayout: UICollectionViewLayout,
                                minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 8
     }
-    
-    public func scrollViewDidScroll(_ scrollView: UIScrollView){
-        
+
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+
         self.didScrollInTable(scrollView)
     }
-    
+
     override open func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
     }
-    
-    fileprivate func getCustomerCards(){
+
+    fileprivate func getCustomerCards() {
         if self.viewModel!.shouldGetCustomerCardsInfo() {
             self.showLoading()
             MerchantServer.getCustomer({ (customer: Customer) -> Void in
@@ -217,30 +208,26 @@ open class CardsAdminViewController: MercadoPagoUIScrollViewController, UICollec
                 self.collectionSearch.dataSource = self
                 self.viewModel.loadingCards = false
                 self.collectionSearch.reloadData()
-            }, failure: { (error: NSError?) -> Void in
+            }, failure: { (_: NSError?) -> Void in
                  self.hideLoading()
             })
         }
     }
 
     fileprivate func hideNavBarCallbackDisplayTitle() -> ((Void) -> (Void)) {
-        return { Void -> (Void) in
+        return { () -> (Void) in
             if self.titleSectionReference != nil {
                 self.titleSectionReference.fillCell()
                 self.titleSectionReference.title.text = self.viewModel.titleScreen
             }
         }
     }
-    
+
     override func getNavigationBarTitle() -> String {
         if self.titleSectionReference != nil {
             self.titleSectionReference.title.text = ""
         }
         return self.viewModel.titleScreen
     }
-    
+
 }
-
-
-
-

--- a/MercadoPagoSDK/MercadoPagoSDK/CardsAdminViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CardsAdminViewModel.swift
@@ -8,98 +8,93 @@
 
 import Foundation
 
+open class CardsAdminViewModel: NSObject {
 
-open class CardsAdminViewModel : NSObject {
-    
-    var cards : [Card]?
-    var customerId : String?
-    var extraOptionTitle : String?
+    var cards: [Card]?
+    var customerId: String?
+    var extraOptionTitle: String?
     var titleScreen = "¿Con qué tarjeta?".localized
     var loadingCards = true
-    
-   public  init(cards : [Card]? = nil,  extraOptionTitle : String? = nil){
+
+   public  init(cards: [Card]? = nil, extraOptionTitle: String? = nil) {
         self.cards = cards
         self.extraOptionTitle = extraOptionTitle
     }
-    
+
     func shouldGetCustomerCardsInfo() -> Bool {
         return cards == nil
     }
-    
+
     func numberOfOptions() -> Int {
         if let _ = self.extraOptionTitle {
-            if let cards = cards{
+            if let cards = cards {
                 return cards.count + 1
-            }else{
+            } else {
                 return 1
             }
-        }else{
-            if let cards = cards{
+        } else {
+            if let cards = cards {
                 return cards.count
-            }else{
+            } else {
                 return 0
             }
         }
     }
-    
-    func setTitle(title : String){
+
+    func setTitle(title: String) {
         self.titleScreen = title
     }
-    
-    
-    
-    func calculateHeight(indexPath : IndexPath, numberOfCells : Int) -> CGFloat {
+
+    func calculateHeight(indexPath: IndexPath, numberOfCells: Int) -> CGFloat {
         if numberOfCells == 0 {
             return 0
         }
-        
-        let section : Int
+
+        let section: Int
         let row = indexPath.row
-        if row % 2 == 1{
+        if row % 2 == 1 {
             section = (row - 1) / 2
-        }else{
+        } else {
             section = row / 2
         }
         let index1 = (section  * 2)
         let index2 = (section  * 2) + 1
-        
+
         if index1 + 1 > numberOfCells {
             return 0
         }
-        
+
         let height1 = heightOfItem(indexItem: index1)
-        
+
         if index2 + 1 > numberOfCells {
             return height1
         }
-        
+
         let height2 = heightOfItem(indexItem: index2)
-        
-        
+
         return height1 > height2 ? height1 : height2
-        
+
     }
-    
+
     func isHeaderSection(section: Int) -> Bool {
         return section == 0
     }
     func isCardsSection(section: Int) -> Bool {
-        
+
         return section == 1
     }
     fileprivate let itemsPerRow: CGFloat = 2
-    
-    var sectionHeight : CGSize?
-    
-    func maxHegithRow(indexPath: IndexPath) -> CGFloat{
+
+    var sectionHeight: CGSize?
+
+    func maxHegithRow(indexPath: IndexPath) -> CGFloat {
         guard let cards = self.cards else {
             return 0
         }
         return self.calculateHeight(indexPath: indexPath, numberOfCells: cards.count)
     }
-    
-    
-    func heightOfItem(indexItem : Int) -> CGFloat {
+
+    func heightOfItem(indexItem: Int) -> CGFloat {
         guard let cards = self.cards else {
             return 0
         }
@@ -111,59 +106,58 @@ open class CardsAdminViewModel : NSObject {
         }
         return 2
     }
-    
+
     public func numberOfItemsInSection (section: Int) -> Int {
         if (self.loadingCards) {
             return 0
         }
-        if (self.isHeaderSection(section: section)){
+        if (self.isHeaderSection(section: section)) {
             return 1
         }
         return self.numberOfOptions()
-        
+
     }
-    
-    
+
     public func sizeForItemAt (indexPath: IndexPath) -> CGSize {
-        
+
         let paddingSpace = CGFloat(32.0)
-        let screenSize : CGRect = UIScreen.main.bounds
+        let screenSize: CGRect = UIScreen.main.bounds
         let screenWidth = screenSize.width
         let availableWidth = screenWidth - paddingSpace
-        
-        let titleCellHeight : CGFloat = 82.0
+
+        let titleCellHeight: CGFloat = 82.0
         if self.isHeaderSection(section: indexPath.section) {
             return CGSize(width : screenWidth, height : titleCellHeight)
         }
         let widthPerItem = availableWidth / self.itemsPerRow
         return CGSize(width: widthPerItem, height: self.maxHegithRow(indexPath:indexPath)  )
     }
-    
-    func isCardItemFor(indexPath: IndexPath) -> Bool{
-        guard let cards = cards else{
+
+    func isCardItemFor(indexPath: IndexPath) -> Bool {
+        guard let cards = cards else {
             return false
         }
-        if !self.isCardsSection(section: indexPath.section){
+        if !self.isCardsSection(section: indexPath.section) {
             return false
-        }else if cards.count > indexPath.row {
+        } else if cards.count > indexPath.row {
             return true
-        }else{
+        } else {
             return false
         }
     }
-    
-    func isExtraOptionItemFor(indexPath: IndexPath) -> Bool{
-        guard let cards = cards else{
+
+    func isExtraOptionItemFor(indexPath: IndexPath) -> Bool {
+        guard let cards = cards else {
             return ( (self.isCardsSection(section: indexPath.section)) && (self.extraOptionTitle != nil) )
         }
-        
-        if !self.isCardsSection(section: indexPath.section){
+
+        if !self.isCardsSection(section: indexPath.section) {
             return false
-        }else if cards.count > indexPath.row {
+        } else if cards.count > indexPath.row {
             return false
-        }else{
+        } else {
             return (self.extraOptionTitle != nil)
         }
     }
-    
+
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -10,7 +10,7 @@ import UIKit
 
 open class MercadoPagoCheckout: NSObject {
 
-    static var currentCheckout : MercadoPagoCheckout?
+    static var currentCheckout: MercadoPagoCheckout?
     var viewModel: MercadoPagoCheckoutViewModel
     var navigationController: UINavigationController!
     var viewControllerBase: UIViewController?
@@ -21,7 +21,7 @@ open class MercadoPagoCheckout: NSObject {
     internal static var firstViewControllerPushed = false
     private var rootViewController: UIViewController?
 
-    public init(checkoutPreference: CheckoutPreference, paymentData: PaymentData? = nil, discount: DiscountCoupon? = nil, navigationController: UINavigationController, paymentResult: PaymentResult? = nil) {
+    public init(publicKey: String, accessToken: String?, checkoutPreference: CheckoutPreference, paymentData: PaymentData? = nil, discount: DiscountCoupon? = nil, navigationController: UINavigationController, paymentResult: PaymentResult? = nil) {
         viewModel = MercadoPagoCheckoutViewModel(checkoutPreference : checkoutPreference, paymentData: paymentData, paymentResult: paymentResult, discount : discount)
         DecorationPreference.saveNavBarStyleFor(navigationController: navigationController)
         self.navigationController = navigationController
@@ -30,6 +30,13 @@ open class MercadoPagoCheckout: NSObject {
             let  newNavigationStack = self.navigationController.viewControllers.filter {!$0.isKind(of:MercadoPagoUIViewController.self) || $0.isKind(of:CheckoutViewController.self)
             }
             viewControllerBase = newNavigationStack.last
+        }
+
+        MercadoPagoContext.setPublicKey(publicKey)
+        if let at = accessToken {
+            MercadoPagoContext.setPayerAccessToken(at)
+        } else {
+            MercadoPagoContext.setPayerAccessToken("")
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -252,7 +252,7 @@ open class MercadoPagoContext: NSObject, MPTrackerDelegate {
     open class func merchantAccessToken() -> String {
         return sharedInstance.merchant_access_token
     }
-    open class func setMerchantAccessToken(merchantAT : String)  {
+    open class func setMerchantAccessToken(merchantAT: String) {
         sharedInstance.merchant_access_token = merchantAT
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoUIViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoUIViewController.swift
@@ -353,7 +353,7 @@ extension UINavigationController {
     }
 
  //   override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        
+
  //       return self.viewControllers.last!.supportedInterfaceOrientations
   //  }
 

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutTest.swift
@@ -32,7 +32,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testInit_withCheckoutPreference() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
         XCTAssertNotNil(self.mpCheckout!.viewModel)
         XCTAssertNotNil(self.mpCheckout!.viewModel.checkoutPreference)
         XCTAssertFalse(self.mpCheckout!.viewModel.paymentData.isComplete())
@@ -49,7 +49,7 @@ class MercadoPagoCheckoutTest: BaseTest {
         paymentData.token = MockBuilder.buildToken()
         let navControllerInstance = UINavigationController()
 
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, paymentData : paymentData, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, paymentData : paymentData, navigationController: navControllerInstance)
 
         XCTAssertNotNil(self.mpCheckout!.viewModel)
         XCTAssertNotNil(self.mpCheckout!.viewModel.checkoutPreference)
@@ -69,7 +69,7 @@ class MercadoPagoCheckoutTest: BaseTest {
         let navControllerInstance = UINavigationController()
         let paymentResult = MockBuilder.buildPaymentResult(paymentMethodId: "visa")
 
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, paymentData : paymentData, navigationController: navControllerInstance, paymentResult : paymentResult)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, paymentData : paymentData, navigationController: navControllerInstance, paymentResult : paymentResult)
 
         XCTAssertNotNil(self.mpCheckout!.viewModel)
         XCTAssertNotNil(self.mpCheckout!.viewModel.checkoutPreference)
@@ -85,7 +85,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testCollectCheckoutPreference() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckoutMock(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckoutMock(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         self.mpCheckout!.collectCheckoutPreference()
 
@@ -97,7 +97,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testCollectPaymentMethodSearch() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckoutMock(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckoutMock(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         XCTAssertNil(self.mpCheckout?.viewModel.rootPaymentMethodOptions)
         XCTAssertNil(self.mpCheckout?.viewModel.search)
@@ -118,7 +118,7 @@ class MercadoPagoCheckoutTest: BaseTest {
 
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         MPCheckoutTestAction.loadGroupsInViewModel(mpCheckout: self.mpCheckout!)
 
@@ -141,7 +141,7 @@ class MercadoPagoCheckoutTest: BaseTest {
         fp.disableDiscount()
         MercadoPagoCheckout.setFlowPreference(fp)
 
-        self.mpCheckout = MercadoPagoCheckoutMock(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckoutMock(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         self.mpCheckout!.validatePreference()
         XCTAssertEqual(navControllerInstance.viewControllers.count, 0)
@@ -149,7 +149,7 @@ class MercadoPagoCheckoutTest: BaseTest {
         // Evitar ir a buscar preferencia. Preferencia inválida debería mostrar error
         checkoutPreference.items = nil
         checkoutPreference._id = nil
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
         self.mpCheckout!.validatePreference()
 //        XCTAssertNotNil(MercadoPagoCheckoutViewModel.error)
 //        XCTAssertNotNil(MercadoPagoCheckoutViewModel.error!.messageDetail)//,errorMessageExpected)
@@ -160,7 +160,7 @@ class MercadoPagoCheckoutTest: BaseTest {
 
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         self.mpCheckout?.collectCard()
 
@@ -176,7 +176,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testCollectIdentification() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         self.mpCheckout?.collectIdentification()
 
@@ -192,7 +192,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testCollectCreditDebit() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         self.mpCheckout?.collectCreditDebit()
 
@@ -208,7 +208,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testStartIssuersScreen() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         self.mpCheckout?.collectCreditDebit()
 
@@ -224,7 +224,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testStartPayerCostScreen() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         self.mpCheckout?.collectCreditDebit()
 
@@ -240,7 +240,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testCollectPaymentData() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         MPCheckoutTestAction.loadGroupsInViewModel(mpCheckout: self.mpCheckout!)
         MPCheckoutTestAction.selectAccountMoney(mpCheckout: self.mpCheckout!)
@@ -256,7 +256,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testDisplayPaymentResult_onlinePayment() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         let paymentMethod = MockBuilder.buildPaymentMethod("visa")
         self.mpCheckout!.viewModel.payment = MockBuilder.buildPayment("visa")
@@ -273,7 +273,7 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testDisplayPaymentResult_offlinePayment() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
 
         let paymentMethod = MockBuilder.buildPaymentMethod("rapipago", paymentTypeId : "ticket")
         self.mpCheckout!.viewModel.payment = MockBuilder.buildPayment("rapipago")

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutViewModelTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutViewModelTest.swift
@@ -27,10 +27,9 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     func testNextStep_withCheckoutPreference_accountMoney() {
 
         // Set access_token
-        MercadoPagoContext.setPayerAccessToken("access_token")
         MercadoPagoContext.setAccountMoneyAvailable(accountMoneyAvailable: true)
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "public_key", accessToken: "access_token", checkoutPreference: checkoutPreference, navigationController: UINavigationController())
         XCTAssertNotNil(mpCheckout.viewModel)
         MercadoPagoCheckoutViewModel.flowPreference.showDiscount = true
 
@@ -85,10 +84,9 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     func testNextStep_withCheckoutPreference_masterCreditCard() {
 
         // Set access_token
-        MercadoPagoContext.setPayerAccessToken("access_token")
         MercadoPagoContext.setAccountMoneyAvailable(accountMoneyAvailable: true)
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "public_key", accessToken: "access_token", checkoutPreference: checkoutPreference, navigationController: UINavigationController())
         XCTAssertNotNil(mpCheckout.viewModel)
         MercadoPagoCheckoutViewModel.flowPreference.showDiscount = true
 
@@ -196,7 +194,6 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     func testNextStep_withCheckoutPreference_accountMoney_noRyC() {
 
         // Set access_token
-        MercadoPagoContext.setPayerAccessToken("access_token")
         MercadoPagoContext.setAccountMoneyAvailable(accountMoneyAvailable: true)
 
         // Deshabilitar ryc
@@ -215,7 +212,7 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
         }
 
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "public_key", accessToken: "access_token", checkoutPreference: checkoutPreference, navigationController: UINavigationController())
 
         XCTAssertNotNil(mpCheckout.viewModel)
 
@@ -256,14 +253,13 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     func testNextStep_withPaymentDataComplete() {
 
         // Set access_token
-        MercadoPagoContext.setPayerAccessToken("access_token")
         MercadoPagoContext.setAccountMoneyAvailable(accountMoneyAvailable: true)
 
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let accountMoneyPaymentMethod = MockBuilder.buildPaymentMethod("account_money", paymentTypeId : "account_money")
         let paymentDataAccountMoney = MockBuilder.buildPaymentData(paymentMethod: accountMoneyPaymentMethod)
 
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, paymentData : paymentDataAccountMoney, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "public_key", accessToken: "access_token", checkoutPreference: checkoutPreference, paymentData : paymentDataAccountMoney, navigationController: UINavigationController())
         XCTAssertNotNil(mpCheckout.viewModel)
 
         // 1. Search Preference
@@ -307,7 +303,6 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     func testNextStep_withPaymentResult() {
 
         // Set access_token
-        MercadoPagoContext.setPayerAccessToken("access_token")
 
         // Init checkout
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
@@ -316,7 +311,7 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
 
         let paymentResult = PaymentResult(status: "status", statusDetail: "statusDetail", paymentData: paymentDataVisa, payerEmail: "payerEmail", id: "id", statementDescription: "description")
 
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController(), paymentResult : paymentResult)
+        let mpCheckout = MercadoPagoCheckout(publicKey: "public_key", accessToken: "access_token", checkoutPreference: checkoutPreference, navigationController: UINavigationController(), paymentResult : paymentResult)
         XCTAssertNotNil(mpCheckout.viewModel)
 
         // 1. Search preference
@@ -341,11 +336,10 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     func testNextStep_withCustomerCard() {
 
         // Set access_token
-        MercadoPagoContext.setPayerAccessToken("access_token")
 
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
 
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "public_key", accessToken: "access_token", checkoutPreference: checkoutPreference, navigationController: UINavigationController())
         XCTAssertNotNil(mpCheckout.viewModel)
 
         // 1. Search preference
@@ -429,7 +423,6 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     func testNextStep_withCheckoutPreference_accountMoney_noDiscount() {
 
         // Set access_token
-        MercadoPagoContext.setPayerAccessToken("access_token")
         MercadoPagoContext.setAccountMoneyAvailable(accountMoneyAvailable: true)
 
         // Deshabilitar descuentos
@@ -438,7 +431,7 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
         MercadoPagoCheckout.setFlowPreference(fp)
 
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "access_token", checkoutPreference: checkoutPreference, navigationController: UINavigationController())
         XCTAssertNotNil(mpCheckout.viewModel)
 
         // 1. Search Preference
@@ -488,7 +481,6 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
     func testNextStep_withCheckoutPreference_accountMoney_withDiscount() {
 
         // Set access_token
-        MercadoPagoContext.setPayerAccessToken("access_token")
         MercadoPagoContext.setAccountMoneyAvailable(accountMoneyAvailable: true)
 
         // Deshabilitar descuentos
@@ -507,7 +499,7 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
         discount.concept = "Descuento de patito"
         discount.amount = 300
 
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, discount: discount, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "access_token", checkoutPreference: checkoutPreference, discount: discount, navigationController: UINavigationController())
         XCTAssertNotNil(mpCheckout.viewModel)
 
         // 1. Search Preference
@@ -560,7 +552,7 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
 
     func testHasError() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: UINavigationController())
 
         XCTAssertFalse(mpCheckout.viewModel.hasError())
 
@@ -575,7 +567,7 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
 
     func testCardFormManager() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: UINavigationController())
 
         let cardFormManager = mpCheckout.viewModel.cardFormManager()
         XCTAssertTrue(cardFormManager.isKind(of: CardViewModelManager.self))
@@ -584,7 +576,7 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
 
     func testPaymentVaultViewModel() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: UINavigationController())
 
         MPCheckoutTestAction.loadGroupsInViewModel(mpCheckout: mpCheckout)
 
@@ -598,7 +590,7 @@ class MercadoPagoCheckoutViewModelTest: BaseTest {
 
     func testDebitCreditViewModel() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: UINavigationController())
 
         MPCheckoutTestAction.loadGroupsInViewModel(mpCheckout: mpCheckout)
 

--- a/MercadoPagoSDK/MercadoPagoSDKTests/PaymentResultScreenPreferenceTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/PaymentResultScreenPreferenceTest.swift
@@ -21,7 +21,7 @@ class PaymentResultScreenPreferenceTest: BaseTest {
     func createCheckout() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
     }
 
     func testSetTitle() {

--- a/MercadoPagoSDK/MercadoPagoSDKTests/ReviewScreenPreferenceTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/ReviewScreenPreferenceTest.swift
@@ -21,7 +21,7 @@ class ReviewScreenPreferenceTest: BaseTest {
     func createCheckout() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
     }
 
     func testSetTitle() {

--- a/MercadoPagoSDK/MercadoPagoSDKTests/WalletIntegrationTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/WalletIntegrationTest.swift
@@ -31,7 +31,7 @@ class WalletIntegrationTest: BaseTest {
 
         // Inicia Checkout con preferencia
         let preference = MockBuilder.buildCheckoutPreference()
-        let mpCheckout = MercadoPagoCheckout(checkoutPreference: preference, navigationController: UINavigationController())
+        let mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "access_token", checkoutPreference: preference, navigationController: UINavigationController())
 
         var step = mpCheckout.viewModel.nextStep()
         XCTAssertEqual(step, CheckoutStep.SEARCH_PREFERENCE)
@@ -69,7 +69,7 @@ class WalletIntegrationTest: BaseTest {
         MercadoPagoCheckout.setFlowPreference(fp)
 
         // Se vuelve a llamar a Checkout para que muestre RyC
-        let mpCheckoutWithRyC = MercadoPagoCheckout(checkoutPreference: preference, paymentData : localPaymentData, navigationController: UINavigationController())
+        let mpCheckoutWithRyC = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "access_token", checkoutPreference: preference, paymentData : localPaymentData, navigationController: UINavigationController())
         step = mpCheckoutWithRyC.viewModel.nextStep()
         XCTAssertEqual(step, CheckoutStep.SEARCH_PREFERENCE)
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/AppDelegate.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/AppDelegate.m
@@ -21,9 +21,9 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
-    [MercadoPagoContext setPublicKey:@"APP_USR-5a399d42-6015-4f6a-8ff8-dd7d368068f8"];
+//    [MercadoPagoContext setPublicKey:@"APP_USR-5a399d42-6015-4f6a-8ff8-dd7d368068f8"];
     
-    [MercadoPagoContext setPublicKey:TEST_PUBLIC_KEY];
+//    [MercadoPagoContext setPublicKey:TEST_PUBLIC_KEY];
 //    [MercadoPagoContext setPayerAccessToken:@"APP_USR-1094487241196549-081708-4bc39f94fd147e7ce839c230c93261cb__LA_LC__-145698489"];
 
 //    [MercadoPagoContext setMerchantAccessToken: MERCHANT_ACCESS_TOKEN];

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -93,7 +93,7 @@
     dc.currency_id = @"ARS";
     dc.concept = @"Descuento de patito";
     dc.amount = 300;
-    self.mpCheckout = [[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:self.paymentData discount:dc navigationController:self.navigationController paymentResult:self.paymentResult ];
+    self.mpCheckout = [[MercadoPagoCheckout alloc] initWithPublicKey: TEST_PUBLIC_KEY accessToken: nil checkoutPreference:self.pref paymentData:self.paymentData discount:dc navigationController:self.navigationController paymentResult:self.paymentResult ];
     
     // Setear PaymentResultScreenPreference
     [self setPaymentResultScreenPreference];

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/StepsExamplesViewController.m
@@ -99,7 +99,7 @@ CheckoutPreference *pref;
     pd.issuer._id = [NSNumber numberWithInt:200];
     
     
-    [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:pd discount:nil navigationController:self.navigationController paymentResult:nil] start];
+    [[[MercadoPagoCheckout alloc] initWithPublicKey: TEST_PUBLIC_KEY accessToken: @"APP_USR-1094487241196549-081708-4bc39f94fd147e7ce839c230c93261cb__LA_LC__-145698489" checkoutPreference:self.pref paymentData:pd discount:nil navigationController:self.navigationController paymentResult:nil] start];
 
     
 }
@@ -114,7 +114,7 @@ CheckoutPreference *pref;
     
     [MainExamplesViewController setPaymentDataCallback];
     
-    [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:nil discount:nil navigationController:self.navigationController paymentResult:nil] start];
+    [[[MercadoPagoCheckout alloc] initWithPublicKey: TEST_PUBLIC_KEY accessToken: @"APP_USR-1094487241196549-081708-4bc39f94fd147e7ce839c230c93261cb__LA_LC__-145698489" checkoutPreference:self.pref paymentData:nil discount:nil navigationController:self.navigationController paymentResult:nil] start];
 
 }
 
@@ -141,7 +141,7 @@ CheckoutPreference *pref;
     pd.issuer = nil;//[[Issuer alloc] init];
      PaymentResult *paymentResult = [[PaymentResult alloc] initWithStatus:@"approved" statusDetail:@"approved" paymentData:pd payerEmail:nil id:nil statementDescription:nil];
     
-    [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:pd discount:nil navigationController:self.navigationController paymentResult:paymentResult] start];
+    [[[MercadoPagoCheckout alloc] initWithPublicKey: TEST_PUBLIC_KEY accessToken: @"APP_USR-1094487241196549-081708-4bc39f94fd147e7ce839c230c93261cb__LA_LC__-145698489" checkoutPreference:self.pref paymentData:pd discount:nil navigationController:self.navigationController paymentResult:paymentResult] start];
 
 }
 


### PR DESCRIPTION
Fix #950

##  Cambios introducidos : 
- Se setea la PK y AT desde el init de mercadopagoCheckout

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
