### PR TITLE
[Feature] Add public sets to PaymentResult and PaymentData

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -47,7 +47,19 @@ open class MercadoPagoCheckout: NSObject {
     public func start() {
         MercadoPagoCheckout.currentCheckout = self
         executeNextStep()
+    }
 
+    public func setPaymentResult(paymentResult: PaymentResult) {
+        self.viewModel.paymentResult = paymentResult
+    }
+
+    public func setPaymentData(paymentData: PaymentData) {
+        self.viewModel.paymentData = paymentData
+    }
+
+    public func resume() {
+        MercadoPagoCheckout.currentCheckout = self
+        executeNextStep()
     }
 
     func initialize() {

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -53,6 +53,10 @@ open class MercadoPagoCheckout: NSObject {
         self.viewModel.paymentResult = paymentResult
     }
 
+    public func setCheckoutPreference(checkoutPreference: CheckoutPreference) {
+        self.viewModel.checkoutPreference = checkoutPreference
+    }
+
     public func setPaymentData(paymentData: PaymentData) {
         self.viewModel.paymentData = paymentData
     }


### PR DESCRIPTION
Fix #1212 

##  Cambios introducidos : 
- Se agrega sets publicos de PaymentResult, checkoutPreference y de PaymentData
- Se agrega un MercadoPagoCheckout.resume() para continuar con el flujo

### Revisión
- [X] Todos los textos se encuentran localizables
- [X] No se introducen warnings al proyecto
- [X] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [X] No se agregan logs / prints innecesarios
- [X] No se agregan comentarios basura
- [X] Correr Swiftlint

### Testeo
- [X] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [X] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
