### PR TITLE
[Fix] Remove issuer congrats

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PXBodyComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXBodyComponent.swift
@@ -75,7 +75,8 @@ open class PXBodyComponent: NSObject, PXComponentizable {
             disclaimerText =  ("En tu estado de cuenta verás el cargo como %0".localized as NSString).replacingOccurrences(of: "%0", with: "\(statementDescription)")
         }
 
-        let bodyProps = PXPaymentMethodProps(paymentMethodIcon: image, amountTitle: amountTitle, amountDetail: amountDetail, paymentMethodDescription: pmDescription, paymentMethodDetail: issuerName, disclaimer: disclaimerText)
+        // Issuer name is nil temporally
+        let bodyProps = PXPaymentMethodProps(paymentMethodIcon: image, amountTitle: amountTitle, amountDetail: amountDetail, paymentMethodDescription: pmDescription, paymentMethodDetail: nil, disclaimer: disclaimerText)
 
         return PXPaymentMethodComponent(props: bodyProps)
     }


### PR DESCRIPTION
##  Cambios introducidos : 
- Se saca el issuerName temporalment en la congrats

### Antes:
![screen shot 2018-02-15 at 12 28 55 pm](https://user-images.githubusercontent.com/9399970/36265277-a5ec1136-124d-11e8-8ce8-9389b794e086.png)

### Ahora:

![screen shot 2018-02-15 at 12 27 08 pm](https://user-images.githubusercontent.com/9399970/36265237-914bdf22-124d-11e8-93d7-88bfc1921d43.png)

