### PR TITLE
Prioritize customer cards server before groups

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentVaultViewModel.swift
@@ -43,8 +43,7 @@ class PaymentVaultViewModel: NSObject {
     }
 
     func shouldGetCustomerCardsInfo() -> Bool {
-        return MercadoPagoCheckoutViewModel.servicePreference.isCustomerInfoAvailable() && self.isRoot && (self.customerPaymentOptions == nil || self.customerPaymentOptions?.count == 0)
-
+        return MercadoPagoCheckoutViewModel.servicePreference.isCustomerInfoAvailable() && self.isRoot
     }
 
     func getCustomerPaymentMethodsToDisplayCount() -> Int {

--- a/MercadoPagoSDK/MercadoPagoSDK/ServicePreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ServicePreference.swift
@@ -27,7 +27,7 @@ open class ServicePreference: NSObject {
     open static var MP_TEST_ENV = "/beta"
     open static let MP_PROD_ENV = "/v1"
     open static var MP_SELECTED_ENV = MP_PROD_ENV
-    
+
     static var API_VERSION = "1.3.X"
 
     static var MP_ENVIROMENT = MP_SELECTED_ENV  + "/checkout"
@@ -158,7 +158,7 @@ open class ServicePreference: NSObject {
     }
 
     public func getPaymentAddionalInfo() -> NSDictionary? {
-        if !NSDictionary.isNullOrEmpty(paymentAdditionalInfo){
+        if !NSDictionary.isNullOrEmpty(paymentAdditionalInfo) {
             return paymentAdditionalInfo!
         }
         return nil
@@ -199,7 +199,7 @@ open class ServicePreference: NSObject {
     }
 
     public func isCustomerInfoAvailable() -> Bool {
-        return !String.isNullOrEmpty(self.customerURL) && !String.isNullOrEmpty(self.customerURI) && customerAdditionalInfo != nil
+        return !String.isNullOrEmpty(self.customerURL) && !String.isNullOrEmpty(self.customerURI)
     }
 
     static public func setupMPEnvironment() {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -119,8 +119,7 @@
 
         ReviewScreenPreference *reviewPreferenceUpdated = [[ReviewScreenPreference alloc] init];
         [reviewPreferenceUpdated setTitleWithTitle:@"Updated"];
-        //[ReviewScreenP
-        reference addCustomItemCellWithCustomCell:customCargaSube];
+        //[ReviewScreenPreference addCustomItemCellWithCustomCell:customCargaSube];
         //[ReviewScreenPreference addAddionalInfoCellWithCustomCell:customCargaSube];
         [self.mpCheckout setReviewScreenPreference:reviewPreferenceUpdated];
         //        UIViewController *vc = [[[MercadoPagoCheckout alloc] initWithCheckoutPreference:self.pref paymentData:paymentData navigationController:self.navigationController] getRootViewController];


### PR DESCRIPTION
Fix #1045 

##  Cambios introducidos : 
- Priorizar el servidor seteado en service preference para buscar cards del customer antes que las customer cards de grupos

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura
- [X] Correr Swiftlint

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
