### PR TITLE
[Fix] Product cell height in RyC

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewModel.swift
@@ -105,7 +105,7 @@ open class CheckoutViewModel: NSObject {
             return 60
 
         } else if self.isProductlCellFor(indexPath: indexPath) {
-            return PurchaseSimpleDetailTableViewCell.PRODUCT_ROW_HEIGHT
+            return numberOfRowsInMainSection() == 1 ? PurchaseSimpleDetailTableViewCell.PRODUCT_ONLY_ROW_HEIGHT : PurchaseSimpleDetailTableViewCell.PRODUCT_ROW_HEIGHT
 
         } else if self.isInstallmentsCellFor(indexPath: indexPath) {
             return PurchaseDetailTableViewCell.getCellHeight(payerCost : self.paymentData.payerCost)

--- a/MercadoPagoSDK/MercadoPagoSDK/PurchaseSimpleDetailTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PurchaseSimpleDetailTableViewCell.swift
@@ -11,6 +11,7 @@ import UIKit
 class PurchaseSimpleDetailTableViewCell: UITableViewCell {
 
     static let PRODUCT_ROW_HEIGHT = CGFloat(30)
+    static let PRODUCT_ONLY_ROW_HEIGHT = CGFloat(70)
     static let TOTAL_ROW_HEIGHT = CGFloat(58)
 
     @IBOutlet weak var titleLabel: MPLabel!

--- a/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewModelTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/CheckoutViewModelTest.swift
@@ -198,7 +198,7 @@ class CheckoutViewModelTest: BaseTest {
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ROW_HEIGHT)
+        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ONLY_ROW_HEIGHT)
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), OfflinePaymentMethodCell.ROW_HEIGHT)
@@ -293,7 +293,7 @@ class CheckoutViewModelTest: BaseTest {
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ROW_HEIGHT)
+        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ONLY_ROW_HEIGHT)
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), OfflinePaymentMethodCell.ROW_HEIGHT)
@@ -319,7 +319,7 @@ class CheckoutViewModelTest: BaseTest {
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ROW_HEIGHT)
+        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ONLY_ROW_HEIGHT)
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), PaymentMethodSelectedTableViewCell.getCellHeight(payerCost : self.instance!.paymentData.payerCost, reviewScreenPreference: self.instance!.reviewScreenPreference))
@@ -375,7 +375,7 @@ class CheckoutViewModelTest: BaseTest {
 
         // Cells
         XCTAssertTrue(self.instance!.isProductlCellFor(indexPath: IndexPath(row: 0, section: 1)))
-        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ROW_HEIGHT)
+        XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 1)), PurchaseSimpleDetailTableViewCell.PRODUCT_ONLY_ROW_HEIGHT)
 
         XCTAssertTrue(self.instance!.isPaymentMethodCellFor(indexPath: IndexPath(row: 0, section: 3)))
         XCTAssertEqual(self.instance!.heightForRow(IndexPath(row: 0, section: 3)), PaymentMethodSelectedTableViewCell.getCellHeight(payerCost : self.instance!.paymentData.payerCost, reviewScreenPreference: self.instance!.reviewScreenPreference))


### PR DESCRIPTION

##  Cambios introducidos : 
- La celda de productos quedaba muy chica al sacar el boton de confirmar. Se arregla el tamaño

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [X] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura
- [X] Correr Swiftlint

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
