### PR TITLE
Localizable Strings & Podspect

### DIFF
--- a/MercadoPagoSDK.podspec
+++ b/MercadoPagoSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #s.dependency 'MercadoPagoTracker'
 
   s.subspec 'Localization' do |t|
-    %w|pt es es-MX es-CO|.map {|localename|
+    %w|pt es es-MX es-CO en es-PE es-VE es-UY|.map {|localename|
       t.subspec localename do |u|
         u.ios.resources = "MercadoPagoSDK/MercadoPagoSDK/#{localename}.lproj"
         u.ios.preserve_paths = "MercadoPagoSDK/MercadoPagoSDK/#{localename}.lproj"

--- a/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
@@ -23,6 +23,10 @@
 "amex"="Amex";
 
 
+"Si" = "Yes";
+"No" = "No";
+
+
 
 //CONGRATS
 

--- a/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/en.lproj/Localizable.strings
@@ -5,8 +5,11 @@
  Created by Matias Gualino on 26/4/15.
  Copyright (c) 2015 MercadoPago. All rights reserved.
  */
-"Cargando..." = "Loading...";
 
+"Si" = "Yes";
+"No" = "No";
+
+"Cargando..." = "Loading...";
 "invalid_cvv_length" = "Ingresa los %1$s números del código de seguridad";
 "invalid_field" = "Check this information";
 "invalid_card_length" = "Enter the %1$s card numbers";
@@ -17,16 +20,9 @@
 "NOT_INSTALLMENTS_FOUND" = "No interest were found available for an amount of $";
 "PAYMENT_ERROR" = "Payment failed.";
 "No se ha podido obtener los métodos de pago con esta preferencia" = "Payment methods could not be obtained with this preference";
-
 "visa"="Visa";
 "master"="Mastercard";
 "amex"="Amex";
-
-
-"Si" = "Yes";
-"No" = "No";
-
-
 
 //CONGRATS
 

--- a/MercadoPagoSDK/MercadoPagoSDK/es.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/es.lproj/Localizable.strings
@@ -10,7 +10,6 @@
 "No" = "No";
 
 "Cargando..." = "Cargando...";
-
 "invalid_cvv_length" = "Ingresa los %1$s números del código de seguridad";
 "invalid_field" = "Revisa este dato";
 "invalid_card_length" = "Ingresa los %1$s números de la tarjeta";
@@ -24,13 +23,11 @@
 "NOT_INSTALLMENTS_FOUND" = "No se encontraron cuotas disponibles para un monto de $";
 "PAYMENT_ERROR" = "No se pudo realizar el pago.";
 "No se ha podido obtener los métodos de pago con esta preferencia" = "No se ha podido obtener los métodos de pago con esta preferencia";
-
 "visa"="Visa";
 "master"="Mastercard";
 "amex"="Amex";
 
 //INSTRUCCIONES
-
 
 //CONGRATS
 

--- a/MercadoPagoSDK/MercadoPagoSDK/es.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/es.lproj/Localizable.strings
@@ -5,6 +5,10 @@
   Created by Matias Gualino on 26/4/15.
   Copyright (c) 2015 MercadoPago. All rights reserved.
 */
+
+"Si" = "Si";
+"No" = "No";
+
 "Cargando..." = "Cargando...";
 
 "invalid_cvv_length" = "Ingresa los %1$s números del código de seguridad";

--- a/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
@@ -6,6 +6,9 @@
   Copyright (c) 2015 MercadoPago. All rights reserved.
 */
 
+"Si" = "Sim";
+"No" = "Não";
+
 "Cargando..." = "Carregando...";
 "invalid_cvv_length" = "Digite os %1$s números do código de segurança";
 "invalid_field" = "Verifique este dado";
@@ -14,11 +17,6 @@
 "security_code" = "Código de segurança";
 "cod_seg_desc" = "Últimos %1$s dígitos do verso do cartão de crédito";
 "cod_seg_desc_amex" = "%1$s dígitos da frente do cartão de crédito";
-
-
-"Si" = "Sim";
-"No" = "Não";
-
 
 //ADDITIONAL STEP
 

--- a/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
+++ b/MercadoPagoSDK/MercadoPagoSDK/pt.lproj/Localizable.strings
@@ -15,6 +15,11 @@
 "cod_seg_desc" = "Últimos %1$s dígitos do verso do cartão de crédito";
 "cod_seg_desc_amex" = "%1$s dígitos da frente do cartão de crédito";
 
+
+"Si" = "Sim";
+"No" = "Não";
+
+
 //ADDITIONAL STEP
 
 //-- Payer Cost


### PR DESCRIPTION
Fix #973 #974

##  Cambios introducidos : 
- Se agregan los sets de strings pertenecientes a Perú, Venezuela, Uruguay e Idioma Inglés al podspect de manera de que el pod se cree con dichos lenguajes.

- Se agregan los textos "Si" - "No" a los archivos Localizables

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [ ] Correr Swiftlint

### Testeo
- [ ] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
