### PR TITLE
Show navigation bar when exiting payment result

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -634,12 +634,12 @@ open class MercadoPagoCheckout: NSObject {
                     guard let strongSelf = self else {
                         return
                     }
+
+                    strongSelf.navigationController.setNavigationBarHidden(false, animated: false)
                     if state == PaymentResult.CongratsState.call_FOR_AUTH {
-                        strongSelf.navigationController.setNavigationBarHidden(false, animated: false)
                         strongSelf.viewModel.prepareForClone()
                         strongSelf.collectSecurityCodeForRetry()
                     } else if state == PaymentResult.CongratsState.cancel_RETRY || state == PaymentResult.CongratsState.cancel_SELECT_OTHER {
-                        strongSelf.navigationController.setNavigationBarHidden(false, animated: false)
                         strongSelf.viewModel.prepareForNewSelection()
                         strongSelf.executeNextStep()
 
@@ -649,8 +649,12 @@ open class MercadoPagoCheckout: NSObject {
 
                 })
             } else {
-                congratsViewController = InstructionsViewController(paymentResult: self.viewModel.paymentResult!, callback: { (_ :PaymentResult.CongratsState) in
-                    self.finish()
+                congratsViewController = InstructionsViewController(paymentResult: self.viewModel.paymentResult!, callback: { [weak self] (_ :PaymentResult.CongratsState) in
+                    guard let strongSelf = self else {
+                        return
+                    }
+                    strongSelf.navigationController.setNavigationBarHidden(false, animated: false)
+                    strongSelf.finish()
                 }, paymentResultScreenPreference: self.viewModel.paymentResultScreenPreference)
             }
             self.pushViewController(viewController : congratsViewController, animated: true)

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -77,10 +77,10 @@
     [self setPaymentDataCallback];
     
     //Setear PaymentCallback
-    //[self setPaymentCallback];
+    [self setPaymentCallback];
     
     //Setear Void Callback
-    //[self setVoidCallback];
+    [self setVoidCallback];
     
     
 
@@ -153,15 +153,14 @@
 -(void)setPaymentCallback {
     [MercadoPagoCheckout setPaymentCallbackWithPaymentCallback:^(Payment * payment) {
         NSLog(@"%@", payment._id);
-        [self setPaymentResult];
-        self.mpCheckout = [[MercadoPagoCheckout alloc] initWithPublicKey:TEST_PUBLIC_KEY checkoutPreference:self.pref paymentData:self.paymentData paymentResult:self.paymentResult discount:nil navigationController:self.navigationController];
-        [self.mpCheckout start];
+        [self.navigationController popToRootViewControllerAnimated:NO];
     }];
 }
 
 -(void)setVoidCallback {
     [MercadoPagoCheckout setCallbackWithCallback:^{
         NSLog(@"Se termino el flujo");
+        [self.navigationController popToRootViewControllerAnimated:NO];
     }];
 }
 


### PR DESCRIPTION
##  Cambios introducidos : 
- Muestra el navigation bar al salir de la pantalla de payment result

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura
- [X] Correr Swiftlint

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
