### PR TITLE
Add language and site sets in MercadoPagoCheckout

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -794,6 +794,14 @@ extension MercadoPagoCheckout {
         MercadoPagoCheckoutViewModel.callback = callback
     }
 
+    open static func setSite(siteID: String) {
+        MercadoPagoContext.setSiteID(siteID)
+    }
+
+    open static func setLanguage(language: Languages) {
+        MercadoPagoContext.setLanguage(language: language)
+    }
+
     open class func showPayerCostDescription() -> Bool {
 
         let path = MercadoPago.getBundle()!.path(forResource: "PayerCostPreferences", ofType: "plist")

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoContext.swift
@@ -100,34 +100,6 @@ open class MercadoPagoContext: NSObject, MPTrackerDelegate {
         case MCO = "MCO"
     }
 
-    @objc public enum Languages: Int {
-        case _SPANISH
-        case _SPANISH_MEXICO
-        case _SPANISH_COLOMBIA
-        case _SPANISH_URUGUAY
-        case _SPANISH_PERU
-        case _SPANISH_VENEZUELA
-//        case _SPANISH_CHILE
-        case _PORTUGUESE
-        case _ENGLISH
-
-        func langPrefix() -> String {
-            switch self {
-            case ._SPANISH : return "es"
-            case ._SPANISH_MEXICO : return "es-MX"
-            case ._SPANISH_COLOMBIA : return "es-CO"
-            case ._SPANISH_URUGUAY : return "es-UY"
-            case ._SPANISH_PERU : return "es-PE"
-            case ._SPANISH_VENEZUELA : return "es-VE"
-//            case ._SPANISH_CHILE : return "es-CH"
-
-            case ._PORTUGUESE : return "pt"
-            case ._ENGLISH : return "en"
-            }
-        }
-
-    }
-
     open func siteId() -> String! {
         return site.rawValue
     }
@@ -296,6 +268,34 @@ open class MercadoPagoContext: NSObject, MPTrackerDelegate {
             return MercadoPagoContext.payerAccessToken()
         } else {
             return MercadoPagoContext.publicKey()
+        }
+    }
+
+}
+
+@objc public enum Languages: Int {
+    case _SPANISH
+    case _SPANISH_MEXICO
+    case _SPANISH_COLOMBIA
+    case _SPANISH_URUGUAY
+    case _SPANISH_PERU
+    case _SPANISH_VENEZUELA
+    //        case _SPANISH_CHILE
+    case _PORTUGUESE
+    case _ENGLISH
+
+    func langPrefix() -> String {
+        switch self {
+        case ._SPANISH : return "es"
+        case ._SPANISH_MEXICO : return "es-MX"
+        case ._SPANISH_COLOMBIA : return "es-CO"
+        case ._SPANISH_URUGUAY : return "es-UY"
+        case ._SPANISH_PERU : return "es-PE"
+        case ._SPANISH_VENEZUELA : return "es-VE"
+            //            case ._SPANISH_CHILE : return "es-CH"
+
+        case ._PORTUGUESE : return "pt"
+        case ._ENGLISH : return "en"
         }
     }
 


### PR DESCRIPTION
Fix #953 

##  Cambios introducidos : 
- Se agregan sets de language y site a MercadoPagoCheckout

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
