### PR TITLE
[Fix] No se borran las cuotas al volver para atrás de RyC

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
@@ -151,6 +151,11 @@ extension MercadoPagoCheckout {
                 }
         })
 
+        checkoutVC.callbackCancel = {
+            self.viewModel.payerCosts = nil
+            self.viewModel.paymentData.payerCost = nil
+        }
+
         self.pushViewController(viewController: checkoutVC, animated: true, completion: {
             self.cleanNavigationStack()
         })

--- a/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenViewController.swift
@@ -100,6 +100,8 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancel)
+
         self.showLoading()
 
         self.titleCellHeight = 44


### PR DESCRIPTION
Fix #1151 

##  Cambios introducidos : 
- Se fixea el bug de que no se limpian las cuotas al volver para atras en Revisa y confima

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura
- [X] Correr Swiftlint

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
