### PR TITLE
Remove Processing Mode from Payments Service

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CustomService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CustomService.swift
@@ -43,10 +43,8 @@ open class CustomService: MercadoPagoService {
     open func createPayment(_ method: String = "POST", body: String, success: @escaping (_ jsonResult: Payment) -> Void, failure: ((_ error: NSError) -> Void)?) {
 
         let headers = [MercadoPagoContext.paymentKey(): "X-Idempotency-Key"]
-        
-        let params = "processing_mode=" + MercadoPagoCheckoutViewModel.servicePreference.getProcessingModeString()
-        
-        self.request(uri: self.URI, params: params, body: body, method: method, headers : headers, cache: false, success: { (jsonResult: AnyObject?) -> Void in
+                
+        self.request(uri: self.URI, params: nil, body: body, method: method, headers : headers, cache: false, success: { (jsonResult: AnyObject?) -> Void in
             if let paymentDic = jsonResult as? NSDictionary {
                 if paymentDic["error"] != nil {
                     if paymentDic["status"] as? Int == ApiUtil.StatusCodes.PROCESSING.rawValue {

--- a/MercadoPagoSDK/MercadoPagoSDK/InstructionsViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/InstructionsViewController.swift
@@ -111,7 +111,8 @@ open class InstructionsViewController: MercadoPagoUIViewController, UITableViewD
         if section == 1 {
             return 1
         } else {
-            return 2
+            let numberOfCells = MercadoPagoCheckoutViewModel.servicePreference.shouldShowEmailConfirmationCell() ? 2 : 1
+            return numberOfCells
         }
     }
 
@@ -136,7 +137,7 @@ open class InstructionsViewController: MercadoPagoUIViewController, UITableViewD
             bodyCell.fillCell(instruction: self.instructionsInfo!.instructions[0], paymentResult: paymentResult)
             return bodyCell
         default:
-            if indexPath.row == 0 {
+            if indexPath.row == 0 && MercadoPagoCheckoutViewModel.servicePreference.shouldShowEmailConfirmationCell() {
                 let confirmEmailCell = self.tableView.dequeueReusableCell(withIdentifier: "emailNib") as! ConfirmEmailTableViewCell
                 confirmEmailCell.fillCell(instruction: instructionsInfo?.instructions[0])
                 confirmEmailCell.selectionStyle = .none

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultViewModel.swift
@@ -175,7 +175,7 @@ class PaymentResultViewModel: NSObject {
     func numberOfCellInBody() -> Int {
         if paymentResult.isApproved() {
             let approvedBodyAdd = !paymentResultScreenPreference.isApprovedPaymentBodyDisableCell() ? 1 : 0
-            let emailCellAdd = !String.isNullOrEmpty(paymentResult.payerEmail) ? 1 : 0
+            let emailCellAdd = !String.isNullOrEmpty(paymentResult.payerEmail) && MercadoPagoCheckoutViewModel.servicePreference.shouldShowEmailConfirmationCell() ? 1 : 0
             return approvedBodyAdd + emailCellAdd
 
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/ServicePreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ServicePreference.swift
@@ -276,6 +276,10 @@ open class ServicePreference: NSObject {
     internal func shouldShowBankDeals() -> Bool {
         return self.processingMode == ProcessingMode.aggregator
     }
+    
+    internal func shouldShowEmailConfirmationCell() -> Bool {
+        return self.processingMode == ProcessingMode.aggregator
+    }
 
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockedResponse.plist
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockedResponse.plist
@@ -3753,7 +3753,7 @@
   &quot;site_id&quot;: &quot;MLA&quot;,
   &quot;brand_name&quot;: &quot;asdasd&quot;
 }</string>
-	<key>POST/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;site_id=MLA&amp;api_version=API_VERSION</key>
+	<key>POST/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;site_id=MLA&amp;api_version=API_VERSION&amp;processing_mode=aggregator</key>
 	<string>{
   &quot;groups&quot;: [
     {
@@ -5815,7 +5815,7 @@
   &quot;site_id&quot;: &quot;MLA&quot;,
   &quot;brand_name&quot;: &quot;asdasd&quot;
 }</string>
-	<key>POST/beta/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_types=account_money&amp;site_id=MLA&amp;api_version=API_VERSION</key>
+	<key>POST/beta/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_types=account_money&amp;site_id=MLA&amp;api_version=API_VERSION&amp;processing_mode=aggregator</key>
 	<string>{
   &quot;groups&quot;: [
     {
@@ -6252,7 +6252,7 @@
     }
   ]
 }</string>
-	<key>POST/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_types=account_money&amp;site_id=MLA&amp;api_version=API_VERSION</key>
+	<key>POST/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_types=account_money&amp;site_id=MLA&amp;api_version=API_VERSION&amp;processing_mode=aggregator</key>
 	<string>{
   &quot;groups&quot;: [
     {

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockedResponse.plist
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockedResponse.plist
@@ -3330,7 +3330,7 @@
 	&quot;notification_url&quot;: null,
 	&quot;refunds&quot;: []
 }</string>
-	<key>POST/v1/checkout/payments?public_key=PK-PROCESSING-TEST&amp;payment_method_id=visa?processing_mode=aggregator</key>
+	<key>POST/v1/checkout/payments?public_key=PK-PROCESSING-TEST&amp;payment_method_id=visa</key>
 	<string>{
   &quot;message&quot;: &quot;&quot;,
   &quot;error&quot;: &quot;processing&quot;,
@@ -3753,7 +3753,7 @@
   &quot;site_id&quot;: &quot;MLA&quot;,
   &quot;brand_name&quot;: &quot;asdasd&quot;
 }</string>
-	<key>POST/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;site_id=MLA&amp;api_version=API_VERSION&amp;processing_mode=aggregator</key>
+	<key>POST/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;site_id=MLA&amp;api_version=API_VERSION</key>
 	<string>{
   &quot;groups&quot;: [
     {
@@ -5815,7 +5815,7 @@
   &quot;site_id&quot;: &quot;MLA&quot;,
   &quot;brand_name&quot;: &quot;asdasd&quot;
 }</string>
-	<key>POST/beta/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_types=account_money&amp;site_id=MLA&amp;api_version=API_VERSION&amp;processing_mode=aggregator</key>
+	<key>POST/beta/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_types=account_money&amp;site_id=MLA&amp;api_version=API_VERSION</key>
 	<string>{
   &quot;groups&quot;: [
     {
@@ -6252,7 +6252,7 @@
     }
   ]
 }</string>
-	<key>POST/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_types=account_money&amp;site_id=MLA&amp;api_version=API_VERSION&amp;processing_mode=aggregator</key>
+	<key>POST/v1/checkout/payment_methods/search/options?public_key=PK_MLA&amp;amount=2579.0&amp;excluded_payment_types=account_money&amp;site_id=MLA&amp;api_version=API_VERSION</key>
 	<string>{
   &quot;groups&quot;: [
     {

--- a/MercadoPagoSDK/MercadoPagoSDKTests/ServicePreferenceTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/ServicePreferenceTest.swift
@@ -76,24 +76,27 @@ class ServicePreferenceTest: BaseTest {
         XCTAssertTrue(servicePreference.isCheckoutPreferenceSet())
     }
     
-    public func testSetAggregatorAsProcessingModeAndEnableBankDeals() {
+    public func testSetAggregatorAsProcessingModeAndEnableBankDealsAndEnableEmailConfirmationCell() {
         let servicePreference = ServicePreference()
         servicePreference.setAggregatorAsProcessingMode()
         XCTAssertEqual(servicePreference.getProcessingModeString(), ProcessingMode.aggregator.rawValue)
         XCTAssertTrue(servicePreference.shouldShowBankDeals())
+        XCTAssertTrue(servicePreference.shouldShowEmailConfirmationCell())
     }
     
-    public func testSetGatewayAsProcessingModeAndDisableBankDeals() {
+    public func testSetGatewayAsProcessingModeAndDisableBankDealsAndDisableEmailConfirmationCell() {
         let servicePreference = ServicePreference()
         servicePreference.setGatewayAsProcessingMode()
         XCTAssertEqual(servicePreference.getProcessingModeString(), ProcessingMode.gateway.rawValue)
         XCTAssertFalse(servicePreference.shouldShowBankDeals())
+        XCTAssertFalse(servicePreference.shouldShowEmailConfirmationCell())
     }
     
-    public func testSetHybridAsProcessingModeAndDisableBankDeals() {
+    public func testSetHybridAsProcessingModeAndDisableBankDealsAndDisableEmailConfirmationCell() {
         let servicePreference = ServicePreference()
         servicePreference.setHybridAsProcessingMode()
         XCTAssertEqual(servicePreference.getProcessingModeString(), ProcessingMode.hybrid.rawValue)
         XCTAssertFalse(servicePreference.shouldShowBankDeals())
+        XCTAssertFalse(servicePreference.shouldShowEmailConfirmationCell())
     }
 }


### PR DESCRIPTION
##  Cambios introducidos : 
- Se elimina el processing mode del servicio de payments
- Si el checkout no esta en modo agregador, en las pantallas de resultados, se oculta la celda en la que se le comunica al usuario que se le enviara un mail.

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [x] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [x] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
