### PR TITLE
MCO Interest Warning Modified

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/ApprovedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ApprovedTableViewCell.swift
@@ -110,9 +110,9 @@ class ApprovedTableViewCell: UITableViewCell {
         if !payerCost.hasInstallmentsRate() {
 
             if MercadoPagoCheckout.showBankInterestWarning() {
-                installmentRate.text = "(" + "No incluye intereses bancarios".localized + ")"
+                installmentRate.text = "No incluye intereses bancarios".localized
                 installmentRate.font = installmentRate.font.withSize(paymentId.font.pointSize)
-                installmentRate.textColor = UIColor.px_grayDark()
+                installmentRate.textColor = total.textColor
             } else {
                 if MercadoPagoCheckout.showPayerCostDescription() {
                     installmentRate.text = "Sin interés".localized

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
@@ -83,27 +83,26 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
             self.paymentDescription.attributedText = Utils.getAttributedAmount(amount, thousandSeparator: currency.thousandsSeparator, decimalSeparator: currency.decimalSeparator, currencySymbol: currency.symbol, color: UIColor.black, fontSize: 24, centsFontSize: 12, baselineOffset: 9)
             self.totalAmountLabel.text = ""
         }
-
-        if paymentData.payerCost != nil && !paymentData.payerCost!.hasInstallmentsRate() && paymentData.payerCost?.installments != 1 {
-
-            if MercadoPagoCheckout.showPayerCostDescription() {
-
-                if MercadoPagoCheckout.showBankInterestWarning() {
-                    self.noRateLabel.attributedText = NSAttributedString(string : "(" + "No incluye intereses bancarios".localized + ")")
-                    self.noRateLabel.textColor = UIColor.px_grayDark()
-                } else {
-                    self.noRateLabel.attributedText = NSAttributedString(string : "Sin interés".localized)
-                }
-            } else {
-
-                if MercadoPagoCheckout.showBankInterestWarning() {
-                    self.noRateLabel.attributedText = NSAttributedString(string : "(" + "No incluye intereses bancarios".localized + ")")
-                    self.noRateLabel.textColor = UIColor.px_grayDark()
-                } else {
-                    self.noRateLabel.attributedText = NSAttributedString(string : "")
-                }
-            }
+        
+        self.noRateLabel.attributedText = NSAttributedString(string : "")
+        
+        if showBankInterestWarning(paymentData: paymentData) {
+            self.noRateLabel.attributedText = NSAttributedString(string : "No incluye intereses bancarios".localized)
+            self.noRateLabel.textColor = self.totalAmountLabel.textColor
+            self.noRateLabel.font = Utils.getFont(size: self.totalAmountLabel.font.pointSize)
         }
+        
+        if showPayerCostDescription(paymentData: paymentData) {
+            self.noRateLabel.attributedText = NSAttributedString(string : "Sin interés".localized)
+        }
+    }
+    
+    func showBankInterestWarning(paymentData: PaymentData) -> Bool {
+        return paymentData.payerCost != nil && MercadoPagoCheckout.showBankInterestWarning()
+    }
+    
+    func showPayerCostDescription(paymentData: PaymentData) -> Bool {
+        return paymentData.payerCost != nil && !paymentData.payerCost!.hasInstallmentsRate() && paymentData.payerCost?.installments != 1 && !showBankInterestWarning(paymentData: paymentData)
     }
 
     func fillChangePaymentMethodButton(reviewScreenPreference: ReviewScreenPreference) {

--- a/MercadoPagoSDK/MercadoPagoSDK/PurchaseDetailTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PurchaseDetailTableViewCell.swift
@@ -46,16 +46,8 @@ open class PurchaseDetailTableViewCell: UITableViewCell {
                 PurchaseDetailTableViewCell.separatorLine!.removeFromSuperview()
             }
             if !payerCost!.hasInstallmentsRate() {
-
-                separatorLineHeight = MercadoPagoCheckout.showPayerCostDescription() || MercadoPagoCheckout.showBankInterestWarning() ? separatorLineHeight + 26 : separatorLineHeight
-
-                if MercadoPagoCheckout.showBankInterestWarning() {
-                    self.noRateLabel.attributedText = NSAttributedString(string : "(" + "No incluye intereses bancarios".localized + ")")
-                    self.noRateLabel.textColor = UIColor.px_grayDark()
-                    self.noRateLabel.font = Utils.getFont(size: 12)
-                } else {
-                    self.noRateLabel.attributedText = NSAttributedString(string : MercadoPagoCheckout.showPayerCostDescription() ? "Sin interés".localized : "")
-                }
+                separatorLineHeight = MercadoPagoCheckout.showPayerCostDescription() ? separatorLineHeight + 26 : separatorLineHeight
+                self.noRateLabel.attributedText = NSAttributedString(string : MercadoPagoCheckout.showPayerCostDescription() ? "Sin interés".localized : "")
             }
             let separatorLine = ViewUtils.getTableCellSeparatorLineView(21, y: separatorLineHeight, width: self.frame.width - 42, height: 1)
             self.addSubview(separatorLine)

--- a/PodTester/PodTester/MainTableViewController.swift
+++ b/PodTester/PodTester/MainTableViewController.swift
@@ -234,7 +234,6 @@ class MainTableViewController: UITableViewController {
             self.navigationController?.popToRootViewController(animated: true)
         }
 
-        MercadoPagoContext.setLanguage(language: ._SPANISH_MEXICO)
         checkout.start()
     }
 


### PR DESCRIPTION
Fix #{issueNumber}

##  Cambios introducidos : 
- Se actualiza la advertencia de intereses bancarios para el site de MCO de acuerdo a los requerimientos de UX.

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [x] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [x] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
