### PR TITLE
Fix clean paymentData in ReviewScreen

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewModel.swift
@@ -278,6 +278,12 @@ open class CheckoutViewModel: NSObject {
         return isPaymentMethodSelectedCard() && self.paymentData.paymentMethod.paymentTypeId != "debit_card" && paymentData.payerCost != nil && paymentData.payerCost?.installments != 1
     }
 
+    func getClearPaymentData() -> PaymentData {
+        let newPaymentData: PaymentData = paymentData
+        newPaymentData.clearCollectedData()
+        return newPaymentData
+    }
+
     public enum Sections: Int {
         case title = 0
         case summary = 1

--- a/MercadoPagoSDK/MercadoPagoSDK/Payer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Payer.swift
@@ -22,7 +22,6 @@ open class Payer: NSObject {
 	}
 
     func clearCollectedData() {
-        self._id = nil
         self.entityType = nil
         self.identification = nil
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenViewController.swift
@@ -75,7 +75,7 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
         self.navBarTextColor = UIColor.primaryColor()
 
         self.displayBackButton()
-        if let callbackCancel = self.callbackCancel{
+        if let callbackCancel = self.callbackCancel {
             self.navigationItem.leftBarButtonItem!.action = #selector(ReviewScreenViewController.exitCheckoutFlow)
         }
         self.checkoutTable.dataSource = self
@@ -384,9 +384,7 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
     }
 
 	func changePaymentMethodSelected() {
-        let pm = PaymentData()
-        pm.discount = self.viewModel.paymentData.discount
-		self.callbackPaymentData(pm)
+        self.callbackPaymentData(self.viewModel.getClearPaymentData())
 	}
 
     internal func openTermsAndConditions(_ title: String, url: URL) {

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewModelTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewModelTest.swift
@@ -28,6 +28,7 @@ class CheckoutViewModelTest: BaseTest {
         paymentData.payerCost = MockBuilder.buildInstallment().payerCosts[1]
         paymentData.payerCost?.installments = 3
         paymentData.discount = MockBuilder.buildDiscount()
+        paymentData.payer = MockBuilder.buildPayer("id")
 
         self.instanceWithCoupon = CheckoutViewModel(checkoutPreference: CheckoutPreference(), paymentData: paymentData, paymentOptionSelected: mockPaymentMethodSearchItem as PaymentMethodOption)
 
@@ -107,7 +108,6 @@ class CheckoutViewModelTest: BaseTest {
     }
 
     func testNumberOfSections() {
-
         let preference = MockBuilder.buildCheckoutPreference()
         self.instance!.preference = preference
 
@@ -576,5 +576,18 @@ class CheckoutViewModelTest: BaseTest {
         XCTAssertEqual(self.instance!.numberOfRowsInSection(section: 2), 1)
         XCTAssertTrue(self.instance!.isItemCellFor(indexPath: IndexPath(row: 0, section: 2)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 2)), reviewScreenPreference.customItemCells[0].getHeight())
+    }
+
+    func testCleanPaymentData() {
+        XCTAssertEqual(self.instanceWithCoupon!.paymentData.paymentMethod._id, "visa")
+        XCTAssertEqual(self.instanceWithCoupon!.paymentData.payerCost!.installments, 3)
+        XCTAssertEqual(self.instanceWithCoupon!.paymentData.payer.email, "thisisanem@il.com")
+        XCTAssertEqual(self.instanceWithCoupon!.paymentData.discount!._id, "id")
+        let newPaymentData = self.instanceWithCoupon!.getClearPaymentData()
+
+        XCTAssertNil(newPaymentData.paymentMethod)
+        XCTAssertNil(newPaymentData.payerCost)
+        XCTAssertEqual(newPaymentData.payer.email, "thisisanem@il.com")
+        XCTAssertEqual(newPaymentData.discount!._id, "id")
     }
 }


### PR DESCRIPTION
Fix #1050 

##  Cambios introducidos : 
- Se limpia solo la data recolectada en el flujo al duplicar el paymentData en Revisa y confirma

##  Snippet de Código o Screenshot : 

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura
- [X] Correr Swiftlint

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
