### PR TITLE
PXPaymentMethodView variables RENAMED

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer.swift
@@ -37,7 +37,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
         // Title
         let title = UILabel()
         title.translatesAutoresizingMaskIntoConstraints = false
-        pmBodyView.amountTitle = title
+        pmBodyView.titleLabel = title
         pmBodyView.addSubview(title)
         title.attributedText = component.props.title
         title.font = Utils.getFont(size: TITLE_FONT_SIZE)
@@ -52,7 +52,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
             let detailLabel = UILabel()
             detailLabel.translatesAutoresizingMaskIntoConstraints = false
             pmBodyView.addSubview(detailLabel)
-            pmBodyView.amountDetail = detailLabel
+            pmBodyView.subtitleLabel = detailLabel
             detailLabel.attributedText = detailText
             detailLabel.font = Utils.getFont(size: SUBTITLE_FONT_SIZE)
             detailLabel.textColor = component.props.lightLabelColor
@@ -67,7 +67,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
             let descriptionLabel = UILabel()
             descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
             pmBodyView.addSubview(descriptionLabel)
-            pmBodyView.paymentMethodDescription = descriptionLabel
+            pmBodyView.descriptionTitleLabel = descriptionLabel
             descriptionLabel.attributedText = paymentMethodDescription
             descriptionLabel.font = Utils.getFont(size: DESCRIPTION_DETAIL_FONT_SIZE)
             descriptionLabel.numberOfLines = 2
@@ -81,7 +81,7 @@ class PXPaymentMethodComponentRenderer: NSObject {
         if let pmDetailText = component.props.descriptionDetail {
             let pmDetailLabel = UILabel()
             pmDetailLabel.translatesAutoresizingMaskIntoConstraints = false
-            pmBodyView.paymentMethodDetail = pmDetailLabel
+            pmBodyView.descriptionDetailLabel = pmDetailLabel
             pmBodyView.addSubview(pmDetailLabel)
             pmDetailLabel.attributedText = pmDetailText
             pmDetailLabel.font = Utils.getFont(size: DESCRIPTION_DETAIL_FONT_SIZE)
@@ -131,10 +131,10 @@ class PXPaymentMethodComponentRenderer: NSObject {
 
 class PXPaymentMethodView: PXBodyView {
     var paymentMethodIcon: UIView?
-    var amountTitle: UILabel?
-    var amountDetail: UILabel?
-    var paymentMethodDescription: UILabel?
-    var paymentMethodDetail: UILabel?
+    var titleLabel: UILabel?
+    var subtitleLabel: UILabel?
+    var descriptionTitleLabel: UILabel?
+    var descriptionDetailLabel: UILabel?
     var disclaimerLabel: UILabel?
     var actionButton: PXSecondaryButton?
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/PXBodyComponentTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/PXBodyComponentTest.swift
@@ -22,10 +22,10 @@ class PXBodyComponentTest: BaseTest {
 
         // Then:
         XCTAssertNotNil(paymentMethodView.paymentMethodIcon)
-        XCTAssertEqual(paymentMethodView.amountTitle?.text, "$ 1.000")
-        XCTAssertEqual(paymentMethodView.amountDetail?.text, nil)
-        XCTAssertEqual(paymentMethodView.paymentMethodDescription?.text?.localized, "visa " + "terminada en ".localized + "1234")
-        XCTAssertEqual(paymentMethodView.paymentMethodDetail?.text, "name")
+        XCTAssertEqual(paymentMethodView.titleLabel?.text, "$ 1.000")
+        XCTAssertEqual(paymentMethodView.subtitleLabel?.text, nil)
+        XCTAssertEqual(paymentMethodView.descriptionTitleLabel?.text?.localized, "visa " + "terminada en ".localized + "1234")
+        XCTAssertEqual(paymentMethodView.descriptionDetailLabel?.text, "name")
         XCTAssertEqual(paymentMethodView.disclaimerLabel?.text?.localized, "En tu estado de cuenta verás el cargo como %0".localized.replacingOccurrences(of: "%0", with: "description"))
     }
 
@@ -40,10 +40,10 @@ class PXBodyComponentTest: BaseTest {
 
         // Then:
         XCTAssertNotNil(paymentMethodView.paymentMethodIcon)
-        XCTAssertEqual(paymentMethodView.amountTitle?.text, "$ 1.000")
-        XCTAssertNil(paymentMethodView.amountDetail?.text)
-        XCTAssertEqual(paymentMethodView.paymentMethodDescription?.text, "account_money")
-        XCTAssertNil(paymentMethodView.paymentMethodDetail?.text)
+        XCTAssertEqual(paymentMethodView.titleLabel?.text, "$ 1.000")
+        XCTAssertNil(paymentMethodView.subtitleLabel?.text)
+        XCTAssertEqual(paymentMethodView.descriptionTitleLabel?.text, "account_money")
+        XCTAssertNil(paymentMethodView.descriptionDetailLabel?.text)
         XCTAssertEqual(paymentMethodView.disclaimerLabel?.text?.localized, "En tu estado de cuenta verás el cargo como %0".localized.replacingOccurrences(of: "%0", with: "description"))
     }
 


### PR DESCRIPTION

##  Cambios introducidos : 
- Se actualizan los nombres de las variables de la clase PXPaymentMethodView para que estén alineados con las props del componente de payment method
