### PR TITLE
Saved cards fix in new selection

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -655,6 +655,7 @@ extension MercadoPagoCheckoutViewModel {
         self.cleanPaymentResult()
         self.resetInformation()
         self.resetGroupSelection()
+        self.rootVC = true
     }
 
     func cleanToken() {


### PR DESCRIPTION

##  Cambios introducidos : 
- Se corrige un error que impedia que se mostraran las tarjeta guardadas del usuario al momento de seleccionar un nuevo medio de pago luego de pasar por una pantalla de error

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [x] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [x] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
