### PR TITLE
Test new MercadoPagoCheckout and Decoration inits

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDKTests/DecorationPreferenceTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/DecorationPreferenceTest.swift
@@ -10,52 +10,72 @@ import XCTest
 
 class DecorationPreferenceTest: BaseTest {
 
-    func testSetBaseColor() {
-        let decoration = DecorationPreference()
+    var decoration: DecorationPreference!
+
+    override func setUp() {
+        super.setUp()
+        self.decoration = DecorationPreference()
+    }
+
+    func testInits() {
+        let decorationPreference = DecorationPreference(baseColor: UIColor.brown)
+        XCTAssertEqual(decorationPreference.baseColor, UIColor.brown)
+    }
+
+    func testDefaultValues() {
         XCTAssertEqual(decoration.getBaseColor(), UIColor.px_blueMercadoPago())
-//        decoration.setBaseColor(color: UIColor())
-//        XCTAssertEqual(decoration.getBaseColor(), UIColor.px_blueMercadoPago())
+        XCTAssertEqual(decoration.fontName, ".SFUIDisplay-Regular")
+        XCTAssertEqual(decoration.fontLightName, ".SFUIDisplay-Light")
+    }
+
+    func testSetBaseColor() {
         decoration.setBaseColor(color: UIColor.brown)
         XCTAssertEqual(decoration.getBaseColor(), UIColor.brown)
     }
 
     func testEnableDarkFont() {
-        let decoration = DecorationPreference()
         decoration.enableDarkFont()
         XCTAssertEqual(decoration.getFontColor(), UIColor.black)
     }
 
     func testEnableLightFont() {
-        let decoration = DecorationPreference()
         decoration.enableLightFont()
         XCTAssertEqual(decoration.getFontColor(), UIColor.white)
     }
 
     func testSetMercadoPagoBaseColor() {
-        let decoration = DecorationPreference()
         decoration.setMercadoPagoBaseColor()
         XCTAssertEqual(decoration.getBaseColor(), UIColor.px_blueMercadoPago())
         decoration.setBaseColor(color: UIColor.purple)
         decoration.setMercadoPagoBaseColor()
         XCTAssertEqual(decoration.getBaseColor(), UIColor.px_blueMercadoPago())
     }
+
     func testSetBaseColorHexa() {
-        let decoration = DecorationPreference()
         decoration.setBaseColor(hexColor: "#B34C42")
         XCTAssertEqual(decoration.getBaseColor(), UIColor.errorCellColor())
     }
+
     func testSetMercadoPagoFont() {
-        let decoration = DecorationPreference()
         decoration.setCustomFontWith(name: "sarasa")
         decoration.setMercadoPagoFont()
         XCTAssertEqual(decoration.getFontName(), ".SFUIDisplay-Regular")
     }
 
     func testSetFontName() {
-        let decoration = DecorationPreference()
-        XCTAssertEqual(decoration.getFontName(), ".SFUIDisplay-Regular")
         decoration.setCustomFontWith(name: "Comic")
         XCTAssertEqual(decoration.getFontName(), "Comic")
+    }
+
+    func testSetMercadoPagoLightFont() {
+        decoration.setLightCustomFontWith(name: "sarasa")
+        decoration.setMercadoPagoLightFont()
+        XCTAssertEqual(decoration.getLightFontName(), ".SFUIDisplay-Light")
+    }
+
+    func testSetLightFontName() {
+        decoration.setLightCustomFontWith(name: "Comic")
+        XCTAssertEqual(decoration.getLightFontName(), "Comic")
     }
 
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoCheckoutTest.swift
@@ -32,12 +32,14 @@ class MercadoPagoCheckoutTest: BaseTest {
     func testInit_withCheckoutPreference() {
         let checkoutPreference = MockBuilder.buildCheckoutPreference()
         let navControllerInstance = UINavigationController()
-        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", checkoutPreference: checkoutPreference, navigationController: navControllerInstance)
         XCTAssertNotNil(self.mpCheckout!.viewModel)
         XCTAssertNotNil(self.mpCheckout!.viewModel.checkoutPreference)
         XCTAssertFalse(self.mpCheckout!.viewModel.paymentData.isComplete())
         XCTAssertNil(self.mpCheckout!.viewModel.paymentResult)
         XCTAssertEqual(self.mpCheckout!.navigationController, navControllerInstance)
+        XCTAssertEqual(MercadoPagoContext.publicKey(), "PK_MLA")
+        XCTAssertEqual(MercadoPagoContext.payerAccessToken(), "")
 
     }
 
@@ -49,13 +51,15 @@ class MercadoPagoCheckoutTest: BaseTest {
         paymentData.token = MockBuilder.buildToken()
         let navControllerInstance = UINavigationController()
 
-        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, paymentData : paymentData, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", checkoutPreference: checkoutPreference, paymentData : paymentData, navigationController: navControllerInstance)
 
         XCTAssertNotNil(self.mpCheckout!.viewModel)
         XCTAssertNotNil(self.mpCheckout!.viewModel.checkoutPreference)
         XCTAssertEqual(self.mpCheckout!.viewModel.paymentData.paymentMethod, paymentMethod)
         XCTAssertNil(self.mpCheckout!.viewModel.paymentResult)
         XCTAssertEqual(self.mpCheckout!.navigationController, navControllerInstance)
+        XCTAssertEqual(MercadoPagoContext.publicKey(), "PK_MLA")
+        XCTAssertEqual(MercadoPagoContext.payerAccessToken(), "")
     }
 
     func testInit_withPaymentResult() {
@@ -69,13 +73,15 @@ class MercadoPagoCheckoutTest: BaseTest {
         let navControllerInstance = UINavigationController()
         let paymentResult = MockBuilder.buildPaymentResult(paymentMethodId: "visa")
 
-        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "", checkoutPreference: checkoutPreference, paymentData : paymentData, paymentResult : paymentResult, navigationController: navControllerInstance)
+        self.mpCheckout = MercadoPagoCheckout(publicKey: "PK_MLA", accessToken: "lala", checkoutPreference: checkoutPreference, paymentData : paymentData, paymentResult : paymentResult, navigationController: navControllerInstance)
 
         XCTAssertNotNil(self.mpCheckout!.viewModel)
         XCTAssertNotNil(self.mpCheckout!.viewModel.checkoutPreference)
         XCTAssertEqual(self.mpCheckout!.viewModel.paymentData.paymentMethod, paymentMethod)
         XCTAssertNotNil(self.mpCheckout!.viewModel.paymentResult)
         XCTAssertEqual(self.mpCheckout!.navigationController, navControllerInstance)
+        XCTAssertEqual(MercadoPagoContext.publicKey(), "PK_MLA")
+        XCTAssertEqual(MercadoPagoContext.payerAccessToken(), "lala")
     }
 
     /*******************************************/


### PR DESCRIPTION
Fix #1014 

##  Cambios introducidos : 
- Test de los nuevos inits en MercadoPagoCheckout
- Test de nuevos inits en decoration Preference
- Test de light font de decoration preference

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
