### PR TITLE
Set urlimage for Result Screen Preference

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -616,6 +616,7 @@
 		C5D27F461EEF289400768C1C /* PaymentVaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D27F441EEF155500768C1C /* PaymentVaultViewModel.swift */; };
 		CC8AA1501DC5612300503910 /* UILabel+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8AA14F1DC5612300503910 /* UILabel+Additions.swift */; };
 		CCDD005D1DC52E4200858CF8 /* PaymentMethodSearch.plist in Resources */ = {isa = PBXBuildFile; fileRef = CCDD005C1DC52E4100858CF8 /* PaymentMethodSearch.plist */; };
+		EFDEEE820ED6EBF8333EE5BE /* Pods_MercadoPagoSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBC6F9326B38C688FC679A4 /* Pods_MercadoPagoSDKTests.framework */; };
 		FC03FD791FCDE49F0006BBD6 /* PXBodyViewModelHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15661C5B1FCDCC47007FD7B7 /* PXBodyViewModelHelper.swift */; };
 		FC0F6CBC20179A01006E3EA1 /* PXContainedLabelComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC0F6CBB20179A01006E3EA1 /* PXContainedLabelComponent.swift */; };
 		FC0F6CBE20179A08006E3EA1 /* PXContainedLabelRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC0F6CBD20179A08006E3EA1 /* PXContainedLabelRenderer.swift */; };
@@ -1213,6 +1214,7 @@
 			files = (
 				4B0E72AA1FA8F9E8006A3853 /* MercadoPagoPXTracking.framework in Frameworks */,
 				4B0E72A81FA8F9E4006A3853 /* MercadoPagoServices.framework in Frameworks */,
+				EFDEEE820ED6EBF8333EE5BE /* Pods_MercadoPagoSDKTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentResultScreenPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentResultScreenPreference.swift
@@ -55,6 +55,7 @@ open class PaymentResultScreenPreference: NSObject {
     var approvedSubtitle = ""
     private var _approvedLabelText = ""
     private var _disableApprovedLabelText = true
+    var approvedURLImage : String? = nil
     var approvedIconName = "default_item_icon"
     var approvedIconBundle = MercadoPago.getBundle()!
 
@@ -67,6 +68,7 @@ open class PaymentResultScreenPreference: NSObject {
     private var _disablePendingLabelText = true
     var pendingIconName = "default_item_icon"
     var pendingIconBundle = MercadoPago.getBundle()!
+    var pendingURLImage : String? = nil
     var hidePendingContentText = false
     var hidePendingContentTitle = false
 
@@ -80,6 +82,7 @@ open class PaymentResultScreenPreference: NSObject {
     var rejectedPaymentMethodPluginIconName = "MPSDK_payment_result_plugin_error"
     var rejectedIconBundle = MercadoPago.getBundle()!
     var rejectedDefaultIconName: String?
+    var rejectedURLImage : String? = nil
     var rejectedIconName: String?
     var rejectedContentTitle = PaymentResultScreenPreference.REJECTED_CONTENT_TITLE.localized
     var rejectedContentText = ""
@@ -166,6 +169,10 @@ open class PaymentResultScreenPreference: NSObject {
         self.approvedIconBundle = bundle
     }
 
+    open func setApprovedHeaderIcon(stringURL : String) {
+        self.approvedURLImage = stringURL
+    }
+
     // MARK: Sets de Pending
 
     open func disablePendingLabelText() {
@@ -195,6 +202,10 @@ open class PaymentResultScreenPreference: NSObject {
     open func setPendingHeaderIcon(name: String, bundle: Bundle) {
         self.pendingIconName = name
         self.pendingIconBundle = bundle
+    }
+
+    open func setPendingHeaderIcon(stringURL : String) {
+        self.pendingURLImage = stringURL
     }
 
     open func setPendingContentText(text: String) {
@@ -239,6 +250,11 @@ open class PaymentResultScreenPreference: NSObject {
         self.rejectedIconBundle = bundle
     }
 
+    open func setRejectedHeaderIcon(stringURL : String) {
+        self.rejectedURLImage = stringURL
+    }
+
+    
     open func setRejectedContentText(text: String) {
         self.rejectedContentText = text
     }
@@ -372,6 +388,11 @@ open class PaymentResultScreenPreference: NSObject {
     }
 
     open func getHeaderApprovedIcon() -> UIImage? {
+        if let urlImage = approvedURLImage {
+            if let image =  ViewUtils.loadImageFromUrl(urlImage) {
+                return image
+            }
+        }
         return MercadoPago.getImage(approvedIconName, bundle: approvedIconBundle)
     }
 
@@ -386,6 +407,11 @@ open class PaymentResultScreenPreference: NSObject {
     }
 
     open func getHeaderPendingIcon() -> UIImage? {
+        if let urlImage = self.pendingURLImage {
+            if let image =  ViewUtils.loadImageFromUrl(urlImage) {
+                return image
+            }
+        }
         return MercadoPago.getImage(pendingIconName, bundle: pendingIconBundle)
     }
 
@@ -433,6 +459,11 @@ open class PaymentResultScreenPreference: NSObject {
     }
 
     open func getHeaderRejectedIcon(_ paymentMethod: PaymentMethod?) -> UIImage? {
+        if let urlImage = self.rejectedURLImage {
+            if let image =  ViewUtils.loadImageFromUrl(urlImage) {
+                return image
+            }
+        }
         if rejectedIconName != nil {
             return MercadoPago.getImage(rejectedIconName, bundle: rejectedIconBundle)
         }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -98,7 +98,7 @@
     
     [self setPaymentMethodPlugins];
 
-    [self setPaymentPlugin];
+//    [self setPaymentPlugin];
 
     // Setear PaymentResultScreenPreference
     [self setPaymentResultScreenPreference];

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/TestComponent.swift
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/TestComponent.swift
@@ -16,6 +16,8 @@ import MercadoPagoSDK
         let bottom = TestComponent()
         let preference = PaymentResultScreenPreference()
         preference.disableApprovedReceipt()
+        preference.setApprovedHeaderIcon(stringURL: "https://i.pinimg.com/736x/16/6a/54/166a54b720bf9763dbce64e4cb52fa17--phoenix-band-nail-fashion.jpg")
+        preference.setPendingHeaderIcon(stringURL: "https://i.pinimg.com/736x/16/6a/54/166a54b720bf9763dbce64e4cb52fa17--phoenix-band-nail-fashion.jpg")
        // preference.setApprovedTopCustomComponent(top)
         //        preference.setApprovedBottomCustomComponent(bottom)
         return preference


### PR DESCRIPTION
Se agrega un nuevo setter de imagen para el icono del header de la pantalla de resultado, para setearla mediante una url (string)