### PR TITLE
Fix - Congrats Cobranded

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer.swift
@@ -66,6 +66,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
             descriptionLabel.text = paymentMethodDescription
             descriptionLabel.font = Utils.getFont(size: DETAIL_FONT_SIZE)
             descriptionLabel.textColor = .pxBrownishGray
+            descriptionLabel.numberOfLines = 2
             descriptionLabel.textAlignment = .center
             pmBodyView.putOnBottomOfLastView(view: descriptionLabel, withMargin: PXLayout.XS_MARGIN)?.isActive = true
             PXLayout.pinLeft(view: descriptionLabel, withMargin: PXLayout.XS_MARGIN).isActive = true

--- a/MercadoPagoSDK/MercadoPagoSDKTests/PXBodyComponentTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/PXBodyComponentTest.swift
@@ -25,7 +25,7 @@ class PXBodyComponentTest: BaseTest {
         XCTAssertEqual(paymentMethodView.amountTitle?.text, "$ 1.000")
         XCTAssertEqual(paymentMethodView.amountDetail?.text, nil)
         XCTAssertEqual(paymentMethodView.paymentMethodDescription?.text?.localized, "visa " + "terminada en ".localized + "1234")
-        XCTAssertEqual(paymentMethodView.paymentMethodDetail?.text, "name")
+        XCTAssertNil(paymentMethodView.paymentMethodDetail)
         XCTAssertEqual(paymentMethodView.disclaimerLabel?.text?.localized, "En tu estado de cuenta verás el cargo como %0".localized.replacingOccurrences(of: "%0", with: "description"))
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDKTests/PXBodyComponentTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/PXBodyComponentTest.swift
@@ -25,7 +25,7 @@ class PXBodyComponentTest: BaseTest {
         XCTAssertEqual(paymentMethodView.amountTitle?.text, "$ 1.000")
         XCTAssertEqual(paymentMethodView.amountDetail?.text, nil)
         XCTAssertEqual(paymentMethodView.paymentMethodDescription?.text?.localized, "visa " + "terminada en ".localized + "1234")
-        XCTAssertNil(paymentMethodView.paymentMethodDetail)
+        XCTAssertEqual(paymentMethodView.paymentMethodDetail?.text, "name")
         XCTAssertEqual(paymentMethodView.disclaimerLabel?.text?.localized, "En tu estado de cuenta verás el cargo como %0".localized.replacingOccurrences(of: "%0", with: "description"))
     }
 


### PR DESCRIPTION
##  Cambios introducidos : 
- Se resuelve el bug que corta el texto de la descripción de la tarjeta de crédito en la pantalla de congrats.
- Se arreglan los test del paymentMethodDetail.

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [ ] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [x] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
