### PR TITLE
Add support to disable payment result in FlowPreference

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -621,38 +621,42 @@ open class MercadoPagoCheckout: NSObject {
     }
 
     func displayPaymentResult() {
-        // TODO : por que dos? esta bien? no hay view models, ver que onda
         if self.viewModel.paymentResult == nil {
             self.viewModel.paymentResult = PaymentResult(payment: self.viewModel.payment!, paymentData: self.viewModel.paymentData)
         }
 
-        let congratsViewController: MercadoPagoUIViewController
-        if PaymentTypeId.isOnlineType(paymentTypeId: self.viewModel.paymentData.paymentMethod.paymentTypeId) {
-            congratsViewController = PaymentResultViewController(paymentResult: self.viewModel.paymentResult!, checkoutPreference: self.viewModel.checkoutPreference, paymentResultScreenPreference: self.viewModel.paymentResultScreenPreference, callback: { [weak self] (state: PaymentResult.CongratsState) in
+        if viewModel.shouldDisplayPaymentResult() {
 
-            guard let strongSelf = self else {
-                return
+            let congratsViewController: MercadoPagoUIViewController
+            if PaymentTypeId.isOnlineType(paymentTypeId: self.viewModel.paymentData.paymentMethod.paymentTypeId) {
+                congratsViewController = PaymentResultViewController(paymentResult: self.viewModel.paymentResult!, checkoutPreference: self.viewModel.checkoutPreference, paymentResultScreenPreference: self.viewModel.paymentResultScreenPreference, callback: { [weak self] (state: PaymentResult.CongratsState) in
+
+                    guard let strongSelf = self else {
+                        return
+                    }
+                    if state == PaymentResult.CongratsState.call_FOR_AUTH {
+                        strongSelf.navigationController.setNavigationBarHidden(false, animated: false)
+                        strongSelf.viewModel.prepareForClone()
+                        strongSelf.collectSecurityCodeForRetry()
+                    } else if state == PaymentResult.CongratsState.cancel_RETRY || state == PaymentResult.CongratsState.cancel_SELECT_OTHER {
+                        strongSelf.navigationController.setNavigationBarHidden(false, animated: false)
+                        strongSelf.viewModel.prepareForNewSelection()
+                        strongSelf.executeNextStep()
+
+                    } else {
+                        strongSelf.finish()
+                    }
+
+                })
+            } else {
+                congratsViewController = InstructionsViewController(paymentResult: self.viewModel.paymentResult!, callback: { (_ :PaymentResult.CongratsState) in
+                    self.finish()
+                }, paymentResultScreenPreference: self.viewModel.paymentResultScreenPreference)
             }
-                if state == PaymentResult.CongratsState.call_FOR_AUTH {
-                    strongSelf.navigationController.setNavigationBarHidden(false, animated: false)
-                    strongSelf.viewModel.prepareForClone()
-                    strongSelf.collectSecurityCodeForRetry()
-                } else if state == PaymentResult.CongratsState.cancel_RETRY || state == PaymentResult.CongratsState.cancel_SELECT_OTHER {
-                    strongSelf.navigationController.setNavigationBarHidden(false, animated: false)
-                    strongSelf.viewModel.prepareForNewSelection()
-                    strongSelf.executeNextStep()
-
-                } else {
-                    strongSelf.finish()
-                }
-
-            })
+            self.pushViewController(viewController : congratsViewController, animated: true)
         } else {
-            congratsViewController = InstructionsViewController(paymentResult: self.viewModel.paymentResult!, callback: { (_ :PaymentResult.CongratsState) in
-                self.finish()
-            }, paymentResultScreenPreference: self.viewModel.paymentResultScreenPreference)
+            finish()
         }
-        self.pushViewController(viewController : congratsViewController, animated: true)
     }
 
     func error() {

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -562,6 +562,19 @@ open class MercadoPagoCheckoutViewModel: NSObject {
         self.errorCallback = errorCallback
     }
 
+    func shouldDisplayPaymentResult() -> Bool {
+        if !MercadoPagoCheckoutViewModel.flowPreference.isPaymentResultScreenEnable() {
+            return false
+        } else if !MercadoPagoCheckoutViewModel.flowPreference.isPaymentApprovedScreenEnable() && self.paymentResult?.status == PaymentStatus.APPROVED.rawValue {
+            return false
+        } else if !MercadoPagoCheckoutViewModel.flowPreference.isPaymentPendingScreenEnable() && self.paymentResult?.status == PaymentStatus.IN_PROCESS.rawValue {
+            return false
+        } else if !MercadoPagoCheckoutViewModel.flowPreference.isPaymentRejectedScreenEnable() && self.paymentResult?.status == PaymentStatus.REJECTED.rawValue {
+            return false
+        }
+        return true
+    }
+
 }
 
 extension MercadoPagoCheckoutViewModel {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/ExampleUtils.h
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/ExampleUtils.h
@@ -10,8 +10,8 @@
 
 @interface ExampleUtils : NSObject
 
-#define TEST_PUBLIC_KEY @"TEST-85a140f5-10ce-4d3a-ba7a-a743e066840f" //Descuento por codigo "PRUEBA"
-#define TEST_PUBLIC_KEY_DISCOUNT @"TEST-ad365c37-8012-4014-84f5-6c895b3f8e0a"
+#define TEST_PUBLIC_KEY @"TEST-ad365c37-8012-4014-84f5-6c895b3f8e0a" //Descuento por codigo "PRUEBA"
+#define TEST_PUBLIC_KEY_DISCOUNT @"TEST-85a140f5-10ce-4d3a-ba7a-a743e066840f"
 #define MERCHANT_PUBLIC_KEY @"TEST-ad365c37-8012-4014-84f5-6c895b3f8e0a"
 //#define TEST_PUBLIC_KEY @"6c0d81bc-99c1-4de8-9976-c8d1d62cd4f2"
 #define MERCHANT_MOCK_BASE_URL @"https://www.mercadopago.com"


### PR DESCRIPTION
Fix #979 

##  Cambios introducidos : 
- Se añade la implentación de poder deshabilitar o habilitar la pantalla de resultados desde el flowPreference

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura
- [X] Correr Swiftlint

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
