### PR TITLE
UI Final Polish Templating RyC with Themes.

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/CheckoutViewModel.swift
@@ -267,8 +267,8 @@ open class CheckoutViewModel: NSObject {
                 let discountSummaryDetail = SummaryDetail(title: self.reviewScreenPreference.summaryTitles[SummaryType.DISCOUNT]!, detail: discountAmountDetail)
                 summary.addSummaryDetail(summaryDetail:discountSummaryDetail, type: SummaryType.DISCOUNT)
             }
-            summary.details[SummaryType.DISCOUNT]?.titleColor = ThemeManager.shared.getTheme().highlightedLabelTintColor()
-            summary.details[SummaryType.DISCOUNT]?.amountColor = ThemeManager.shared.getTheme().highlightedLabelTintColor()
+            summary.details[SummaryType.DISCOUNT]?.titleColor = ThemeManager.shared.getTheme().noTaxAndDiscountLabelTintColor()
+            summary.details[SummaryType.DISCOUNT]?.amountColor = ThemeManager.shared.getTheme().noTaxAndDiscountLabelTintColor()
         }
         if let payerCost = self.paymentData.payerCost {
             let interest = payerCost.totalAmount - amount

--- a/MercadoPagoSDK/MercadoPagoSDK/ConfirmAdditionalInfoTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ConfirmAdditionalInfoTableViewCell.swift
@@ -14,7 +14,7 @@ class ConfirmAdditionalInfoTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         self.selectionStyle = .none
-        self.contentView.backgroundColor = ThemeManager.shared.getTheme().detailedBackgroundColor()
+        self.contentView.backgroundColor = .white
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/MercadoPagoSDK/MercadoPagoSDK/DiscountBodyCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/DiscountBodyCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class DiscountBodyCell: UIView {
 
-    let DISCOUNT_COLOR = ThemeManager.shared.getTheme().highlightedLabelTintColor()
+    let DISCOUNT_COLOR = ThemeManager.shared.getTheme().noTaxAndDiscountLabelTintColor()
     let LABEL_COLOR = ThemeManager.shared.getTheme().boldLabelTintColor()
     let ACCENT_LINK = ThemeManager.shared.getTheme().secondaryButton().tintColor
     let PRIMARY_BUTTON_TEXT_COLOR = ThemeManager.shared.getTheme().primaryButton().tintColor

--- a/MercadoPagoSDK/MercadoPagoSDK/DiscountDetailView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/DiscountDetailView.swift
@@ -21,7 +21,7 @@ class DiscountDetailView: UIView {
     let fontSize: CGFloat = 18.0
     let baselineOffSet: Int = 6
     let fontColor = ThemeManager.shared.getTheme().modalComponent().tintColor
-    let discountFontColor = ThemeManager.shared.getTheme().highlightedLabelTintColor()
+    let discountFontColor = ThemeManager.shared.getTheme().noTaxAndDiscountLabelTintColor()
 
     var coupon: DiscountCoupon!
     var amount: Double!

--- a/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/OfflinePaymentMethodCell.swift
@@ -46,7 +46,7 @@ class OfflinePaymentMethodCell: UITableViewCell {
         self.accreditationTimeIcon.tintColor = ThemeManager.shared.getTheme().labelTintColor()
         self.accreditationTimeIcon.image = image
         self.iconCash.image = MercadoPago.getOfflineReviewAndConfirmImage()
-        self.contentView.backgroundColor = ThemeManager.shared.getTheme().detailedBackgroundColor()
+        self.contentView.backgroundColor = .white
     }
 
     override func prepareForReuse() {

--- a/MercadoPagoSDK/MercadoPagoSDK/PXBodyComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXBodyComponent.swift
@@ -76,7 +76,7 @@ open class PXBodyComponent: NSObject, PXComponentizable {
         }
 
         // Issuer name is nil temporally
-        let bodyProps = PXPaymentMethodProps(paymentMethodIcon: image, title: amountTitle.toAttributedString(), subtitle: amountDetail?.toAttributedString(), descriptionTitle: pmDescription.toAttributedString(), descriptionDetail: nil, disclaimer: disclaimerText?.toAttributedString())
+        let bodyProps = PXPaymentMethodProps(paymentMethodIcon: image, title: amountTitle.toAttributedString(), subtitle: amountDetail?.toAttributedString(), descriptionTitle: pmDescription.toAttributedString(), descriptionDetail: nil, disclaimer: disclaimerText?.toAttributedString(), backgroundColor: ThemeManager.shared.getTheme().detailedBackgroundColor(), lightLabelColor: ThemeManager.shared.getTheme().labelTintColor(), boldLabelColor: ThemeManager.shared.getTheme().boldLabelTintColor())
 
         return PXPaymentMethodComponent(props: bodyProps)
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXCFTComponentView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXCFTComponentView.swift
@@ -26,7 +26,7 @@ final class PXCFTComponentView: PXComponentView {
             cftLabel.translatesAutoresizingMaskIntoConstraints = false
             cftLabel.textAlignment = .center
             cftLabel.numberOfLines = 1
-            cftLabel.attributedText = NSAttributedString(string: "CFT \(cftValue)", attributes: [NSFontAttributeName: Utils.getFont(size: PXLayout.M_FONT)])
+            cftLabel.attributedText = NSAttributedString(string: "CFT \(cftValue)", attributes: [NSFontAttributeName: Utils.getFont(size: PXLayout.S_FONT)])
             cftLabel.textColor = titleColor
             
             self.addSubview(cftLabel)

--- a/MercadoPagoSDK/MercadoPagoSDK/PXContainedActionButtonComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXContainedActionButtonComponent.swift
@@ -29,7 +29,7 @@ open class PXContainedActionButtonProps : NSObject {
     init(title: String, action:  @escaping (() -> Void)) {
         self.title = title
         self.action = action
-        self.backgroundColor = ThemeManager.shared.getTheme().detailedBackgroundColor()
+        self.backgroundColor = .white
         self.buttonColor = ThemeManager.shared.getTheme().primaryButton().backgroundColor
         self.textColor = ThemeManager.shared.getTheme().primaryButton().tintColor
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXContainedLabelRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXContainedLabelRenderer.swift
@@ -13,7 +13,7 @@ class PXContainedLabelRenderer: NSObject {
     func render(_ containedLabel: PXContainedLabelComponent) -> PXContainedLabelView {
         let containedLabelView = PXContainedLabelView()
         containedLabelView.translatesAutoresizingMaskIntoConstraints = false
-        containedLabelView.backgroundColor = ThemeManager.shared.getTheme().detailedBackgroundColor()
+        containedLabelView.backgroundColor = .white
         
         //Label
         containedLabelView.mainLabel = buildLabel(with: containedLabel.props.labelText)

--- a/MercadoPagoSDK/MercadoPagoSDK/PXDefaultTheme.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXDefaultTheme.swift
@@ -24,25 +24,25 @@ class PXDefaultTheme: NSObject {
 extension PXDefaultTheme: PXTheme {
 
     public func navigationBar() -> PXThemeProperty {
-        var themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 0, green: 0.5411764706, blue: 0.8392156863, alpha: 1), tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))
+        var themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 0, green: 0.5411764706, blue: 0.8392156863, alpha: 1), tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), selectedColor: .clear)
         if let customColor = primaryColor {
-           themeProperty = PXThemeProperty(backgroundColor: customColor, tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))
+           themeProperty = PXThemeProperty(backgroundColor: customColor, tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), selectedColor: .clear)
         }
         return themeProperty
     }
 
     public func primaryButton() -> PXThemeProperty {
-        var themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 0, green: 0.5411764706, blue: 0.8392156863, alpha: 1), tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))
+        var themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 0, green: 0.5411764706, blue: 0.8392156863, alpha: 1), tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), selectedColor: .clear)
         if let customColor = primaryColor {
-            themeProperty = PXThemeProperty(backgroundColor: customColor, tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))
+            themeProperty = PXThemeProperty(backgroundColor: customColor, tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), selectedColor: .clear)
         }
         return themeProperty
     }
 
     public func secondaryButton() -> PXThemeProperty {
-        var themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor:#colorLiteral(red: 0, green: 0.5411764706, blue: 0.8392156863, alpha: 1))
+        var themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor:#colorLiteral(red: 0, green: 0.5411764706, blue: 0.8392156863, alpha: 1), selectedColor: .clear)
         if let customColor = primaryColor {
-            themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor: customColor)
+            themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor: customColor, selectedColor: .clear)
         }
         return themeProperty
     }
@@ -59,7 +59,7 @@ extension PXDefaultTheme: PXTheme {
         return #colorLiteral(red: 0.2, green: 0.2, blue: 0.2, alpha: 1)
     }
     
-    public func highlightedLabelTintColor() -> UIColor {
+    public func noTaxAndDiscountLabelTintColor() -> UIColor {
         return #colorLiteral(red: 0.2235294118, green: 0.7098039216, blue: 0.2901960784, alpha: 1)
     }
 
@@ -76,15 +76,15 @@ extension PXDefaultTheme: PXTheme {
     }
 
     public func loadingComponent() -> PXThemeProperty {
-        var themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor: #colorLiteral(red: 0, green: 0.5411764706, blue: 0.8392156863, alpha: 1))
+        var themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor: #colorLiteral(red: 0, green: 0.5411764706, blue: 0.8392156863, alpha: 1), selectedColor: .clear)
         if let customColor = primaryColor {
-            themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor: customColor)
+            themeProperty = PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor: customColor, selectedColor: .clear)
         }
         return themeProperty
     }
 
     public func modalComponent() -> PXThemeProperty {
-        return PXThemeProperty(backgroundColor: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.95), tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))
+        return PXThemeProperty(backgroundColor: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.95), tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), selectedColor: .clear)
     }
 
     public func highlightBackgroundColor() -> UIColor {

--- a/MercadoPagoSDK/MercadoPagoSDK/PXItemComponentProps.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXItemComponentProps.swift
@@ -15,13 +15,19 @@ final class PXItemComponentProps : NSObject {
     var quantity: Int?
     var unitAmount: Double?
     var reviewScreenPreference: ReviewScreenPreference
+    let backgroundColor: UIColor
+    let boldLabelColor: UIColor
+    let lightLabelColor: UIColor
 
-    init(imageURL: String?, title: String?, description: String?, quantity: Int?, unitAmount: Double?, reviewScreenPreference: ReviewScreenPreference = ReviewScreenPreference()) {
+    init(imageURL: String?, title: String?, description: String?, quantity: Int?, unitAmount: Double?, reviewScreenPreference: ReviewScreenPreference = ReviewScreenPreference(), backgroundColor: UIColor, boldLabelColor: UIColor, lightLabelColor: UIColor) {
         self.imageURL = imageURL
         self.title = title
         self._description = description
         self.quantity = quantity
         self.unitAmount = unitAmount
         self.reviewScreenPreference = reviewScreenPreference
+        self.backgroundColor = backgroundColor
+        self.boldLabelColor = boldLabelColor
+        self.lightLabelColor = lightLabelColor
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXItemRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXItemRenderer.swift
@@ -22,7 +22,7 @@ struct PXItemRenderer {
 
     func render(_ itemComponent: PXItemComponent) -> PXItemContainerView {
         let itemView = PXItemContainerView()
-        itemView.backgroundColor = UIColor.px_grayBackgroundColor()
+        itemView.backgroundColor = itemComponent.props.backgroundColor
         itemView.translatesAutoresizingMaskIntoConstraints = false
 
         itemView.itemImage = buildItemImage(imageURL: itemComponent.props.imageURL, collectorImage: itemComponent.props.reviewScreenPreference.getCollectorIcon())
@@ -38,7 +38,7 @@ struct PXItemRenderer {
 
         // Item Title
         if itemComponent.shouldShowTitle() {
-            itemView.itemTitle = buildTitle(with: itemComponent.getTitle())
+            itemView.itemTitle = buildTitle(with: itemComponent.getTitle(), labelColor: itemComponent.props.boldLabelColor)
         }
         if let itemTitle = itemView.itemTitle {
             itemView.addSubviewToButtom(itemTitle, withMargin: PXLayout.S_MARGIN)
@@ -48,7 +48,7 @@ struct PXItemRenderer {
 
         // Item description
         if itemComponent.shouldShowDescription() {
-            itemView.itemDescription = buildDescription(with: itemComponent.getDescription())
+            itemView.itemDescription = buildDescription(with: itemComponent.getDescription(), labelColor: itemComponent.props.lightLabelColor)
         }
         if let itemDescription = itemView.itemDescription {
             itemView.addSubviewToButtom(itemDescription, withMargin: PXLayout.XS_MARGIN)
@@ -58,7 +58,7 @@ struct PXItemRenderer {
 
         // Item quantity
         if itemComponent.shouldShowQuantity() {
-            itemView.itemQuantity = buildQuantity(with: itemComponent.getQuantity())
+            itemView.itemQuantity = buildQuantity(with: itemComponent.getQuantity(), labelColor: itemComponent.props.lightLabelColor)
         }
         if let itemQuantity = itemView.itemQuantity {
             itemView.addSubviewToButtom(itemQuantity, withMargin: PXLayout.XS_MARGIN)
@@ -68,7 +68,7 @@ struct PXItemRenderer {
 
         // Item amount
         if itemComponent.shouldShowUnitAmount() {
-            itemView.itemAmount = buildItemAmount(with: itemComponent.getUnitAmountPrice(), title: itemComponent.getUnitAmountTitle())
+            itemView.itemAmount = buildItemAmount(with: itemComponent.getUnitAmountPrice(), title: itemComponent.getUnitAmountTitle(), labelColor: itemComponent.props.lightLabelColor)
         }
         if let itemAmount = itemView.itemAmount {
             let margin = itemView.itemQuantity == nil ? PXLayout.XS_MARGIN : PXLayout.XXXS_MARGIN
@@ -112,49 +112,45 @@ extension PXItemRenderer {
         return imageView
     }
 
-    fileprivate func buildTitle(with text: String?) -> UILabel? {
+    fileprivate func buildTitle(with text: String?, labelColor: UIColor) -> UILabel? {
         guard let text = text else {
             return nil
         }
 
         let font = Utils.getFont(size: PXItemRenderer.TITLE_FONT_SIZE)
-        let color = ThemeManager.shared.getTheme().boldLabelTintColor()
-        return buildLabel(text: text, color: color, font: font)
+        return buildLabel(text: text, color: labelColor, font: font)
     }
 
-    fileprivate func buildDescription(with text: String?) -> UILabel? {
+    fileprivate func buildDescription(with text: String?, labelColor: UIColor) -> UILabel? {
         guard let text = text else {
             return nil
         }
 
         let font = Utils.getFont(size: PXItemRenderer.DESCRIPTION_FONT_SIZE)
-        let color = ThemeManager.shared.getTheme().labelTintColor()
-        return buildLabel(text: text, color: color, font: font)
+        return buildLabel(text: text, color: labelColor, font: font)
     }
 
-    func buildQuantity(with text: String?) -> UILabel? {
+    func buildQuantity(with text: String?, labelColor: UIColor) -> UILabel? {
         guard let text = text else {
             return nil
         }
 
         let font = Utils.getFont(size: PXItemRenderer.QUANTITY_FONT_SIZE)
-        let color = ThemeManager.shared.getTheme().labelTintColor()
-        return buildLabel(text: text, color: color, font: font)
+        return buildLabel(text: text, color: labelColor, font: font)
     }
 
-    fileprivate func buildItemAmount(with amount: Double?, title: String?) -> UILabel? {
+    fileprivate func buildItemAmount(with amount: Double?, title: String?, labelColor: UIColor) -> UILabel? {
         guard let title = title, let amount = amount else {
             return nil
         }
 
         let font = Utils.getFont(size: PXItemRenderer.AMOUNT_FONT_SIZE)
-        let color = ThemeManager.shared.getTheme().labelTintColor()
 
-        let unitPrice = buildAttributedUnitAmount(amount: amount, color: color, fontSize: font.pointSize)
+        let unitPrice = buildAttributedUnitAmount(amount: amount, color: labelColor, fontSize: font.pointSize)
         let unitPriceTitle = NSMutableAttributedString(string: title, attributes: [NSFontAttributeName: font])
         unitPriceTitle.append(unitPrice)
 
-        return buildLabel(attributedText: unitPriceTitle, color: color, font: font)
+        return buildLabel(attributedText: unitPriceTitle, color: labelColor, font: font)
     }
 
     fileprivate func buildAttributedUnitAmount(amount: Double, color: UIColor, fontSize: CGFloat) -> NSAttributedString {

--- a/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponent.swift
@@ -36,9 +36,11 @@ class PXPaymentMethodProps: NSObject {
     let descriptionDetail: NSAttributedString?
     let disclaimer: NSAttributedString?
     let action: PXComponentAction?
-    let backgroundColor: UIColor?
+    let backgroundColor: UIColor
+    let lightLabelColor: UIColor
+    let boldLabelColor: UIColor
 
-    public init(paymentMethodIcon: UIImage?, title: NSAttributedString, subtitle: NSAttributedString?, descriptionTitle: NSAttributedString?, descriptionDetail: NSAttributedString?, disclaimer: NSAttributedString?, action: PXComponentAction? = nil, backgroundColor: UIColor? = nil) {
+    public init(paymentMethodIcon: UIImage?, title: NSAttributedString, subtitle: NSAttributedString?, descriptionTitle: NSAttributedString?, descriptionDetail: NSAttributedString?, disclaimer: NSAttributedString?, action: PXComponentAction? = nil, backgroundColor: UIColor, lightLabelColor: UIColor, boldLabelColor: UIColor) {
         self.paymentMethodIcon = paymentMethodIcon
         self.title = title
         self.subtitle = subtitle
@@ -47,5 +49,7 @@ class PXPaymentMethodProps: NSObject {
         self.disclaimer = disclaimer
         self.action = action
         self.backgroundColor = backgroundColor
+        self.lightLabelColor = lightLabelColor
+        self.boldLabelColor = boldLabelColor
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer.swift
@@ -23,6 +23,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
 
     func render(component: PXPaymentMethodComponent) -> PXPaymentMethodView {
         let pmBodyView = PXPaymentMethodView()
+        pmBodyView.backgroundColor = component.props.backgroundColor
         pmBodyView.translatesAutoresizingMaskIntoConstraints = false
         let paymentMethodIcon = component.getPaymentMethodIconComponent()
         pmBodyView.paymentMethodIcon = paymentMethodIcon.render()
@@ -40,7 +41,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
         pmBodyView.addSubview(title)
         title.attributedText = component.props.title
         title.font = Utils.getFont(size: TITLE_FONT_SIZE)
-        title.textColor = .pxBlack
+        title.textColor = component.props.boldLabelColor
         title.textAlignment = .center
         title.numberOfLines = 0
         pmBodyView.putOnBottomOfLastView(view: title, withMargin: PXLayout.S_MARGIN)?.isActive = true
@@ -54,7 +55,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
             pmBodyView.amountDetail = detailLabel
             detailLabel.attributedText = detailText
             detailLabel.font = Utils.getFont(size: SUBTITLE_FONT_SIZE)
-            detailLabel.textColor = .pxBrownishGray
+            detailLabel.textColor = component.props.lightLabelColor
             detailLabel.textAlignment = .center
             PXLayout.setHeight(owner: detailLabel, height: 18.0).isActive = true
             pmBodyView.putOnBottomOfLastView(view: detailLabel, withMargin: PXLayout.XXS_MARGIN)?.isActive = true
@@ -69,7 +70,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
             pmBodyView.paymentMethodDescription = descriptionLabel
             descriptionLabel.attributedText = paymentMethodDescription
             descriptionLabel.font = Utils.getFont(size: SUBTITLE_FONT_SIZE)
-            descriptionLabel.textColor = .pxBrownishGray
+            descriptionLabel.textColor = component.props.lightLabelColor
             descriptionLabel.textAlignment = .center
             descriptionLabel.numberOfLines = 2
             pmBodyView.putOnBottomOfLastView(view: descriptionLabel, withMargin: PXLayout.XS_MARGIN)?.isActive = true
@@ -84,7 +85,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
             pmBodyView.addSubview(pmDetailLabel)
             pmDetailLabel.attributedText = pmDetailText
             pmDetailLabel.font = Utils.getFont(size: DESCRIPTION_DETAIL_FONT_SIZE)
-            pmDetailLabel.textColor = .pxBrownishGray
+            pmDetailLabel.textColor = component.props.lightLabelColor
             pmDetailLabel.textAlignment = .center
             pmBodyView.putOnBottomOfLastView(view: pmDetailLabel, withMargin: PXLayout.XXS_MARGIN)?.isActive = true
             PXLayout.pinLeft(view: pmDetailLabel, withMargin:  PXLayout.XXS_MARGIN).isActive = true
@@ -99,7 +100,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
             disclaimerLabel.attributedText = disclaimer
             disclaimerLabel.numberOfLines = 2
             disclaimerLabel.font = Utils.getFont(size: DISCLAIMER_FONT_SIZE)
-            disclaimerLabel.textColor = .pxBrownishGray
+            disclaimerLabel.textColor = component.props.lightLabelColor
             disclaimerLabel.textAlignment = .center
             pmBodyView.putOnBottomOfLastView(view: disclaimerLabel, withMargin: PXLayout.M_MARGIN)?.isActive = true
             PXLayout.pinLeft(view: disclaimerLabel, withMargin:  PXLayout.XS_MARGIN).isActive = true
@@ -113,20 +114,13 @@ class PXPaymentMethodComponentRenderer: NSObject {
             actionButton.add(for: .touchUpInside, action.action)
             pmBodyView.actionButton = actionButton
             pmBodyView.addSubview(actionButton)
+            actionButton.backgroundColor = .clear
             
             pmBodyView.putOnBottomOfLastView(view: actionButton, withMargin: PXLayout.S_MARGIN)?.isActive = true
             
             PXLayout.pinLeft(view: actionButton, withMargin:  PXLayout.XXS_MARGIN).isActive = true
             PXLayout.pinRight(view: actionButton, withMargin:  PXLayout.XXS_MARGIN).isActive = true
             PXLayout.setHeight(owner: actionButton, height: BUTTON_HEIGHT).isActive = true
-            
-        }
-        
-        if let backgroundColor = component.props.backgroundColor {
-            pmBodyView.backgroundColor = backgroundColor
-            if let actionButton = pmBodyView.actionButton {
-                actionButton.backgroundColor = backgroundColor
-            }
         }
         
         pmBodyView.pinLastSubviewToBottom(withMargin: PXLayout.L_MARGIN)?.isActive = true
@@ -142,5 +136,5 @@ class PXPaymentMethodView: PXBodyView {
     var paymentMethodDescription: UILabel?
     var paymentMethodDetail: UILabel?
     var disclaimerLabel: UILabel?
-    var actionButton: UIButton?
+    var actionButton: PXSecondaryButton?
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
@@ -47,6 +47,10 @@ class PXReviewViewController: PXComponentContainerViewController {
         self.view.layoutIfNeeded()
     }
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
     func update(viewModel: PXReviewViewModel) {
         self.viewModel = viewModel
     }
@@ -56,6 +60,10 @@ class PXReviewViewController: PXComponentContainerViewController {
 extension PXReviewViewController {
     
     fileprivate func setupUI() {
+        navBarTextColor = ThemeManager.shared.getTitleColorForReviewConfirmNavigation()
+        loadMPStyles()
+        navigationController?.navigationBar.barTintColor = ThemeManager.shared.getTheme().highlightBackgroundColor()
+        navigationItem.leftBarButtonItem?.tintColor = ThemeManager.shared.getTitleColorForReviewConfirmNavigation()
         if contentView.getSubviews().isEmpty {
             renderViews()
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
@@ -47,10 +47,6 @@ class PXReviewViewController: PXComponentContainerViewController {
         self.view.layoutIfNeeded()
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-    
     func update(viewModel: PXReviewViewModel) {
         self.viewModel = viewModel
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewModel.swift
@@ -147,8 +147,8 @@ extension PXReviewViewModel {
                 let discountSummaryDetail = SummaryDetail(title: self.reviewScreenPreference.summaryTitles[SummaryType.DISCOUNT]!, detail: discountAmountDetail)
                 summary.addSummaryDetail(summaryDetail:discountSummaryDetail, type: SummaryType.DISCOUNT)
             }
-            summary.details[SummaryType.DISCOUNT]?.titleColor = ThemeManager.shared.getTheme().highlightedLabelTintColor()
-            summary.details[SummaryType.DISCOUNT]?.amountColor = ThemeManager.shared.getTheme().highlightedLabelTintColor()
+            summary.details[SummaryType.DISCOUNT]?.titleColor = ThemeManager.shared.getTheme().noTaxAndDiscountLabelTintColor()
+            summary.details[SummaryType.DISCOUNT]?.amountColor = ThemeManager.shared.getTheme().noTaxAndDiscountLabelTintColor()
         }
         if let payerCost = self.paymentData.payerCost {
             let interest = payerCost.totalAmount - amount
@@ -199,7 +199,9 @@ extension PXReviewViewModel {
         var subtitle: NSAttributedString? = nil
         var accreditationTime: NSAttributedString? = nil
         var action = withAction
-        let backgroundColor = UIColor.px_grayBackgroundColor()
+        let backgroundColor = ThemeManager.shared.getTheme().detailedBackgroundColor()
+        let lightLabelColor = ThemeManager.shared.getTheme().lightLabelTintColor()
+        let boldLabelColor = ThemeManager.shared.getTheme().boldLabelTintColor()
         
         if pm.isCard {
             if let lastFourDigits = (paymentData.token?.lastFourDigits) {
@@ -221,7 +223,7 @@ extension PXReviewViewModel {
             action = nil
         }
         
-        let props = PXPaymentMethodProps(paymentMethodIcon: image, title: title, subtitle: subtitle, descriptionTitle: nil, descriptionDetail: accreditationTime, disclaimer: nil, action: action, backgroundColor: backgroundColor)
+        let props = PXPaymentMethodProps(paymentMethodIcon: image, title: title, subtitle: subtitle, descriptionTitle: nil, descriptionDetail: accreditationTime, disclaimer: nil, action: action, backgroundColor: backgroundColor, lightLabelColor: lightLabelColor, boldLabelColor: boldLabelColor)
         
         return PXPaymentMethodComponent(props: props)
     }
@@ -247,7 +249,7 @@ extension PXReviewViewModel {
     }
 
     func buildTitleComponent() -> PXReviewTitleComponent {
-        let props = PXReviewTitleComponentProps(titleColor: ThemeManager.shared.getTheme().boldLabelTintColor(), backgroundColor: ThemeManager.shared.getTheme().highlightBackgroundColor())
+        let props = PXReviewTitleComponentProps(titleColor: ThemeManager.shared.getTitleColorForReviewConfirmNavigation(), backgroundColor: ThemeManager.shared.getTheme().highlightBackgroundColor())
         return PXReviewTitleComponent(props: props)
     }
 }
@@ -285,7 +287,7 @@ extension PXReviewViewModel {
         let itemTitle = getItemTitle(item: item)
         let itemDescription = getItemDescription(item: item)
 
-        let itemProps = PXItemComponentProps(imageURL: item.pictureUrl, title: itemTitle, description: itemDescription, quantity: itemQuantiy, unitAmount: itemPrice)
+        let itemProps = PXItemComponentProps(imageURL: item.pictureUrl, title: itemTitle, description: itemDescription, quantity: itemQuantiy, unitAmount: itemPrice, backgroundColor: ThemeManager.shared.getTheme().detailedBackgroundColor(), boldLabelColor: ThemeManager.shared.getTheme().boldLabelTintColor(), lightLabelColor: ThemeManager.shared.getTheme().labelTintColor())
         return PXItemComponent(props: itemProps)
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXTermsAndConditionView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXTermsAndConditionView.swift
@@ -79,7 +79,7 @@ extension PXTermsAndConditionView {
         
         let style = NSMutableParagraphStyle()
         style.alignment = .center
-        style.lineSpacing = CGFloat(6)
+        style.lineSpacing = CGFloat(3)
         
         mutableAttributedString.addAttribute(NSParagraphStyleAttributeName, value: style, range: NSMakeRange(0, mutableAttributedString.length))
         

--- a/MercadoPagoSDK/MercadoPagoSDK/PXTheme.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXTheme.swift
@@ -16,7 +16,7 @@ import Foundation
     func labelTintColor() -> UIColor
     func lightLabelTintColor() -> UIColor
     func boldLabelTintColor() -> UIColor
-    func highlightedLabelTintColor() -> UIColor
+    func noTaxAndDiscountLabelTintColor() -> UIColor
 
     func successColor() -> UIColor
     func warningColor() -> UIColor

--- a/MercadoPagoSDK/MercadoPagoSDK/PXThemeProperty.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXThemeProperty.swift
@@ -11,8 +11,14 @@ import Foundation
 open class PXThemeProperty: NSObject {
     let backgroundColor: UIColor
     let tintColor: UIColor
-    public init (backgroundColor: UIColor, tintColor: UIColor) {
+    let selectedColor: UIColor
+    public init (backgroundColor: UIColor, tintColor: UIColor, selectedColor: UIColor) {
         self.backgroundColor = backgroundColor
         self.tintColor = tintColor
+        if selectedColor == .clear {
+            self.selectedColor = backgroundColor
+        } else {
+            self.selectedColor = selectedColor
+        }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PayerCostView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PayerCostView.swift
@@ -38,7 +38,7 @@ final class PayerCostView: UIView, PXComponent {
             self.noRateLabel = MPLabel(frame:CGRect(x: (HORIZONTAL_MARGIN * 2) +  self.purchaseDetailTitle.frame.size.width, y: VERTICAL_MARGIN * 2 + self.purchaseDetailAmount.frame.size.height, width: (self.getWeight() - 3 * HORIZONTAL_MARGIN)/2, height: 0 ))
             self.noRateLabel.attributedText = NSAttributedString(string : MercadoPagoCheckout.showPayerCostDescription() ? PayerCostView.NO_INTEREST_TEXT: "")
             self.noRateLabel.font = Utils.getFont(size: PayerCostView.TITLE_FONT_SIZE)
-            self.noRateLabel.textColor = ThemeManager.shared.getTheme().highlightedLabelTintColor()
+            self.noRateLabel.textColor = ThemeManager.shared.getTheme().noTaxAndDiscountLabelTintColor()
             self.noRateLabel.textAlignment = .right
             self.requiredHeight = self.requiredHeight + self.noRateLabel.requiredHeight()
             self.addSubview(noRateLabel)

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethodSelectedTableViewCell.swift
@@ -28,7 +28,7 @@ class PaymentMethodSelectedTableViewCell: UITableViewCell {
     @IBOutlet weak var totalAmountLabel: MPLabel!
     override func awakeFromNib() {
         super.awakeFromNib()
-        self.contentView.backgroundColor = ThemeManager.shared.getTheme().detailedBackgroundColor()
+        self.contentView.backgroundColor = .white
         self.noRateLabel.text = ""
         self.noRateLabel.font = Utils.getFont(size: self.noRateLabel.font.pointSize)
         self.totalAmountLabel.attributedText = NSAttributedString(string : "")

--- a/MercadoPagoSDK/MercadoPagoSDK/PurchaseItemDetailTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PurchaseItemDetailTableViewCell.swift
@@ -26,7 +26,7 @@ class PurchaseItemDetailTableViewCell: UITableViewCell {
         self.contentView.layer.borderColor = UIColor.grayTableSeparator().cgColor
         self.contentView.layer.borderWidth = 1.0
         self.itemImage.image = MercadoPago.getImage("MPSDK_review_iconoCarrito")
-        self.contentView.backgroundColor = ThemeManager.shared.getTheme().detailedBackgroundColor()
+        self.contentView.backgroundColor = .white
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenPreference.swift
@@ -16,7 +16,7 @@ open class ReviewScreenPreference: NSObject {
 	private var shouldDisplayChangeMethodOption = true
     var details: [SummaryType: SummaryDetail] = [SummaryType: SummaryDetail]()
     var disclaimer: String?
-    var disclaimerColor: UIColor = ThemeManager.shared.getTheme().highlightedLabelTintColor()
+    var disclaimerColor: UIColor = ThemeManager.shared.getTheme().noTaxAndDiscountLabelTintColor()
     var showSubitle: Bool = false
     let summaryTitles: [SummaryType: String] = [SummaryType.PRODUCT: "Producto".localized, SummaryType.ARREARS: "Mora".localized, SummaryType.CHARGE: "Cargos".localized,
                                                             SummaryType.DISCOUNT: "Descuentos".localized, SummaryType.TAXES: "Impuestos".localized, SummaryType.SHIPPING: "Envío".localized]

--- a/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ReviewScreenViewController.swift
@@ -119,7 +119,6 @@ open class ReviewScreenViewController: MercadoPagoUIScrollViewController, UITabl
 
         self.extendedLayoutIncludesOpaqueBars = true
 
-        self.navBarTextColor = ThemeManager.shared.getTintColorForReviewConfirmNavigation()
         loadMPStyles()
 
         if self.shouldShowNavBar(self.checkoutTable) {

--- a/MercadoPagoSDK/MercadoPagoSDK/ThemeManager.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/ThemeManager.swift
@@ -77,9 +77,9 @@ extension ThemeManager {
         return nil
     }
     
-    func getTintColorForReviewConfirmNavigation() -> UIColor {
+    func getTitleColorForReviewConfirmNavigation() -> UIColor {
         if currentTheme is PXDefaultTheme {
-            return currentTheme.boldLabelTintColor()
+            return currentTheme.navigationBar().backgroundColor
         }
         return ThemeManager.shared.getTheme().navigationBar().tintColor
     }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MeliTheme.swift
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MeliTheme.swift
@@ -12,15 +12,15 @@ import MercadoPagoSDK
 @objc class MeliTheme: NSObject, PXTheme {
 
     public func navigationBar() -> PXThemeProperty {
-        return PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 0.9176470588, blue: 0.4705882353, alpha: 1), tintColor: #colorLiteral(red: 0.2, green: 0.2, blue: 0.2, alpha: 1))
+        return PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 0.9176470588, blue: 0.4705882353, alpha: 1), tintColor: #colorLiteral(red: 0.2, green: 0.2, blue: 0.2, alpha: 1), selectedColor: .clear)
     }
 
     public func primaryButton() -> PXThemeProperty {
-        return PXThemeProperty(backgroundColor: #colorLiteral(red: 0.2039215686, green: 0.5137254902, blue: 0.9803921569, alpha: 1), tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))
+        return PXThemeProperty(backgroundColor: #colorLiteral(red: 0.2039215686, green: 0.5137254902, blue: 0.9803921569, alpha: 1), tintColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), selectedColor: #colorLiteral(red: 0.1628948748, green: 0.4370952249, blue: 0.8369542956, alpha: 1))
     }
 
     public func secondaryButton() -> PXThemeProperty {
-        return PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor: #colorLiteral(red: 0.2039215686, green: 0.5137254902, blue: 0.9803921569, alpha: 1))
+        return PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), tintColor: #colorLiteral(red: 0.2039215686, green: 0.5137254902, blue: 0.9803921569, alpha: 1), selectedColor: .clear)
     }
 
     public func labelTintColor() -> UIColor {
@@ -35,7 +35,7 @@ import MercadoPagoSDK
         return #colorLiteral(red: 0.2, green: 0.2, blue: 0.2, alpha: 1)
     }
     
-    public func highlightedLabelTintColor() -> UIColor {
+    public func noTaxAndDiscountLabelTintColor() -> UIColor {
         return #colorLiteral(red: 0.2235294118, green: 0.7098039216, blue: 0.2901960784, alpha: 1)
     }
 
@@ -52,11 +52,11 @@ import MercadoPagoSDK
     }
 
     public func loadingComponent() -> PXThemeProperty {
-        return  PXThemeProperty(backgroundColor:#colorLiteral(red: 1, green: 0.9176470588, blue: 0.4705882353, alpha: 1), tintColor: #colorLiteral(red: 0.2039215686, green: 0.5137254902, blue: 0.9803921569, alpha: 1))
+        return PXThemeProperty(backgroundColor:#colorLiteral(red: 1, green: 0.9176470588, blue: 0.4705882353, alpha: 1), tintColor: #colorLiteral(red: 0.2039215686, green: 0.5137254902, blue: 0.9803921569, alpha: 1), selectedColor: .clear)
     }
 
     public func modalComponent() -> PXThemeProperty {
-        return PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 0.8588235294, blue: 0.08235294118, alpha: 1), tintColor: #colorLiteral(red: 0.2, green: 0.2, blue: 0.2, alpha: 1))
+        return PXThemeProperty(backgroundColor: #colorLiteral(red: 1, green: 0.8588235294, blue: 0.08235294118, alpha: 1), tintColor: #colorLiteral(red: 0.2, green: 0.2, blue: 0.2, alpha: 1), selectedColor: .clear)
     }
 
     public func highlightBackgroundColor() -> UIColor {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/TestComponent.swift
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/TestComponent.swift
@@ -38,7 +38,7 @@ import MercadoPagoSDK
         let frame = CGRect(x: 0, y: 0, width: 500, height: 100)
         let view = UIView(frame: frame)
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .red
+        view.backgroundColor = .white
         let label = UILabel(frame: frame)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = "Custom Component"


### PR DESCRIPTION
Polish final de RyC ya chequeado con Max. 
Todos los componentes se integran correctamente y visualizan correctamente.
Se soporta Skin de Meli, de SinglePlayer y de cualquier otro integrador menor basado solo en primaryColor o un Theme entero. (Se testeo especialmente central de pasajes).

**Central Pasajes** _(Basado en setPrimaryColor)_
![image](https://user-images.githubusercontent.com/972199/37316528-626f522e-263e-11e8-97db-cb9584a1d19c.png)
![image](https://user-images.githubusercontent.com/972199/37316530-663a2726-263e-11e8-8d52-d0e31fb6eb3e.png)

**SinglePlayer** _(Basado en DefaultTheme)_
![image](https://user-images.githubusercontent.com/972199/37316538-79fd0a44-263e-11e8-93e2-2922ec9d56e4.png)
![image](https://user-images.githubusercontent.com/972199/37316541-7cc5bdc0-263e-11e8-8655-f634cd4bc845.png)

**Meli** _(Basado en skin theme meli de instore)_
![image](https://user-images.githubusercontent.com/972199/37316551-8a774790-263e-11e8-9946-1aca3084924c.png)
![image](https://user-images.githubusercontent.com/972199/37316554-8fd522d4-263e-11e8-8390-9594a05fd16d.png)




