### PR TITLE
Custom Component Store

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -614,7 +614,6 @@
 		C5D27F461EEF289400768C1C /* PaymentVaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D27F441EEF155500768C1C /* PaymentVaultViewModel.swift */; };
 		CC8AA1501DC5612300503910 /* UILabel+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8AA14F1DC5612300503910 /* UILabel+Additions.swift */; };
 		CCDD005D1DC52E4200858CF8 /* PaymentMethodSearch.plist in Resources */ = {isa = PBXBuildFile; fileRef = CCDD005C1DC52E4100858CF8 /* PaymentMethodSearch.plist */; };
-		E33CF3839B1D3EB5F7968996 /* Pods_MercadoPagoSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBC6F9326B38C688FC679A4 /* Pods_MercadoPagoSDKTests.framework */; };
 		FC03FD791FCDE49F0006BBD6 /* PXBodyViewModelHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15661C5B1FCDCC47007FD7B7 /* PXBodyViewModelHelper.swift */; };
 		FC0F6CBC20179A01006E3EA1 /* PXContainedLabelComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC0F6CBB20179A01006E3EA1 /* PXContainedLabelComponent.swift */; };
 		FC0F6CBE20179A08006E3EA1 /* PXContainedLabelRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC0F6CBD20179A08006E3EA1 /* PXContainedLabelRenderer.swift */; };
@@ -1211,7 +1210,6 @@
 			files = (
 				4B0E72AA1FA8F9E8006A3853 /* MercadoPagoPXTracking.framework in Frameworks */,
 				4B0E72A81FA8F9E4006A3853 /* MercadoPagoServices.framework in Frameworks */,
-				E33CF3839B1D3EB5F7968996 /* Pods_MercadoPagoSDKTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MercadoPagoSDK/MercadoPagoSDK/Hooks/PXComponentizable.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Hooks/PXComponentizable.swift
@@ -11,3 +11,7 @@ import Foundation
 public protocol PXComponentizable {
     func render() -> UIView
 }
+
+public protocol PXCustomComponentizable {
+    func render(store: PXCheckoutStore) -> UIView?
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Hooks/PXComponentizable.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Hooks/PXComponentizable.swift
@@ -12,6 +12,7 @@ public protocol PXComponentizable {
     func render() -> UIView
 }
 
+@objc
 public protocol PXCustomComponentizable {
     func render(store: PXCheckoutStore) -> UIView?
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Hooks/PXHookComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Hooks/PXHookComponent.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 @objc
-public protocol PXHookComponent: PXComponentizable {
+public protocol PXHookComponent: PXCustomComponentizable {
     func hookForStep() -> PXHookStep
-    func render() -> UIView
+    func render(store: PXCheckoutStore) -> UIView?
     @objc optional func shouldSkipHook(hookStore: PXCheckoutStore) -> Bool
     @objc optional func didReceive(hookStore: PXCheckoutStore)
     @objc optional func navigationHandlerForHook(navigationHandler: PXHookNavigationHandler)

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout+Screens+Hooks.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout+Screens+Hooks.swift
@@ -42,10 +42,11 @@ extension MercadoPagoCheckout {
                 vc.shouldHideNavigationBar = !shouldShowNavigationBar
             }
 
-            let hookView = targetHook.render()
-            hookView.removeFromSuperview()
-            hookView.frame = vc.view.frame
-            vc.view.addSubview(hookView)
+            if let hookView = targetHook.render(store: PXCheckoutStore.sharedInstance) {
+                hookView.removeFromSuperview()
+                hookView.frame = vc.view.frame
+                vc.view.addSubview(hookView)
+            }
 
             targetHook.renderDidFinish?()
 

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout+Screens+Plugins.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout+Screens+Plugins.swift
@@ -53,11 +53,11 @@ extension MercadoPagoCheckout {
             containerVC.shouldHideNavigationBar = !shouldShowNavigationBar
         }
 
-        let paymentMethodConfigPluginComponentView = paymentMethodConfigPluginComponent.render()
-
-        paymentMethodConfigPluginComponentView.removeFromSuperview()
-        paymentMethodConfigPluginComponentView.frame = containerVC.view.frame
-        containerVC.view.addSubview(paymentMethodConfigPluginComponentView)
+        if let paymentMethodConfigPluginComponentView = paymentMethodConfigPluginComponent.render(store: PXCheckoutStore()) {
+            paymentMethodConfigPluginComponentView.removeFromSuperview()
+            paymentMethodConfigPluginComponentView.frame = containerVC.view.frame
+            containerVC.view.addSubview(paymentMethodConfigPluginComponentView)
+        }
 
         paymentMethodConfigPluginComponent.renderDidFinish?()
 
@@ -89,15 +89,15 @@ extension MercadoPagoCheckout {
             containerVC.shouldHideNavigationBar = !shouldShowNavigationBar
         }
 
-        let paymentPluginComponentView = paymentPluginComponent.render()
-        paymentPluginComponentView.removeFromSuperview()
-        paymentPluginComponentView.frame = containerVC.view.frame
-        containerVC.view.addSubview(paymentPluginComponentView)
+        if let paymentPluginComponentView = paymentPluginComponent.render(store: PXCheckoutStore.sharedInstance) {
+            paymentPluginComponentView.removeFromSuperview()
+            paymentPluginComponentView.frame = containerVC.view.frame
+            paymentPluginComponentView.backgroundColor = ThemeManager.shared.getTheme().highlightBackgroundColor()
+            containerVC.view.addSubview(paymentPluginComponentView)
+        }
 
         //TODO: Change in Q2 - Payment processor by block. Not a view.
         containerVC.view.backgroundColor = ThemeManager.shared.getTheme().highlightBackgroundColor()
-        paymentPluginComponentView.backgroundColor = ThemeManager.shared.getTheme().highlightBackgroundColor()
-        
         paymentPluginComponent.renderDidFinish?()
 
         self.navigationController.pushViewController(containerVC, animated: false)

--- a/MercadoPagoSDK/MercadoPagoSDK/PXCustomComponentContainer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXCustomComponentContainer.swift
@@ -8,16 +8,20 @@
 
 import UIKit
 
-class PXCustomComponentContainer: PXComponentizable {
-    let customComponent: PXComponentizable
+class PXCustomComponentContainer: PXCustomComponentizable {
+    let customComponent: PXCustomComponentizable
 
-    init(withComponent customComponent: PXComponentizable) {
+    init(withComponent customComponent: PXCustomComponentizable) {
         self.customComponent = customComponent
     }
-    func render() -> UIView {
+    func render(store: PXCheckoutStore) -> UIView? {
         let componentView = UIView()
         componentView.translatesAutoresizingMaskIntoConstraints = false
-        let customComponentView = customComponent.render()
+        
+        guard let customComponentView = customComponent.render(store: store) else {
+            return nil
+        }
+        
         customComponentView.translatesAutoresizingMaskIntoConstraints = false
         PXLayout.setHeight(owner: customComponentView, height: customComponentView.frame.height).isActive = true
         componentView.addSubview(customComponentView)

--- a/MercadoPagoSDK/MercadoPagoSDK/PXCustomComponentsHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXCustomComponentsHelper.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension PXResultViewModel {
-    open func buildTopCustomComponent() -> PXComponentizable? {
+    open func buildTopCustomComponent() -> PXCustomComponentizable? {
         if let customComponent = preference.getApprovedTopCustomComponent(), self.paymentResult.isApproved() {
             return PXCustomComponentContainer(withComponent: customComponent)
         } else {
@@ -17,7 +17,7 @@ extension PXResultViewModel {
         }
     }
 
-    open func buildBottomCustomComponent() -> PXComponentizable? {
+    open func buildBottomCustomComponent() -> PXCustomComponentizable? {
         if let customComponent = preference.getApprovedBottomCustomComponent(), self.paymentResult.isApproved() {
             return PXCustomComponentContainer(withComponent: customComponent)
         } else {

--- a/MercadoPagoSDK/MercadoPagoSDK/PXResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXResultViewController.swift
@@ -157,8 +157,8 @@ extension PXResultViewController {
     }
 
     func buildTopCustomView() -> UIView {
-        if let component = self.viewModel.buildTopCustomComponent() {
-            return component.render()
+        if let component = self.viewModel.buildTopCustomComponent(), let componentView = component.render(store: PXCheckoutStore.sharedInstance) {
+            return componentView
         }
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -166,8 +166,8 @@ extension PXResultViewController {
     }
 
     func buildBottomCustomView() -> UIView {
-        if let component = self.viewModel.buildBottomCustomComponent() {
-            return component.render()
+        if let component = self.viewModel.buildBottomCustomComponent(), let componentView = component.render(store: PXCheckoutStore.sharedInstance) {
+            return componentView
         }
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodPlugins/PXPluginComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodPlugins/PXPluginComponent.swift
@@ -17,8 +17,8 @@ import Foundation
     @objc optional func support(pluginStore: PXCheckoutStore) -> Bool
 }
 
-@objc public protocol PXPluginComponent: PXComponentizable {
-    func render() -> UIView
+@objc public protocol PXPluginComponent: PXCustomComponentizable {
+    func render(store: PXCheckoutStore) -> UIView?
     @objc optional func didReceive(pluginStore: PXCheckoutStore)
     @objc optional func renderDidFinish()
     @objc optional func viewWillAppear()

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultScreenPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultScreenPreference.swift
@@ -18,19 +18,19 @@ open class PaymentResultScreenPreference: NSObject {
         case check
     }
 
-    var topCustomComponent: PXComponentizable?
-    var bottomCustomComponent: PXComponentizable?
+    var topCustomComponent: PXCustomComponentizable?
+    var bottomCustomComponent: PXCustomComponentizable?
 
-    open func setApprovedTopCustomComponent(_ component: PXComponentizable) {
+    open func setApprovedTopCustomComponent(_ component: PXCustomComponentizable) {
         self.topCustomComponent = component
     }
-    open func setApprovedBottomCustomComponent(_ component: PXComponentizable) {
+    open func setApprovedBottomCustomComponent(_ component: PXCustomComponentizable) {
         self.bottomCustomComponent = component
     }
-    open func getApprovedTopCustomComponent() -> PXComponentizable? {
+    open func getApprovedTopCustomComponent() -> PXCustomComponentizable? {
         return self.topCustomComponent
     }
-    open func getApprovedBottomCustomComponent() -> PXComponentizable? {
+    open func getApprovedBottomCustomComponent() -> PXCustomComponentizable? {
         return self.bottomCustomComponent
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockComponent.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@objc public class TestComponent: NSObject, PXComponentizable {
+@objc public class TestComponent: NSObject, PXCustomComponentizable {
 
     static public func getPreference() -> PaymentResultScreenPreference {
         let top = TestComponent()
@@ -17,7 +17,7 @@ import Foundation
         return preference
     }
 
-    public func render() -> UIView {
+    public func render(store: PXCheckoutStore) -> UIView {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 500, height: 100))
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .red

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockConfigPaymentMethodPlugin.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockConfigPaymentMethodPlugin.swift
@@ -26,7 +26,7 @@ open class MockConfigPaymentMethodPlugin: UIViewController {
 // MARK: - Plugin implementation delegates.
 extension MockConfigPaymentMethodPlugin: PXConfigPluginComponent {
 
-    public func render() -> UIView {
+    public func render(store: PXCheckoutStore) -> UIView? {
         return self.view
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockPaymentPluginViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockPaymentPluginViewController.swift
@@ -23,7 +23,7 @@ open class MockPaymentPluginViewController: UIViewController {
 // MARK: - Plugin implementation delegates.
 extension MockPaymentPluginViewController: PXPaymentPluginComponent {
 
-    public func render() -> UIView {
+    public func render(store: PXCheckoutStore) -> UIView? {
         return self.view
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MockedHookViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MockedHookViewController.swift
@@ -32,7 +32,7 @@ extension MockedHookViewController: PXHookComponent {
         return hookStep!
     }
 
-    public func render() -> UIView {
+    public func render(store: PXCheckoutStore) -> UIView? {
         return self.view
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDKTests/ResultMockComponentHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/ResultMockComponentHelper.swift
@@ -75,12 +75,12 @@ public class ResultMockComponentHelper: NSObject {
 
     // Mark: Custom component builders
 
-    static func buildTopCustomComponent(resultViewModel: PXResultViewModel) -> PXComponentizable? {
+    static func buildTopCustomComponent(resultViewModel: PXResultViewModel) -> PXCustomComponentizable? {
         let topCustomComponent = resultViewModel.buildTopCustomComponent()
         return topCustomComponent
     }
 
-    static func buildBottomCustomComponent(resultViewModel: PXResultViewModel) -> PXComponentizable? {
+    static func buildBottomCustomComponent(resultViewModel: PXResultViewModel) -> PXCustomComponentizable? {
         let bottomCustomComponent = resultViewModel.buildBottomCustomComponent()
         return bottomCustomComponent
     }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/FirstHookViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/FirstHookViewController.m
@@ -80,7 +80,7 @@
 
 
 #pragma mark - PXHookComponent mandatory delegates.
-- (UIView * _Nonnull)render {
+- (UIView * _Nullable)renderWithStore:(PXCheckoutStore * _Nonnull)store {
     return self.view;
 }
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/SecondHookViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/SecondHookViewController.m
@@ -31,7 +31,7 @@
 
 
 #pragma mark - PXHookComponent mandatory delegates.
-- (UIView * _Nonnull)render {
+- (UIView * _Nullable)renderWithStore:(PXCheckoutStore * _Nonnull)store {
     return self.view;
 }
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/ThirdHookViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/Hooks/ThirdHookViewController.m
@@ -27,7 +27,7 @@
 
 
 #pragma mark - PXHookComponent mandatory delegates.
-- (UIView * _Nonnull)render {
+- (UIView * _Nullable)renderWithStore:(PXCheckoutStore * _Nonnull)store {
     return self.view;
 }
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/PaymentMethodPluginConfigViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/PaymentMethodPluginConfigViewController.m
@@ -55,7 +55,7 @@
 
 #pragma mark - Plugin implementation.
 
-- (UIView * _Nonnull)render {
+- (UIView * _Nullable)renderWithStore:(PXCheckoutStore * _Nonnull)store {
     return self.view;
 }
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/PaymentPluginViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/PaymentPluginViewController.m
@@ -21,7 +21,7 @@
 }
 
 #pragma mark - Plugin implementation.
-- (UIView * _Nonnull)render {
+- (UIView * _Nullable)renderWithStore:(PXCheckoutStore * _Nonnull)store {
     return self.view;
 }
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/TestComponent.swift
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/TestComponent.swift
@@ -9,7 +9,7 @@
 import UIKit
 import MercadoPagoSDK
 
-@objc public class TestComponent: NSObject, PXComponentizable {
+@objc public class TestComponent: NSObject, PXCustomComponentizable {
 
     static public func getPreference() -> PaymentResultScreenPreference {
         let top = TestComponent()
@@ -21,7 +21,7 @@ import MercadoPagoSDK
         return preference
     }
 
-    public func render() -> UIView {
+    public func render(store: PXCheckoutStore) -> UIView? {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 500, height: 100))
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .red


### PR DESCRIPTION

##  Cambios introducidos : 
- Se creo el protocolo PXCustomComponentizable al que se le pasa un PXCheckoutStore en la función render.
- Se adaptaron los componentes existentes para soportar PXCustomComponentizable.

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [ ] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [x] Testeado en BETA con dispositivo
- [x] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
