### PR TITLE
[Fix] Limpiar token al volver para atrás en el flujo

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -213,7 +213,8 @@ open class MercadoPagoCheckoutViewModel: NSObject {
 
     //SEARCH_PAYMENT_METHODS
     public func updateCheckoutModel(paymentMethods: [PaymentMethod], cardToken: CardToken?) {
-		self.paymentMethods = paymentMethods
+        self.cleanToken()
+        self.paymentMethods = paymentMethods
         self.paymentData.paymentMethod = self.paymentMethods?[0] // Ver si son mas de uno
         self.cardToken = cardToken
     }
@@ -237,6 +238,7 @@ open class MercadoPagoCheckoutViewModel: NSObject {
     }
 
     public func updateCheckoutModel(identification: Identification) {
+        self.cleanToken()
         if paymentData.paymentMethod.isCard() {
             self.cardToken!.cardholder!.identification = identification
         } else {
@@ -623,6 +625,10 @@ extension MercadoPagoCheckoutViewModel {
         self.cleanPaymentResult()
         self.resetInformation()
         self.resetGroupSelection()
+    }
+
+    func cleanToken() {
+        self.paymentData.token = nil
     }
 
 }


### PR DESCRIPTION
Fix #1072 

##  Cambios introducidos : 
- Se limpia el token al salir de identification y de componente de tarjeta

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura
- [X] Correr Swiftlint

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
