### PR TITLE
Fix Error Screen in R&C

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckout.swift
@@ -280,12 +280,15 @@ open class MercadoPagoCheckout: NSObject {
         self.navigationController.present(self.currentLoadingView!, animated: false, completion: nil)
     }
 
-    func dismissLoading(animated: Bool = true) {
+    func dismissLoading(animated: Bool = true, finishCallback:(()-> Void)? = nil) {
         self.countLoadings = 0
         if self.currentLoadingView != nil {
             self.currentLoadingView?.modalTransitionStyle = .crossDissolve
-            self.currentLoadingView!.dismiss(animated: true, completion: {
+            self.currentLoadingView!.dismiss(animated: animated, completion: {
                 self.currentLoadingView = nil
+                if let callback = finishCallback {
+                    callback()
+                }
             })
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
@@ -233,7 +233,6 @@ extension MercadoPagoCheckout {
     }
 
     func showErrorScreen() {
-        self.dismissLoading()
         let errorStep = ErrorViewController(error: MercadoPagoCheckoutViewModel.error, callback: nil, callbackCancel: {[weak self] in
 
             guard let strongSelf = self else {
@@ -248,7 +247,10 @@ extension MercadoPagoCheckout {
                 self.viewModel.errorCallback?()
             })
         }
-        self.navigationController.present(errorStep, animated: true, completion: {})
+        self.dismissLoading {
+            self.navigationController.present(errorStep, animated: true, completion: {})
+        }
+        
     }
 
     func showFinancialInstitutionsScreen() {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -86,9 +86,11 @@
     dc.amountWithoutDiscount = 60;
     dc = nil;
 
-    self.pref.preferenceId = @"241261700-459d4126-903c-4bad-bc05-82e5f13fa7d3";
-
-    self.mpCheckout = [[MercadoPagoCheckout alloc] initWithPublicKey:@"TEST-93c0061e-ba7d-479c-9d52-c60b0af58a91"
+   // self.pref.preferenceId = @"241261700-459d4126-903c-4bad-bc05-82e5f13fa7d3";
+    self.pref.preferenceId = @"241261708-cd353b1b-940f-493b-b960-10106a24203c"; // Error
+    
+    //self.mpCheckout = [[MercadoPagoCheckout alloc] initWithPublicKey:@"TEST-93c0061e-ba7d-479c-9d52-c60b0af58a91"
+    self.mpCheckout = [[MercadoPagoCheckout alloc] initWithPublicKey:@"APP_USR-2e257493-3b80-4b71-8547-c841d035e8f2" // Error
     accessToken:nil
                                                   checkoutPreference:self.pref paymentData:self.paymentData paymentResult:self.paymentResult discount:dc navigationController:self.navigationController];
 


### PR DESCRIPTION
- Se corrige el bug que hacia que no se muestre la pantalla de error cuando fallaba un pago (no error de pago).
- Se agrega la funcionalidad para que la función de dismissLoading tenga un callback finish.


_**Warning: Attempt to present <MercadoPagoSDK.ErrorViewController: 0x7ff6ff87da00> on <UINavigationController: 0x7ff6ff816e00> while a presentation is in progress!**_