### PR TITLE
Catchup Tecnológico ( Fixes para iOS 11 )

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/AdditionalStepViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/AdditionalStepViewController.swift
@@ -53,7 +53,7 @@ open class AdditionalStepViewController: MercadoPagoUIScrollViewController, UITa
 
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.title = ""
+   //     self.title = ""
         self.navigationItem.leftBarButtonItem!.action = #selector(invokeCallbackCancel)
         self.extendedLayoutIncludesOpaqueBars = true
         self.titleCellHeight = 44

--- a/MercadoPagoSDK/MercadoPagoSDK/IdentificationViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/IdentificationViewController.swift
@@ -223,31 +223,34 @@ open class IdentificationViewController: MercadoPagoUIViewController, UITextFiel
 
     func setupInputAccessoryView() {
 
-        let frame =  CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44)
-        let toolbar = UIToolbar(frame: frame)
+        if self.toolbar == nil {
+            let frame =  CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44)
+            
+            let toolbar = UIToolbar(frame: frame)
+            
+            toolbar.barStyle = UIBarStyle.default
+            toolbar.backgroundColor = UIColor.mpLightGray()
+            toolbar.alpha = 1
+            toolbar.isUserInteractionEnabled = true
+            
+            let buttonNext = UIBarButtonItem(title: "Continuar".localized, style: .done, target: self, action: #selector(CardFormViewController.rightArrowKeyTapped))
+            let buttonPrev = UIBarButtonItem(title: "Anterior".localized, style: .plain, target: self, action: #selector(CardFormViewController.leftArrowKeyTapped))
+            
+            let font = Utils.getFont(size: 14)
+            buttonNext.setTitleTextAttributes([NSFontAttributeName: font], for: .normal)
+            buttonPrev.setTitleTextAttributes([NSFontAttributeName: font], for: .normal)
+            
+            buttonNext.setTitlePositionAdjustment(UIOffset(horizontal: UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
+            buttonPrev.setTitlePositionAdjustment(UIOffset(horizontal: -UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
+            
+            let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            
+            toolbar.items = [flexibleSpace, buttonPrev, flexibleSpace, buttonNext, flexibleSpace]
 
-        toolbar.barStyle = UIBarStyle.default
-        toolbar.backgroundColor = UIColor.mpLightGray()
-        toolbar.alpha = 1
-        toolbar.isUserInteractionEnabled = true
-
-        let buttonNext = UIBarButtonItem(title: "Continuar".localized, style: .done, target: self, action: #selector(CardFormViewController.rightArrowKeyTapped))
-        let buttonPrev = UIBarButtonItem(title: "Anterior".localized, style: .plain, target: self, action: #selector(CardFormViewController.leftArrowKeyTapped))
-
-        let font = Utils.getFont(size: 14)
-        buttonNext.setTitleTextAttributes([NSFontAttributeName: font], for: .normal)
-        buttonPrev.setTitleTextAttributes([NSFontAttributeName: font], for: .normal)
-
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-
-        toolbar.items = [flexibleSpace, buttonPrev, flexibleSpace, buttonNext, flexibleSpace]
-
-        buttonPrev.setTitlePositionAdjustment(UIOffset(horizontal: UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
-        buttonNext.setTitlePositionAdjustment(UIOffset(horizontal: -UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
-
-        numberTextField.delegate = self
-        self.toolbar = toolbar
-        numberTextField.inputAccessoryView = toolbar
+            numberTextField.delegate = self
+            self.toolbar = toolbar
+        }
+        numberTextField.inputAccessoryView = self.toolbar
 
     }
 

--- a/PodTester/Podfile.lock
+++ b/PodTester/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - MercadoPagoSDK (3.6.1):
-    - MercadoPagoSDK/Default (= 3.6.1)
-  - MercadoPagoSDK/Default (3.6.1)
+  - MercadoPagoSDK (3.6.2):
+    - MercadoPagoSDK/Default (= 3.6.2)
+  - MercadoPagoSDK/Default (3.6.2)
 
 DEPENDENCIES:
   - MercadoPagoSDK (from `../`)
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  MercadoPagoSDK: 25280857ff2a19055127cb800db43f1793ac0255
+  MercadoPagoSDK: 0011e5aab9c47c21dd629a62371742e68580d338
 
 PODFILE CHECKSUM: 7652d70c091fe815ac1f0c32abd1230fe0dccf1a
 

--- a/PodTester/Pods/Local Podspecs/MercadoPagoSDK.podspec.json
+++ b/PodTester/Pods/Local Podspecs/MercadoPagoSDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MercadoPagoSDK",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "summary": "MercadoPagoSDK",
   "homepage": "https://www.mercadopago.com",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/mercadopago/px-ios.git",
-    "tag": "3.6.1"
+    "tag": "3.6.2"
   },
   "platforms": {
     "ios": "8.0"

--- a/PodTester/Pods/Manifest.lock
+++ b/PodTester/Pods/Manifest.lock
@@ -1,7 +1,7 @@
 PODS:
-  - MercadoPagoSDK (3.6.1):
-    - MercadoPagoSDK/Default (= 3.6.1)
-  - MercadoPagoSDK/Default (3.6.1)
+  - MercadoPagoSDK (3.6.2):
+    - MercadoPagoSDK/Default (= 3.6.2)
+  - MercadoPagoSDK/Default (3.6.2)
 
 DEPENDENCIES:
   - MercadoPagoSDK (from `../`)
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  MercadoPagoSDK: 25280857ff2a19055127cb800db43f1793ac0255
+  MercadoPagoSDK: 0011e5aab9c47c21dd629a62371742e68580d338
 
 PODFILE CHECKSUM: 7652d70c091fe815ac1f0c32abd1230fe0dccf1a
 

--- a/PodTester/Pods/Target Support Files/MercadoPagoSDK/Info.plist
+++ b/PodTester/Pods/Target Support Files/MercadoPagoSDK/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.6.1</string>
+  <string>3.6.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
Fix #1237 #1238

##  Cambios introducidos : 
- Se fixea el accesory view del input en Identification View Controller en iOS 11
- Se fixea la desaparicion de titulo en Additional Step View Controller en iOS 11

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [ ] No se agregan comentarios basura
- [ ] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
