### PR TITLE
Disable new swiftlint rules

### DIFF
--- a/MercadoPagoSDK/.swiftlint.yml
+++ b/MercadoPagoSDK/.swiftlint.yml
@@ -95,10 +95,9 @@ disabled_rules:
   - conditional_returns_on_newline
   - function_parameter_count
   - object_literal
-
-
-
-
+  - empty_parameters
+  - statement_position
+  - unused_closure_parameter
 
 # disabled_rules:
 #     - trailing_newline


### PR DESCRIPTION

##  Cambios introducidos : 
- Se deshabilitan las nuevas reglas en swiftlint

### Revisión
- [ ] Todos los textos se encuentran localizables
- [ ] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [ ] No se agregan logs / prints innecesarios
- [ ] No se agregan comentarios basura
- [ ] Correr Swiftlint

### Testeo
- [ ] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
