### PR TITLE
Capability to make hooks as optional in runtime

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Hooks/PXHookComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Hooks/PXHookComponent.swift
@@ -12,8 +12,8 @@ import Foundation
 public protocol PXHookComponent: PXComponetizable {
     func hookForStep() -> PXHookStep
     func render() -> UIView
+    func shouldSkipHook(hookStore: HookStore) -> Bool
     func renderDidFinish()
-    func didReceive(hookStore: HookStore)
     func titleForNavigationBar() -> String?
     func colorForNavigationBar() -> UIColor?
     func shouldShowBackArrow() -> Bool

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
@@ -292,14 +292,18 @@ extension MercadoPagoCheckout {
                 self.viewModel.wentBackFrom(hook: hookStep)
             }
 
-
             // Set a copy of CheckoutVM in HookStore
             if let viewModelCopy = self.viewModel.copy() as? MercadoPagoCheckoutViewModel {
                 HookStore.sharedInstance.paymentData = viewModelCopy.paymentData
                 HookStore.sharedInstance.paymentOptionSelected = viewModelCopy.paymentOptionSelected
             }
 
-            targetHook.didReceive(hookStore: HookStore.sharedInstance)
+            // Skip hook if need and send hookstore data.
+            if targetHook.shouldSkipHook(hookStore: HookStore.sharedInstance) {
+                self.viewModel.continueFrom(hook: hookStep)
+                self.executeNextStep()
+                return
+            }
 
             // Set custom attributes to Hook NavigationBar
             vc.title = targetHook.titleForNavigationBar()

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockedHookViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockedHookViewController.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+
 open class MockedHookViewController: UIViewController, PXHookComponent {
 
     var hookStep: PXHookStep?
@@ -32,9 +33,9 @@ open class MockedHookViewController: UIViewController, PXHookComponent {
     public func renderDidFinish() {
 
     }
-
-    public func didReceive(hookStore: HookStore) {
-
+    
+    public func shouldSkipHook(hookStore: HookStore) -> Bool {
+        return false
     }
 
     public func titleForNavigationBar() -> String? {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/FirstHookViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/FirstHookViewController.m
@@ -25,7 +25,7 @@ id <PaymentMethodOption> paymentOptionSelected;
     [self setupNextButton];
 }
 
-- (void) viewDidAppear:(BOOL)animated{
+- (void)viewDidAppear:(BOOL)animated{
     [self.codeTextField becomeFirstResponder];
 }
 
@@ -92,8 +92,11 @@ id <PaymentMethodOption> paymentOptionSelected;
     return PXHookStepAFTER_PAYMENT_TYPE_SELECTED;
 }
 
+- (BOOL)shouldSkipHookWithHookStore:(HookStore * _Nonnull)hookStore {
+    return NO;
+}
+
 - (void)renderDidFinish {
-    //self.paymentType.text = [paymentOptionSelected getDescription];
     self.messageLabel.text = nil;
     self.codeTextField.text = nil;
     [self.codeTextField becomeFirstResponder];

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/SecondHookViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/SecondHookViewController.m
@@ -33,12 +33,13 @@
     return self.view;
 }
 
-- (void)didReceiveWithHookStore:(HookStore * _Nonnull)hookStore {
-    self.paymentData = [hookStore getPaymentData];
-}
-
 - (enum PXHookStep)hookForStep {
     return PXHookStepAFTER_PAYMENT_METHOD_SELECTED;
+}
+
+- (BOOL)shouldSkipHookWithHookStore:(HookStore * _Nonnull)hookStore {
+    self.paymentData = [hookStore getPaymentData];
+    return NO;
 }
 
 - (void)renderDidFinish {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/ThirdHookViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/ThirdHookViewController.m
@@ -30,12 +30,12 @@
     return self.view;
 }
 
-- (void)didReceiveWithHookStore:(HookStore * _Nonnull)hookStore {
-
-}
-
 - (enum PXHookStep)hookForStep {
     return PXHookStepBEFORE_PAYMENT;
+}
+
+- (BOOL)shouldSkipHookWithHookStore:(HookStore * _Nonnull)hookStore {
+    return NO;
 }
 
 - (void)renderDidFinish {
@@ -57,5 +57,6 @@
 - (UIColor * _Nullable)colorForNavigationBar {
     return nil;
 }
+
 @end
 


### PR DESCRIPTION
- El integrador puede definir si mostrarlo o no, en funcion de la data que viene o lo que considere. Para eso se reemplazo en la interfase de Hook "didReceive" por "shouldSkipHook". Que retorna un BOOL y envia los parametros de HookStore.
- Se integro a los ejemplos de ObjcC
- Se integro a los Test