### PR TITLE
Product title from Preference if need

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewModel.swift
@@ -17,7 +17,6 @@ final class PXReviewViewModel: NSObject {
     var paymentData: PaymentData!
     var paymentOptionSelected: PaymentMethodOption
     var discount: DiscountCoupon?
-    
     var reviewScreenPreference: ReviewScreenPreference
     
     public init(checkoutPreference: CheckoutPreference, paymentData: PaymentData, paymentOptionSelected: PaymentMethodOption, discount: DiscountCoupon? = nil, reviewScreenPreference: ReviewScreenPreference = ReviewScreenPreference()) {
@@ -237,9 +236,13 @@ extension PXReviewViewModel {
             totalAmount = tAmount
         }
 
-        if let pref = preference, pref.items.count == 1 {
-            if let itemTitle = pref.items.first?.title, itemTitle.count > 0 {
-                customTitle = itemTitle
+        if let prefDetail = reviewScreenPreference.details[SummaryType.PRODUCT], !prefDetail.title.isEmpty {
+            customTitle = prefDetail.title
+        } else {
+            if let pref = preference, pref.items.count == 1 {
+                if let itemTitle = pref.items.first?.title, itemTitle.count > 0 {
+                    customTitle = itemTitle
+                }
             }
         }
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -83,7 +83,7 @@
     dc.amountWithoutDiscount = 100;
     dc = nil;
 
-    self.pref._id = @"243962506-e8314fc2-7abc-42d0-bf07-325b1f861ca8";
+    self.pref._id = @"243962506-c0d402b6-7351-450a-adab-101eb737f5dd";
 
     self.mpCheckout = [[MercadoPagoCheckout alloc] initWithPublicKey:@"TEST-e4bdd1cf-bcb2-43f7-b565-ed4c9ea25be7"
     accessToken:nil

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/TestComponent.swift
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/TestComponent.swift
@@ -50,17 +50,13 @@ import MercadoPagoSDK
         let preference = ReviewScreenPreference()
         preference.setTopComponent(top)
         preference.setBottomComponent(bottom)
-//        preference.disableItems()
-//        preference.disableChangeMethodOption()
+        // preference.disableItems()
+        // preference.disableChangeMethodOption()
         
-        // Not getting.
-        preference.setSummaryProductTitle(productTitle: "Produc title from ReviewScreenPreference")
-        preference.setAmountTitle(title: "Amount title from RSP")
+        // preference.setSummaryProductTitle(productTitle: "Product title from ReviewScreenPreference")
+        // preference.setAmountTitle(title: "Amount title from RSP")
         
-        // Design note. (Solo en full) y 1 linea.
         //preference.setDisclaimerText(text: "Disclamer text from RSP")
-        preference.addSummaryDiscountDetail(amount: 10)
-        preference.addSummaryTaxesDetail(amount: 12)
         
         return preference
     }


### PR DESCRIPTION
Nuevo scenario:
- Si es mas de un item diferente se muestra "Productos"
- Si es solo un item se muestra el titulo del item (desde la pref de backend)
- Si el integrador hace el seter de la ReviewScreenPreference de productTitle, se anula todo lo anterior, y se muestra el titulo seteado en la ReviewScreenPreference independientemente de si es 1 producto o muchos productos.