### PR TITLE
Floating Confirm Button

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewModel.swift
@@ -96,8 +96,6 @@ open class CheckoutViewModel: NSObject {
 
         numberOfRows += shouldShowTotal() ? 1 : 0
 
-        // Boton de confirmar
-        numberOfRows += 1
         return numberOfRows
 
     }
@@ -118,7 +116,7 @@ open class CheckoutViewModel: NSObject {
         } else if self.isPayerCostAdditionalInfoFor(indexPath: indexPath) || self.isUnlockCardCellFor(indexPath: indexPath) {
             return ConfirmAdditionalInfoTableViewCell.ROW_HEIGHT
 
-        } else if self.isConfirmButtonCellFor(indexPath: indexPath) || isSecondaryConfirmButton(indexPath: indexPath) {
+        } else if self.isConfirmButtonCellFor(indexPath: indexPath) {
             return ConfirmPaymentTableViewCell.ROW_HEIGHT
 
         } else if self.isItemCellFor(indexPath: indexPath) {
@@ -145,9 +143,6 @@ open class CheckoutViewModel: NSObject {
 
     func isTermsAndConditionsViewCellFor(indexPath: IndexPath) -> Bool {
         return indexPath.section == Sections.footer.rawValue && (indexPath.row == 0 && !isUserLogged())
-    }
-    func isSecondaryConfirmButton(indexPath: IndexPath) -> Bool {
-        return indexPath.section == Sections.footer.rawValue && ( (indexPath.row == 1 && !isUserLogged()) || (indexPath.row == 0 && isUserLogged()) )
     }
     func isExitButtonTableViewCellFor(indexPath: IndexPath) -> Bool {
         return indexPath.section == Sections.footer.rawValue && ( (indexPath.row == 2 && !isUserLogged()) || (indexPath.row == 1 && isUserLogged()) )
@@ -237,11 +232,7 @@ open class CheckoutViewModel: NSObject {
     }
 
     func isConfirmButtonCellFor(indexPath: IndexPath) -> Bool {
-        var numberOfRows = numberOfSummaryRows()
-        numberOfRows += shouldShowTotal() ? 1 : 0
-        numberOfRows += shouldShowInstallmentSummary() ? 1 : 0
-        numberOfRows += hasConfirmAdditionalInfo() ? 1 : 0
-        return indexPath.section == Sections.summary.rawValue && indexPath.row == numberOfRows
+        return indexPath.section == Sections.footer.rawValue && ( (indexPath.row == 1 && !isUserLogged()) || (indexPath.row == 0 && isUserLogged()) )
     }
 
     func hasConfirmAdditionalInfo() -> Bool {
@@ -282,6 +273,24 @@ open class CheckoutViewModel: NSObject {
         let newPaymentData: PaymentData = paymentData
         newPaymentData.clearCollectedData()
         return newPaymentData
+    }
+
+    func getFloatingConfirmButtonHeight() -> CGFloat {
+        return 80
+    }
+
+    func getFloatingConfirmButtonViewFrame() -> CGRect {
+        let height = self.getFloatingConfirmButtonHeight()
+        let width = UIScreen.main.bounds.width
+        let frame = CGRect(x: 0, y: UIScreen.main.bounds.maxY - height, width: width, height: height)
+        return frame
+    }
+
+    func getFloatingConfirmButtonCellFrame() -> CGRect {
+        let height = self.getFloatingConfirmButtonHeight()
+        let width = UIScreen.main.bounds.width
+        let frame = CGRect(x: 0, y: 0, width: width, height: height)
+        return frame
     }
 
     public enum Sections: Int {

--- a/MercadoPagoSDK/MercadoPagoSDK/ConfirmPaymentTableViewCell.xib
+++ b/MercadoPagoSDK/MercadoPagoSDK/ConfirmPaymentTableViewCell.xib
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,11 +15,11 @@
             <rect key="frame" x="0.0" y="0.0" width="392" height="110"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="392" height="109"/>
+                <rect key="frame" x="0.0" y="0.0" width="392" height="110"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GVA-BR-Chn">
-                        <rect key="frame" x="20" y="33" width="352" height="50"/>
+                        <rect key="frame" x="20" y="30" width="352" height="50"/>
                         <color key="backgroundColor" red="0.0" green="0.61960784313725492" blue="0.8901960784313725" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="50" id="Iq1-h6-nPD"/>
@@ -31,9 +31,12 @@
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="GVA-BR-Chn" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="25" id="0Xm-QO-24T"/>
+                    <constraint firstItem="GVA-BR-Chn" firstAttribute="top" relation="greaterThanOrEqual" secondItem="H2p-sc-9uM" secondAttribute="topMargin" priority="999" constant="12" id="0Xm-QO-24T"/>
                     <constraint firstItem="GVA-BR-Chn" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="12" id="4VY-cH-3nn"/>
+                    <constraint firstItem="GVA-BR-Chn" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="A6e-mj-6zD"/>
                     <constraint firstAttribute="trailingMargin" secondItem="GVA-BR-Chn" secondAttribute="trailing" constant="12" id="B6G-V3-nNk"/>
+                    <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="GVA-BR-Chn" secondAttribute="bottom" priority="999" constant="12" id="lqT-AO-w5c"/>
+                    <constraint firstItem="GVA-BR-Chn" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="m8x-Og-cBe"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>

--- a/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenViewController.swift
@@ -10,6 +10,10 @@ import UIKit
 
 open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITableViewDataSource, UITableViewDelegate, TermsAndConditionsDelegate, MPCustomRowDelegate, UnlockCardDelegate {
 
+    var floatingConfirmButtonView: UIView!
+    var fixedButton: UIButton?
+    var floatingButton: UIButton?
+
     static let kNavBarOffset = CGFloat(-64.0)
     static let kDefaultNavBarOffset = CGFloat(0.0)
     var preferenceId: String!
@@ -80,6 +84,7 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
 
         self.registerAllCells()
 
+        self.displayFloatingConfirmButton()
         self.displayStatusBar()
     }
 
@@ -153,13 +158,10 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
             return self.getPurchaseSimpleDetailCell(indexPath: indexPath, title : "Total".localized, amount : self.viewModel.getTotalAmount(), addSeparatorLine: false)
 
         } else if self.viewModel.isPayerCostAdditionalInfoFor(indexPath: indexPath) {
-            return self.getConfirmAddtionalInfo(indexPath: indexPath, payerCost: self.viewModel.paymentData.payerCost)
+            return self.getConfirmAdditionalInfo(indexPath: indexPath, payerCost: self.viewModel.paymentData.payerCost)
 
         } else if self.viewModel.isUnlockCardCellFor(indexPath: indexPath) {
             return self.getUnlockCardCell(indexPath: indexPath)
-
-        } else if self.viewModel.isConfirmButtonCellFor(indexPath: indexPath) {
-            return self.getConfirmPaymentButtonCell(indexPath: indexPath)
 
         } else if self.viewModel.isItemCellFor(indexPath: indexPath) {
             return viewModel.hasCustomItemCells() ? self.getCustomItemCell(indexPath: indexPath) : self.getPurchaseItemDetailCell(indexPath: indexPath)
@@ -176,8 +178,10 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
         } else if viewModel.isTermsAndConditionsViewCellFor(indexPath: indexPath) {
             return self.getTermsAndConditionsCell(indexPath: indexPath)
 
-        } else if viewModel.isSecondaryConfirmButton(indexPath: indexPath) {
-            return self.getConfirmPaymentButtonCell(indexPath: indexPath)
+        } else if viewModel.isConfirmButtonCellFor(indexPath: indexPath) {
+            let cell = self.getConfirmPaymentButtonCell(indexPath: indexPath) as! ConfirmPaymentTableViewCell
+            self.fixedButton = cell.confirmPaymentButton
+            return cell
 
         } else if viewModel.isExitButtonTableViewCellFor(indexPath: indexPath) {
             return self.getCancelPaymentButtonCell(indexPath: indexPath)
@@ -255,8 +259,8 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
         let purchaseUnlockCard = UINib(nibName: "UnlockCardTableViewCell", bundle: self.bundle)
         self.checkoutTable.register(purchaseUnlockCard, forCellReuseIdentifier: "unlockCardTableViewCell")
 
-        let confirmAddtionalInfoCFT = UINib(nibName: "ConfirmAdditionalInfoTableViewCell", bundle: self.bundle)
-        self.checkoutTable.register(confirmAddtionalInfoCFT, forCellReuseIdentifier: "confirmAddtionalInfoCFT")
+        let confirmAdditionalInfoCFT = UINib(nibName: "ConfirmAdditionalInfoTableViewCell", bundle: self.bundle)
+        self.checkoutTable.register(confirmAdditionalInfoCFT, forCellReuseIdentifier: "confirmAdditionalInfoCFT")
 
         self.checkoutTable.delegate = self
         self.checkoutTable.dataSource = self
@@ -323,8 +327,8 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
         return purchaseSimpleDetailTableViewCell
     }
 
-    private func getConfirmAddtionalInfo( indexPath: IndexPath, payerCost: PayerCost?) -> UITableViewCell {
-        let confirmAdditionalInfoCFT = self.checkoutTable.dequeueReusableCell(withIdentifier: "confirmAddtionalInfoCFT", for: indexPath) as! ConfirmAdditionalInfoTableViewCell
+    private func getConfirmAdditionalInfo( indexPath: IndexPath, payerCost: PayerCost?) -> UITableViewCell {
+        let confirmAdditionalInfoCFT = self.checkoutTable.dequeueReusableCell(withIdentifier: "confirmAdditionalInfoCFT", for: indexPath) as! ConfirmAdditionalInfoTableViewCell
         confirmAdditionalInfoCFT.fillCell(payerCost: payerCost)
         return confirmAdditionalInfoCFT
     }
@@ -332,7 +336,7 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
     private func getConfirmPaymentButtonCell(indexPath: IndexPath) -> UITableViewCell {
         let confirmPaymentTableViewCell = self.checkoutTable.dequeueReusableCell(withIdentifier: "confirmPaymentTableViewCell", for: indexPath) as! ConfirmPaymentTableViewCell
         confirmPaymentTableViewCell.confirmPaymentButton.addTarget(self, action: #selector(confirmPayment), for: .touchUpInside)
-		let confirmPaymentTitle = (indexPath.section == 1) ? viewModel.reviewScreenPreference.getConfirmButtonText() : "Confirmar".localized
+        let confirmPaymentTitle = viewModel.reviewScreenPreference.getConfirmButtonText()
         confirmPaymentTableViewCell.confirmPaymentButton.setTitle(confirmPaymentTitle, for: .normal)
         return confirmPaymentTableViewCell
     }
@@ -412,7 +416,54 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
         return ""
     }
 
+    open func isConfirmButtonVisible() -> Bool {
+        guard let floatingButton = self.floatingButton, let fixedButton = self.fixedButton else {
+            return false
+        }
+        let floatingButtonCoordinates = floatingButton.convert(CGPoint.zero, from: self.view.window)
+        let fixedButtonCoordinates = fixedButton.convert(CGPoint.zero, from: self.view.window)
+        return fixedButtonCoordinates.y > floatingButtonCoordinates.y
+    }
+
+    open func getFloatingButtonView() -> UIView {
+        let frame = self.viewModel.getFloatingConfirmButtonViewFrame()
+        let view = UIView(frame: frame)
+        view.layer.shadowOffset = CGSize(width: 0, height: 0)
+        view.layer.shadowColor = UIColor.black.cgColor
+        view.layer.shadowRadius = 4
+        view.layer.shadowOpacity = 0.25
+        view.layer.masksToBounds = false
+        view.clipsToBounds = false
+        return view
+    }
+
+    open func getFloatingButtonCell() -> UITableViewCell {
+        let indexPath = IndexPath(row: 0, section: 1)
+        let frame = self.viewModel.getFloatingConfirmButtonCellFrame()
+        let cell = self.getConfirmPaymentButtonCell(indexPath: indexPath) as! ConfirmPaymentTableViewCell
+        cell.frame = frame
+        self.floatingButton = cell.confirmPaymentButton
+        return cell
+    }
+
+    open func displayFloatingConfirmButton() {
+        self.floatingConfirmButtonView = self.getFloatingButtonView()
+        let cell = self.getFloatingButtonCell()
+        self.floatingConfirmButtonView.addSubview(cell)
+        self.view.addSubview(floatingConfirmButtonView)
+        self.view.bringSubview(toFront: floatingConfirmButtonView)
+    }
+
+    public func checkFloatingButtonVisibility() {
+        if isConfirmButtonVisible() {
+            self.floatingConfirmButtonView.isHidden = true
+        } else {
+            self.floatingConfirmButtonView.isHidden = false
+        }
+    }
+
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        self.checkFloatingButtonVisibility()
         self.didScrollInTable(scrollView)
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewModelTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewModelTest.swift
@@ -52,15 +52,10 @@ class CheckoutViewModelTest: BaseTest {
         XCTAssertTrue(self.instance!.isTermsAndConditionsViewCellFor(indexPath: IndexPath(row: 0, section: 5)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 5)), TermsAndConditionsViewCell.getCellHeight())
 
-        XCTAssertTrue(self.instance!.isSecondaryConfirmButton(indexPath: IndexPath(row: 1, section: 5)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 1, section: 5)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
-
         XCTAssertTrue(self.instance!.isExitButtonTableViewCellFor(indexPath: IndexPath(row: 2, section: 5)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 2, section: 5)), ExitButtonTableViewCell.ROW_HEIGHT)
 
         MercadoPagoContext.setPayerAccessToken("sarasa")
-        XCTAssertTrue(self.instance!.isSecondaryConfirmButton(indexPath: IndexPath(row: 0, section: 5)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 5)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         XCTAssertTrue(self.instance!.isExitButtonTableViewCellFor(indexPath: IndexPath(row: 1, section: 5)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 1, section: 5)), ExitButtonTableViewCell.ROW_HEIGHT)
@@ -132,7 +127,7 @@ class CheckoutViewModelTest: BaseTest {
         self.instance!.paymentData.paymentMethod = paymentMethodOff
 
         let result = self.instance!.numberOfRowsInMainSection()
-        XCTAssertEqual(2, result)
+        XCTAssertEqual(1, result)
     }
 
     func testIsPreferenceLoaded() {
@@ -195,12 +190,11 @@ class CheckoutViewModelTest: BaseTest {
         /// SUMARY:
         ///
         /// Productos --- $30
-        /// Confirmar
 
         self.instance!.paymentData = MockBuilder.buildPaymentData(paymentMethodId: "account_money", paymentMethodName: "account_money", paymentMethodTypeId: "account_money")
 
         // Number of Rows
-        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 2)
+        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 1)
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
@@ -208,9 +202,6 @@ class CheckoutViewModelTest: BaseTest {
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), OfflinePaymentMethodCell.ROW_HEIGHT)
-
-        XCTAssertTrue(self.instance!.isConfirmButtonCellFor(indexPath: IndexPath(row: 1, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 1, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         // Extra checks
         XCTAssertFalse(self.instance!.shouldShowInstallmentSummary())
@@ -226,12 +217,11 @@ class CheckoutViewModelTest: BaseTest {
         /// Productos --- $30
         /// Descuento --- -$10
         /// Total --- $20
-        /// Confirmar
 
         self.instanceWithCoupon!.paymentData.paymentMethod = PaymentMethod(_id: "account_money", name : "account_money", paymentTypeId : "account_money")
 
         // Number of Rows
-        XCTAssertEqual(self.instanceWithCoupon!.numberOfRowsInMainSection(), 4)
+        XCTAssertEqual(self.instanceWithCoupon!.numberOfRowsInMainSection(), 3)
 
         // Cells
         XCTAssertTrue(self.instanceWithCoupon!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
@@ -242,9 +232,6 @@ class CheckoutViewModelTest: BaseTest {
 
         XCTAssertTrue(self.instanceWithCoupon!.isTotalCellFor(indexPath: IndexPath(row: 2, section: 1)))
         XCTAssertEqual(self.instanceWithCoupon!.heightForRow(IndexPath(row: 2, section: 1)), PurchaseSimpleDetailTableViewCell.TOTAL_ROW_HEIGHT)
-
-        XCTAssertTrue(self.instanceWithCoupon!.isConfirmButtonCellFor(indexPath: IndexPath(row: 3, section: 1)))
-        XCTAssertEqual(self.instanceWithCoupon!.heightForRow(IndexPath(row: 3, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         XCTAssertTrue(self.instanceWithCoupon!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instanceWithCoupon!.heightForRow(IndexPath(row: 0, section: 3)), OfflinePaymentMethodCell.ROW_HEIGHT)
@@ -264,12 +251,11 @@ class CheckoutViewModelTest: BaseTest {
         /// Comision --- -$10
         /// Descuento --- -$10
         /// Total --- $20
-        /// Confirmar
 
         self.instanceWithCustomSummaryRow!.paymentData.paymentMethod = PaymentMethod(_id: "account_money", name : "account_money", paymentTypeId : "account_money")
 
         // Number of Rows
-        XCTAssertEqual(self.instanceWithCustomSummaryRow!.numberOfRowsInMainSection(), 5)
+        XCTAssertEqual(self.instanceWithCustomSummaryRow!.numberOfRowsInMainSection(), 4)
 
         // Cells
         XCTAssertTrue(self.instanceWithCustomSummaryRow!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
@@ -283,9 +269,6 @@ class CheckoutViewModelTest: BaseTest {
 
         XCTAssertTrue(self.instanceWithCustomSummaryRow!.isTotalCellFor(indexPath: IndexPath(row: 3, section: 1)))
         XCTAssertEqual(self.instanceWithCustomSummaryRow!.heightForRow(IndexPath(row: 3, section: 1)), PurchaseSimpleDetailTableViewCell.TOTAL_ROW_HEIGHT)
-
-        XCTAssertTrue(self.instanceWithCustomSummaryRow!.isConfirmButtonCellFor(indexPath: IndexPath(row: 4, section: 1)))
-        XCTAssertEqual(self.instanceWithCustomSummaryRow!.heightForRow(IndexPath(row: 4, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         XCTAssertTrue(self.instanceWithCustomSummaryRow!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instanceWithCustomSummaryRow!.heightForRow(IndexPath(row: 0, section: 3)), OfflinePaymentMethodCell.ROW_HEIGHT)
@@ -302,19 +285,15 @@ class CheckoutViewModelTest: BaseTest {
         /// SUMARY:
         ///
         /// Productos --- $30
-        /// Confirmar
 
         self.instance!.paymentData = MockBuilder.buildPaymentData(paymentMethodId: "oxxo", paymentMethodName: "Oxxo", paymentMethodTypeId: "ticket")
 
         // Number of Rows
-        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 2)
+        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 1)
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ROW_HEIGHT)
-
-        XCTAssertTrue(self.instance!.isConfirmButtonCellFor(indexPath: IndexPath(row: 1, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 1, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), OfflinePaymentMethodCell.ROW_HEIGHT)
@@ -331,13 +310,12 @@ class CheckoutViewModelTest: BaseTest {
         /// SUMARY:
         ///
         /// Productos --- $30
-        /// Confirmar
 
         self.instance!.paymentData = MockBuilder.buildPaymentData(paymentMethodId: "visa", paymentMethodName: "Visa", paymentMethodTypeId: "credit_card")
         self.instance!.paymentData.payerCost = MockBuilder.buildPayerCost()
 
         // Number of Rows
-        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 2)
+        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 1)
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
@@ -345,9 +323,6 @@ class CheckoutViewModelTest: BaseTest {
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), PaymentMethodSelectedTableViewCell.getCellHeight(payerCost : self.instance!.paymentData.payerCost, reviewScreenPreference: self.instance!.reviewScreenPreference))
-
-        XCTAssertTrue(self.instance!.isConfirmButtonCellFor(indexPath: IndexPath(row: 1, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 1, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         // Extra checks
         XCTAssertFalse(self.instance!.shouldShowInstallmentSummary())
@@ -362,13 +337,12 @@ class CheckoutViewModelTest: BaseTest {
         /// Productos --- $30
         /// Pagas --- 3X$10
         /// Total --- 30
-        /// Confirmar
 
         self.instance!.paymentData = MockBuilder.buildPaymentData(paymentMethodId: "visa", paymentMethodName: "Visa", paymentMethodTypeId: "credit_card")
         self.instance!.paymentData.payerCost = MockBuilder.buildPayerCost(installments: 3)
 
         // Number of Rows
-        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 4)
+        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 3)
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
@@ -379,9 +353,6 @@ class CheckoutViewModelTest: BaseTest {
 
         XCTAssertTrue(self.instance!.isTotalCellFor(indexPath: IndexPath(row: 2, section: 1)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 2, section: 1)), PurchaseSimpleDetailTableViewCell.TOTAL_ROW_HEIGHT)
-
-        XCTAssertTrue(self.instance!.isConfirmButtonCellFor(indexPath: IndexPath(row: 3, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 3, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), PaymentMethodSelectedTableViewCell.getCellHeight(payerCost : self.instance!.paymentData.payerCost, reviewScreenPreference: self.instance!.reviewScreenPreference))
@@ -396,19 +367,15 @@ class CheckoutViewModelTest: BaseTest {
         /// SUMARY:
         ///
         /// Productos --- $30
-        /// Confirmar
 
         self.instance!.paymentData = MockBuilder.buildPaymentData(paymentMethodId: "visa", paymentMethodName: "Visa", paymentMethodTypeId: "debit_card")
 
         // Number of Cells
-        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 2) // Productos + Confirm Button
+        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 1) // Productos
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ROW_HEIGHT)
-
-        XCTAssertTrue(self.instance!.isConfirmButtonCellFor(indexPath: IndexPath(row: 1, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 1, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), PaymentMethodSelectedTableViewCell.getCellHeight(payerCost : self.instance!.paymentData.payerCost, reviewScreenPreference: self.instance!.reviewScreenPreference))
@@ -427,14 +394,13 @@ class CheckoutViewModelTest: BaseTest {
         /// Descuento --- -$0
         /// Pagas --- 3X$10
         /// Total --- 30
-        /// Confirmar
 
         MercadoPagoCheckoutViewModel.flowPreference.enableDiscount()
         instanceWithCoupon!.summaryRows = []
         instanceWithCoupon!.setSummaryRows()
 
         // Number of cells
-        XCTAssertEqual(self.instanceWithCoupon!.numberOfRowsInMainSection(), 5)
+        XCTAssertEqual(self.instanceWithCoupon!.numberOfRowsInMainSection(), 4)
 
         // Cells
         XCTAssertTrue(self.instanceWithCoupon!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
@@ -448,9 +414,6 @@ class CheckoutViewModelTest: BaseTest {
 
         XCTAssertTrue(self.instanceWithCoupon!.isTotalCellFor(indexPath: IndexPath(row: 3, section: 1)))
         XCTAssertEqual(self.instanceWithCoupon!.heightForRow(IndexPath(row: 3, section: 1)), PurchaseSimpleDetailTableViewCell.TOTAL_ROW_HEIGHT)
-
-        XCTAssertTrue(self.instanceWithCoupon!.isConfirmButtonCellFor(indexPath: IndexPath(row: 4, section: 1)))
-        XCTAssertEqual(self.instanceWithCoupon!.heightForRow(IndexPath(row: 4, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         XCTAssertTrue(self.instanceWithCoupon!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instanceWithCoupon!.heightForRow(IndexPath(row: 0, section: 3)), PaymentMethodSelectedTableViewCell.getCellHeight(payerCost : self.instanceWithCoupon!.paymentData.payerCost, reviewScreenPreference: self.instanceWithCoupon!.reviewScreenPreference))
@@ -470,7 +433,6 @@ class CheckoutViewModelTest: BaseTest {
         /// Pagas --- 3X$10
         /// Total --- 30
         /// CFT Y TEA
-        /// Confirmar
 
         MercadoPagoCheckoutViewModel.flowPreference.enableDiscount()
         instanceWithCoupon!.summaryRows = []
@@ -479,7 +441,7 @@ class CheckoutViewModelTest: BaseTest {
         self.instanceWithCoupon!.paymentData.payerCost = MockBuilder.buildPayerCost(installments: 3, hasCFT: true)
 
         // Number of cells
-        XCTAssertEqual(self.instanceWithCoupon!.numberOfRowsInMainSection(), 6)
+        XCTAssertEqual(self.instanceWithCoupon!.numberOfRowsInMainSection(), 5)
 
         // Cells
         XCTAssertTrue(self.instanceWithCoupon!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
@@ -496,9 +458,6 @@ class CheckoutViewModelTest: BaseTest {
 
         XCTAssertTrue(self.instanceWithCoupon!.isPayerCostAdditionalInfoFor(indexPath: IndexPath(row: 4, section: 1)))
         XCTAssertEqual(self.instanceWithCoupon!.heightForRow(IndexPath(row: 4, section: 1)), ConfirmAdditionalInfoTableViewCell.ROW_HEIGHT)
-
-        XCTAssertTrue(self.instanceWithCoupon!.isConfirmButtonCellFor(indexPath: IndexPath(row: 5, section: 1)))
-        XCTAssertEqual(self.instanceWithCoupon!.heightForRow(IndexPath(row: 5, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         XCTAssertTrue(self.instanceWithCoupon!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instanceWithCoupon!.heightForRow(IndexPath(row: 0, section: 3)), PaymentMethodSelectedTableViewCell.getCellHeight(payerCost : self.instanceWithCoupon!.paymentData.payerCost, reviewScreenPreference: self.instanceWithCoupon!.reviewScreenPreference))
@@ -520,13 +479,12 @@ class CheckoutViewModelTest: BaseTest {
         /// Pagas --- 3X$10
         /// Total --- 30
         /// CFT Y TEA
-        /// Confirmar
 
         self.instance!.paymentData = MockBuilder.buildPaymentData(paymentMethodId: "visa", paymentMethodName: "Visa", paymentMethodTypeId: "credit_card")
         self.instance!.paymentData.payerCost = MockBuilder.buildPayerCost(installments: 3, hasCFT: true)
 
         // Number of cells
-        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 5)
+        XCTAssertEqual(self.instance!.numberOfRowsInMainSection(), 4)
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
@@ -540,9 +498,6 @@ class CheckoutViewModelTest: BaseTest {
 
         XCTAssertTrue(self.instance!.isPayerCostAdditionalInfoFor(indexPath: IndexPath(row: 3, section: 1)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 3, section: 1)), ConfirmAdditionalInfoTableViewCell.ROW_HEIGHT)
-
-        XCTAssertTrue(self.instance!.isConfirmButtonCellFor(indexPath: IndexPath(row: 4, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 4, section: 1)), ConfirmPaymentTableViewCell.ROW_HEIGHT)
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), PaymentMethodSelectedTableViewCell.getCellHeight(payerCost : self.instance!.paymentData.payerCost, reviewScreenPreference: self.instance!.reviewScreenPreference))


### PR DESCRIPTION

##  Cambios introducidos : 
- Se reemplazan los dos botones de confirmar el pago por uno solo "flotante" que acompaña al usuario a medida que se desplaza por la pantalla de revisa y confirma.

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [x] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [x] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
