### PR TITLE
Add custom component to business restult. Add Example.

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		1563DCA81E9C11CB00A7E5C8 /* CardsAdminViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1563DCA51E9C11CB00A7E5C8 /* CardsAdminViewController.swift */; };
 		1563DCA91E9C11CB00A7E5C8 /* CardsAdminViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1563DCA61E9C11CB00A7E5C8 /* CardsAdminViewController.xib */; };
 		1563DCAA1E9C11CB00A7E5C8 /* CardsAdminViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1563DCA61E9C11CB00A7E5C8 /* CardsAdminViewController.xib */; };
+		156526C7209F74A800852D39 /* PXCustomComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156526C6209F74A800852D39 /* PXCustomComponent.swift */; };
 		15661C561FCC7334007FD7B7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		15661C5C1FCDCC48007FD7B7 /* PXBodyViewModelHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15661C5B1FCDCC47007FD7B7 /* PXBodyViewModelHelper.swift */; };
 		156A6DD01F6C7C9C00B17A20 /* SummaryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156A6DCF1F6C7C9C00B17A20 /* SummaryTest.swift */; };
@@ -227,6 +228,7 @@
 		15EEE1D91D89D477004D3A19 /* CardFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EEE1D81D89D477004D3A19 /* CardFormViewModel.swift */; };
 		15F3D7591EA65B3B00DC57AA /* CardsAdminViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F3D7581EA65B3B00DC57AA /* CardsAdminViewModelTest.swift */; };
 		15FE72921E79AAA200111A9C /* AdditionalStepTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAA55F91DB0241700501061 /* AdditionalStepTitleTableViewCell.swift */; };
+		18C5207E2B69C803C38CB024 /* Pods_MercadoPagoSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBC6F9326B38C688FC679A4 /* Pods_MercadoPagoSDKTests.framework */; };
 		231437512060A56600F08B4B /* PXBusinessResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813B411E2051837800B6D886 /* PXBusinessResult.swift */; };
 		231AE27020472C1400CB87CF /* PXSummaryComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231AE26F20472C1400CB87CF /* PXSummaryComponent.swift */; };
 		231AE27220472C3000CB87CF /* PXSummaryComponentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231AE27120472C3000CB87CF /* PXSummaryComponentRenderer.swift */; };
@@ -818,6 +820,7 @@
 		155F58321E3923180070A0D6 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		1563DCA51E9C11CB00A7E5C8 /* CardsAdminViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardsAdminViewController.swift; sourceTree = "<group>"; };
 		1563DCA61E9C11CB00A7E5C8 /* CardsAdminViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CardsAdminViewController.xib; sourceTree = "<group>"; };
+		156526C6209F74A800852D39 /* PXCustomComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXCustomComponent.swift; sourceTree = "<group>"; };
 		15661C5B1FCDCC47007FD7B7 /* PXBodyViewModelHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PXBodyViewModelHelper.swift; sourceTree = "<group>"; };
 		156A6DCF1F6C7C9C00B17A20 /* SummaryTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SummaryTest.swift; sourceTree = "<group>"; };
 		156F25B21EA927430073D3AA /* CardsAdminViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardsAdminViewModel.swift; sourceTree = "<group>"; };
@@ -1193,6 +1196,7 @@
 			files = (
 				4B0E72AA1FA8F9E8006A3853 /* MercadoPagoPXTracking.framework in Frameworks */,
 				4B0E72A81FA8F9E4006A3853 /* MercadoPagoServices.framework in Frameworks */,
+				18C5207E2B69C803C38CB024 /* Pods_MercadoPagoSDKTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1520,6 +1524,7 @@
 				155954EA1F87CD200086854B /* PayerInfoViewModel.swift */,
 				15AE1DAC1F61B98200B0DAF8 /* PXComponent.swift */,
 				150E4BFD1FB37FD300773565 /* PXComponentContainerViewController.swift */,
+				156526C6209F74A800852D39 /* PXCustomComponent.swift */,
 			);
 			name = Components;
 			sourceTree = "<group>";
@@ -2936,6 +2941,7 @@
 				0F9883751AD2AB6000F750F0 /* Identification.swift in Sources */,
 				FCAA97001E6A0E0D000612F6 /* AdditionalStepViewModel.swift in Sources */,
 				4BEFBF8F1F06BB20003EA94E /* PayerCostCFTTableViewCell.swift in Sources */,
+				156526C7209F74A800852D39 /* PXCustomComponent.swift in Sources */,
 				4B48541C204825C0001C0921 /* PXItemComponent.swift in Sources */,
 				4B4E2327200062F5007E8FDD /* PXReceiptViewModelHelper.swift in Sources */,
 				FCAD2BE51E96E1370087D943 /* AdditionalStepCellFactory.swift in Sources */,

--- a/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResult.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResult.swift
@@ -30,23 +30,20 @@ import UIKit
  */
 @objcMembers open class PXBusinessResult: NSObject {
 
-    var status: PXBusinessResultStatus // APPROVED REJECTED PENDING
-    var title: String // Titluo de Congrats
-    var subtitle: String? // Sub Titluo de Congrats
-    var icon: UIImage?  // Icono de Congrats
-    var mainAction: PXComponentAction? // Boton principal (Azul)
-    var secondaryAction: PXComponentAction? // Boton secundario (link)
-    var helpMessage: String? // Texto
-    var showPaymentMethod: Bool = false // Si quiere que muestre la celda de PM
-    var statementDescription : String?
-    var imageUrl: String?
-    var topCustomView: UIView?
-    var bottomCustomView: UIView?
+    private let status: PXBusinessResultStatus // APPROVED REJECTED PENDING
+    private let title: String // Titluo de Congrats
+    private let subtitle: String? // Sub Titluo de Congrats
+    private let icon: UIImage?  // Icono de Congrats
+    private let mainAction: PXComponentAction? // Boton principal (Azul)
+    private let secondaryAction: PXComponentAction? // Boton secundario (link)
+    private let helpMessage: String? // Texto
+    private let showPaymentMethod: Bool // Si quiere que muestre la celda de PM
+    private let statementDescription : String?
+    private let imageUrl: String?
+    private let topCustomView: UIView?
+    private let bottomCustomView: UIView?
+    private var receiptId: String?
     
-    //Datos que actualmente devuelve la procesadora de pagos
-    var receiptId: String?
-    //------
-
     public init(receiptId: String? = nil, status: PXBusinessResultStatus, title: String, subtitle: String? = nil, icon: UIImage? = nil, mainAction: PXComponentAction? = nil, secondaryAction: PXComponentAction?, helpMessage: String? = nil , showPaymentMethod : Bool = false, statementDescription: String? = nil, imageUrl: String? = nil, topCustomView: UIView? = nil, bottomCustomView: UIView? = nil) {
         self.receiptId = receiptId
         self.status = status
@@ -62,5 +59,50 @@ import UIKit
         self.topCustomView = topCustomView
         self.bottomCustomView = bottomCustomView
         super.init()
+    }
+   
+}
+
+//MARK: Getters
+extension PXBusinessResult {
+    
+    public func getStatus() -> PXBusinessResultStatus {
+        return self.status
+    }
+    public func getTitle() -> String {
+        return self.title
+    }
+    public func getStatementDescription() -> String? {
+        return self.statementDescription
+    }
+    public func getTopCustomView() -> UIView? {
+        return self.topCustomView
+    }
+    public func getBottomCustomView() -> UIView? {
+        return self.bottomCustomView
+    }
+    public func getImageUrl() -> String? {
+        return self.imageUrl
+    }
+    public func getReceiptId() -> String? {
+        return self.receiptId
+    }
+    public func getSubTitle() -> String? {
+        return self.subtitle
+    }
+    public func getHelpMessage() -> String? {
+        return self.helpMessage
+    }
+    public func getIcon() -> UIImage? {
+        return self.icon
+    }
+    public func getMainAction() ->  PXComponentAction? {
+        return self.mainAction
+    }
+    public func getSecondaryAction() ->  PXComponentAction? {
+        return self.secondaryAction
+    }
+    public func mustShowPaymentMethod() ->  Bool {
+        return self.showPaymentMethod
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResult.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResult.swift
@@ -40,12 +40,14 @@ import UIKit
     var showPaymentMethod: Bool = false // Si quiere que muestre la celda de PM
     var statementDescription : String?
     var imageUrl: String?
+    var topCustomView: UIView?
+    var bottomCustomView: UIView?
     
     //Datos que actualmente devuelve la procesadora de pagos
     var receiptId: String?
     //------
 
-    public init(receiptId: String? = nil, status: PXBusinessResultStatus, title: String, subtitle: String? = nil, icon: UIImage? = nil, mainAction: PXComponentAction? = nil, secondaryAction: PXComponentAction?, helpMessage: String? = nil , showPaymentMethod : Bool = false, statementDescription: String? = nil, imageUrl: String? = nil) {
+    public init(receiptId: String? = nil, status: PXBusinessResultStatus, title: String, subtitle: String? = nil, icon: UIImage? = nil, mainAction: PXComponentAction? = nil, secondaryAction: PXComponentAction?, helpMessage: String? = nil , showPaymentMethod : Bool = false, statementDescription: String? = nil, imageUrl: String? = nil, topCustomView: UIView? = nil, bottomCustomView: UIView? = nil) {
         self.receiptId = receiptId
         self.status = status
         self.title = title
@@ -57,6 +59,8 @@ import UIKit
         self.showPaymentMethod = showPaymentMethod
         self.statementDescription = statementDescription
         self.imageUrl = imageUrl
+        self.topCustomView = topCustomView
+        self.bottomCustomView = bottomCustomView
         super.init()
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResultViewModel.swift
@@ -179,11 +179,17 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
     }
     
     func buildTopCustomComponent() -> PXCustomComponentizable? {
-        return nil
+        guard let view = self.businessResult.topCustomView else {
+            return nil
+        }
+        return PXCustomComponent(view: view)
     }
 
     func buildBottomCustomComponent() -> PXCustomComponentizable? {
-        return nil
+        guard let view = self.businessResult.bottomCustomView else {
+            return nil
+        }
+        return PXCustomComponent(view: view)
     }
 
     func getHeaderIcon() -> UIImage? {

--- a/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResultViewModel.swift
@@ -39,7 +39,7 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
 
     func primaryResultColor() -> UIColor {
 
-        switch self.businessResult.status {
+        switch self.businessResult.getStatus() {
         case .APPROVED:
             return ThemeManager.shared.getTheme().successColor()
         case .REJECTED:
@@ -56,15 +56,15 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
     }
 
     func getPaymentStatus() -> String {
-        return businessResult.status.getDescription()
+        return businessResult.getStatus().getDescription()
     }
 
     func getPaymentStatusDetail() -> String {
-        return businessResult.status.getDescription()
+        return businessResult.getStatus().getDescription()
     }
 
     func getPaymentId() -> String? {
-       return  businessResult.receiptId
+       return  businessResult.getReceiptId()
     }
 
     func isCallForAuth() -> Bool {
@@ -72,7 +72,7 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
     }
 
     func getBadgeImage() -> UIImage? {
-        switch self.businessResult.status {
+        switch self.businessResult.getStatus() {
         case .APPROVED:
             return MercadoPago.getImage("ok_badge")
         case .REJECTED:
@@ -85,18 +85,18 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
     }
     func buildHeaderComponent() -> PXHeaderComponent {
         let headerImage = getHeaderIcon()
-        let headerProps = PXHeaderProps(labelText: businessResult.subtitle?.toAttributedString(), title: businessResult.title.toAttributedString(), backgroundColor: primaryResultColor(), productImage: headerImage, statusImage: getBadgeImage())
+        let headerProps = PXHeaderProps(labelText: businessResult.getSubTitle()?.toAttributedString(), title: businessResult.getTitle().toAttributedString(), backgroundColor: primaryResultColor(), productImage: headerImage, statusImage: getBadgeImage())
         return PXHeaderComponent(props: headerProps)
     }
 
     func buildFooterComponent() -> PXFooterComponent {
-        let linkAction = businessResult.secondaryAction != nil ? businessResult.secondaryAction : PXCloseLinkAction()
-        let footerProps = PXFooterProps(buttonAction: businessResult.mainAction, linkAction: linkAction)
+        let linkAction = businessResult.getSecondaryAction() != nil ? businessResult.getSecondaryAction() : PXCloseLinkAction()
+        let footerProps = PXFooterProps(buttonAction: businessResult.getMainAction(), linkAction: linkAction)
         return PXFooterComponent(props: footerProps)
     }
 
     func buildReceiptComponent() -> PXReceiptComponent? {
-        guard let recieptId = businessResult.receiptId else {
+        guard let recieptId = businessResult.getReceiptId() else {
             return nil
         }
         let date = Date()
@@ -107,10 +107,10 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
     func buildBodyComponent() -> PXComponentizable? {
         var pmComponent : PXComponentizable? = nil
         var helpComponent : PXComponentizable? = nil
-        if self.businessResult.showPaymentMethod {
+        if self.businessResult.mustShowPaymentMethod() {
             pmComponent =  getPaymentMethodComponent()
         }
-        if (self.businessResult.helpMessage != nil) {
+        if (self.businessResult.getHelpMessage() != nil) {
             helpComponent = getHelpMessageComponent()
         }
         
@@ -118,7 +118,7 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
     }
 
     func getHelpMessageComponent() -> PXErrorComponent? {
-        guard let labelInstruction = self.businessResult.helpMessage else {
+        guard let labelInstruction = self.businessResult.getHelpMessage() else {
             return nil
         }
         
@@ -159,7 +159,7 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
         }
         
         var disclaimerText: String? = nil
-        if let statementDescription = self.businessResult.statementDescription {
+        if let statementDescription = self.businessResult.getStatementDescription() {
             disclaimerText =  ("En tu estado de cuenta verás el cargo como %0".localized as NSString).replacingOccurrences(of: "%0", with: "\(statementDescription)")
         }
         
@@ -179,25 +179,25 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
     }
     
     func buildTopCustomComponent() -> PXCustomComponentizable? {
-        guard let view = self.businessResult.topCustomView else {
+        guard let view = self.businessResult.getTopCustomView() else {
             return nil
         }
         return PXCustomComponent(view: view)
     }
 
     func buildBottomCustomComponent() -> PXCustomComponentizable? {
-        guard let view = self.businessResult.bottomCustomView else {
+        guard let view = self.businessResult.getBottomCustomView() else {
             return nil
         }
         return PXCustomComponent(view: view)
     }
 
     func getHeaderIcon() -> UIImage? {
-        if let brImageUrl = businessResult.imageUrl {
+        if let brImageUrl = businessResult.getImageUrl() {
             if let image =  ViewUtils.loadImageFromUrl(brImageUrl) {
                 return image
             }
-        } else if let brIcon = businessResult.icon {
+        } else if let brIcon = businessResult.getIcon() {
             return brIcon
         } else if let defaultBundle = approvedIconBundle, let defaultImage = MercadoPago.getImage(approvedIconName, bundle: defaultBundle) {
             return defaultImage

--- a/MercadoPagoSDK/MercadoPagoSDK/PXCustomComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXCustomComponent.swift
@@ -1,0 +1,30 @@
+//
+//  PXCustomComponent.swift
+//  MercadoPagoSDK
+//
+//  Created by Demian Tejo on 6/5/18.
+//  Copyright © 2018 MercadoPago. All rights reserved.
+//
+
+import UIKit
+
+class PXCustomComponent: PXCustomComponentizable, PXComponentizable {
+
+    
+    let view : UIView
+    
+    func render() -> UIView {
+        return view
+    }
+    
+    func render(store: PXCheckoutStore, theme: PXTheme) -> UIView? {
+        return self.render()
+    }
+
+    
+    init(view:UIView) {
+        self.view = view
+    }
+    
+
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/PXLayout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXLayout.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-open class PXLayout: NSObject {
+class PXLayout: NSObject {
 
     //Margins
     static let ZERO_MARGIN: CGFloat = 0.0
@@ -33,26 +33,26 @@ open class PXLayout: NSObject {
     static let XXL_FONT: CGFloat = 26.0
     static let XXXL_FONT: CGFloat = 26.0
 
-    open static let DEFAULT_CONTRAINT_ACTIVE = true
+    static let DEFAULT_CONTRAINT_ACTIVE = true
 
-    open static func checkContraintActivation(_ constraint: NSLayoutConstraint, withDefault isActive: Bool = DEFAULT_CONTRAINT_ACTIVE) -> NSLayoutConstraint {
+    static func checkContraintActivation(_ constraint: NSLayoutConstraint, withDefault isActive: Bool = DEFAULT_CONTRAINT_ACTIVE) -> NSLayoutConstraint {
         constraint.isActive = isActive
         return constraint
     }
 
     //Altura fija
-    open static func setHeight(owner: UIView, height: CGFloat ) -> NSLayoutConstraint {
+    static func setHeight(owner: UIView, height: CGFloat ) -> NSLayoutConstraint {
         owner.translatesAutoresizingMaskIntoConstraints = false
         return checkContraintActivation(NSLayoutConstraint(item: owner, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: height))
     }
 
     //Ancho fijo
-    open static func setWidth(owner: UIView, width: CGFloat ) -> NSLayoutConstraint {
+    static func setWidth(owner: UIView, width: CGFloat ) -> NSLayoutConstraint {
         return checkContraintActivation(NSLayoutConstraint(item: owner, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: width))
     }
 
     // Pin Left
-    open static func pinLeft(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
+    static func pinLeft(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -62,7 +62,7 @@ open class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: .leading, relatedBy: .equal, toItem: superView, attribute: .leading, multiplier: 1, constant: margin))
     }
     //Pin Right
-    open static func pinRight(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
+    static func pinRight(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -72,7 +72,7 @@ open class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: .trailing, relatedBy: .equal, toItem: superView, attribute: .trailing, multiplier: 1, constant: -margin))
     }
     //Pin Top
-    open static func pinTop(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
+    static func pinTop(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -82,7 +82,7 @@ open class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: .top, relatedBy: .equal, toItem: superView, attribute: .top, multiplier: 1, constant: margin))
     }
     //Pin Bottom
-    open static func pinBottom(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
+    static func pinBottom(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -93,7 +93,7 @@ open class PXLayout: NSObject {
     }
 
     //Pin parent last subview to Bottom
-    open static func pinLastSubviewToBottom(view: UIView, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint? {
+    static func pinLastSubviewToBottom(view: UIView, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint? {
         guard let lastView = view.subviews.last else {
             return nil
         }
@@ -101,7 +101,7 @@ open class PXLayout: NSObject {
     }
 
     //Pin parent first subview to Top
-    open static func pinFirstSubviewToTop(view: UIView, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint? {
+    static func pinFirstSubviewToTop(view: UIView, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint? {
         guard let firstView = view.subviews.first else {
             return nil
         }
@@ -109,7 +109,7 @@ open class PXLayout: NSObject {
     }
 
     //Vista 1 abajo de vista 2
-    open static func put(view: UIView, onBottomOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint {
+    static func put(view: UIView, onBottomOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint {
         return checkContraintActivation(NSLayoutConstraint(
             item: view,
             attribute: .top,
@@ -121,7 +121,7 @@ open class PXLayout: NSObject {
         ))
     }
     //Vista 1 abajo de la ultima vista
-    open static func put(view: UIView, onBottomOfLastViewOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint? {
+    static func put(view: UIView, onBottomOfLastViewOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint? {
         if !view2.subviews.contains(view) {
             return nil
         }
@@ -132,7 +132,7 @@ open class PXLayout: NSObject {
     }
 
     //Vista 1 arriba de vista 2
-    open static func put(view: UIView, aboveOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint {
+    static func put(view: UIView, aboveOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint {
         return checkContraintActivation(NSLayoutConstraint(
             item: view,
             attribute: .bottom,
@@ -145,7 +145,7 @@ open class PXLayout: NSObject {
     }
 
     //Centrado horizontal
-    open static func centerHorizontally(view: UIView, to container: UIView? = nil) -> NSLayoutConstraint {
+    static func centerHorizontally(view: UIView, to container: UIView? = nil) -> NSLayoutConstraint {
         var superView: UIView!
         if container == nil {
             superView = view.superview
@@ -156,7 +156,7 @@ open class PXLayout: NSObject {
     }
 
     //Centrado Vertical
-    open static func centerVertically(view: UIView, to container: UIView? = nil) -> NSLayoutConstraint {
+    static func centerVertically(view: UIView, to container: UIView? = nil) -> NSLayoutConstraint {
         var superView: UIView!
         if container == nil {
             superView = view.superview
@@ -166,7 +166,7 @@ open class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: NSLayoutAttribute.centerY, relatedBy: NSLayoutRelation.equal, toItem: superView, attribute: NSLayoutAttribute.centerY, multiplier: 1.0, constant: 0))
     }
 
-    open static func matchWidth(ofView view: UIView, toView otherView: UIView? = nil, withPercentage percent: CGFloat = 100) -> NSLayoutConstraint {
+    static func matchWidth(ofView view: UIView, toView otherView: UIView? = nil, withPercentage percent: CGFloat = 100) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -176,7 +176,7 @@ open class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: NSLayoutAttribute.width, relatedBy: NSLayoutRelation.equal, toItem: superView, attribute: NSLayoutAttribute.width, multiplier: percent / 100, constant: 0))
     }
 
-    open static func matchHeight(ofView view: UIView, toView otherView: UIView? = nil, withPercentage percent: CGFloat = 100) -> NSLayoutConstraint {
+    static func matchHeight(ofView view: UIView, toView otherView: UIView? = nil, withPercentage percent: CGFloat = 100) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -186,13 +186,13 @@ open class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: NSLayoutAttribute.height, relatedBy: NSLayoutRelation.equal, toItem: superView, attribute: NSLayoutAttribute.height, multiplier: percent / 100, constant: 0))
     }
 
-    open static func getScreenWidth(applyingMarginFactor percent: CGFloat = 100) -> CGFloat {
+    static func getScreenWidth(applyingMarginFactor percent: CGFloat = 100) -> CGFloat {
         let screenSize = UIScreen.main.bounds
         let availableWidth = screenSize.width * percent / 100
         return availableWidth
     }
 
-    open static func getScreenHeight(applyingMarginFactor percent: CGFloat = 100) -> CGFloat {
+    static func getScreenHeight(applyingMarginFactor percent: CGFloat = 100) -> CGFloat {
         let screenSize = UIScreen.main.bounds
         let availableHeight = screenSize.height * percent / 100
         return availableHeight
@@ -201,7 +201,7 @@ open class PXLayout: NSObject {
 }
 
 extension PXLayout {
-    open static func getSafeAreaBottomInset() -> CGFloat {
+    static func getSafeAreaBottomInset() -> CGFloat {
         // iPhoneX or any device with safe area inset > 0
         var bottomDeltaMargin: CGFloat = 0
         if #available(iOS 11.0, *) {

--- a/MercadoPagoSDK/MercadoPagoSDK/PXLayout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXLayout.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class PXLayout: NSObject {
+open class PXLayout: NSObject {
 
     //Margins
     static let ZERO_MARGIN: CGFloat = 0.0
@@ -33,26 +33,26 @@ class PXLayout: NSObject {
     static let XXL_FONT: CGFloat = 26.0
     static let XXXL_FONT: CGFloat = 26.0
 
-    static let DEFAULT_CONTRAINT_ACTIVE = true
+    open static let DEFAULT_CONTRAINT_ACTIVE = true
 
-    static func checkContraintActivation(_ constraint: NSLayoutConstraint, withDefault isActive: Bool = DEFAULT_CONTRAINT_ACTIVE) -> NSLayoutConstraint {
+    open static func checkContraintActivation(_ constraint: NSLayoutConstraint, withDefault isActive: Bool = DEFAULT_CONTRAINT_ACTIVE) -> NSLayoutConstraint {
         constraint.isActive = isActive
         return constraint
     }
 
     //Altura fija
-    static func setHeight(owner: UIView, height: CGFloat ) -> NSLayoutConstraint {
+    open static func setHeight(owner: UIView, height: CGFloat ) -> NSLayoutConstraint {
         owner.translatesAutoresizingMaskIntoConstraints = false
         return checkContraintActivation(NSLayoutConstraint(item: owner, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: height))
     }
 
     //Ancho fijo
-    static func setWidth(owner: UIView, width: CGFloat ) -> NSLayoutConstraint {
+    open static func setWidth(owner: UIView, width: CGFloat ) -> NSLayoutConstraint {
         return checkContraintActivation(NSLayoutConstraint(item: owner, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: width))
     }
 
     // Pin Left
-    static func pinLeft(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
+    open static func pinLeft(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -62,7 +62,7 @@ class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: .leading, relatedBy: .equal, toItem: superView, attribute: .leading, multiplier: 1, constant: margin))
     }
     //Pin Right
-    static func pinRight(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
+    open static func pinRight(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -72,7 +72,7 @@ class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: .trailing, relatedBy: .equal, toItem: superView, attribute: .trailing, multiplier: 1, constant: -margin))
     }
     //Pin Top
-    static func pinTop(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
+    open static func pinTop(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -82,7 +82,7 @@ class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: .top, relatedBy: .equal, toItem: superView, attribute: .top, multiplier: 1, constant: margin))
     }
     //Pin Bottom
-    static func pinBottom(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
+    open static func pinBottom(view: UIView, to otherView: UIView? = nil, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -93,7 +93,7 @@ class PXLayout: NSObject {
     }
 
     //Pin parent last subview to Bottom
-    static func pinLastSubviewToBottom(view: UIView, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint? {
+    open static func pinLastSubviewToBottom(view: UIView, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint? {
         guard let lastView = view.subviews.last else {
             return nil
         }
@@ -101,7 +101,7 @@ class PXLayout: NSObject {
     }
 
     //Pin parent first subview to Top
-    static func pinFirstSubviewToTop(view: UIView, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint? {
+    open static func pinFirstSubviewToTop(view: UIView, withMargin margin: CGFloat = 0 ) -> NSLayoutConstraint? {
         guard let firstView = view.subviews.first else {
             return nil
         }
@@ -109,7 +109,7 @@ class PXLayout: NSObject {
     }
 
     //Vista 1 abajo de vista 2
-    static func put(view: UIView, onBottomOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint {
+    open static func put(view: UIView, onBottomOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint {
         return checkContraintActivation(NSLayoutConstraint(
             item: view,
             attribute: .top,
@@ -121,7 +121,7 @@ class PXLayout: NSObject {
         ))
     }
     //Vista 1 abajo de la ultima vista
-    static func put(view: UIView, onBottomOfLastViewOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint? {
+    open static func put(view: UIView, onBottomOfLastViewOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint? {
         if !view2.subviews.contains(view) {
             return nil
         }
@@ -132,7 +132,7 @@ class PXLayout: NSObject {
     }
 
     //Vista 1 arriba de vista 2
-    static func put(view: UIView, aboveOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint {
+    open static func put(view: UIView, aboveOf view2: UIView, withMargin margin: CGFloat = 0) -> NSLayoutConstraint {
         return checkContraintActivation(NSLayoutConstraint(
             item: view,
             attribute: .bottom,
@@ -145,7 +145,7 @@ class PXLayout: NSObject {
     }
 
     //Centrado horizontal
-    static func centerHorizontally(view: UIView, to container: UIView? = nil) -> NSLayoutConstraint {
+    open static func centerHorizontally(view: UIView, to container: UIView? = nil) -> NSLayoutConstraint {
         var superView: UIView!
         if container == nil {
             superView = view.superview
@@ -156,7 +156,7 @@ class PXLayout: NSObject {
     }
 
     //Centrado Vertical
-    static func centerVertically(view: UIView, to container: UIView? = nil) -> NSLayoutConstraint {
+    open static func centerVertically(view: UIView, to container: UIView? = nil) -> NSLayoutConstraint {
         var superView: UIView!
         if container == nil {
             superView = view.superview
@@ -166,7 +166,7 @@ class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: NSLayoutAttribute.centerY, relatedBy: NSLayoutRelation.equal, toItem: superView, attribute: NSLayoutAttribute.centerY, multiplier: 1.0, constant: 0))
     }
 
-    static func matchWidth(ofView view: UIView, toView otherView: UIView? = nil, withPercentage percent: CGFloat = 100) -> NSLayoutConstraint {
+    open static func matchWidth(ofView view: UIView, toView otherView: UIView? = nil, withPercentage percent: CGFloat = 100) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -176,7 +176,7 @@ class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: NSLayoutAttribute.width, relatedBy: NSLayoutRelation.equal, toItem: superView, attribute: NSLayoutAttribute.width, multiplier: percent / 100, constant: 0))
     }
 
-    static func matchHeight(ofView view: UIView, toView otherView: UIView? = nil, withPercentage percent: CGFloat = 100) -> NSLayoutConstraint {
+    open static func matchHeight(ofView view: UIView, toView otherView: UIView? = nil, withPercentage percent: CGFloat = 100) -> NSLayoutConstraint {
         var superView: UIView!
         if otherView == nil {
             superView = view.superview
@@ -186,13 +186,13 @@ class PXLayout: NSObject {
         return checkContraintActivation(NSLayoutConstraint(item: view, attribute: NSLayoutAttribute.height, relatedBy: NSLayoutRelation.equal, toItem: superView, attribute: NSLayoutAttribute.height, multiplier: percent / 100, constant: 0))
     }
 
-    static func getScreenWidth(applyingMarginFactor percent: CGFloat = 100) -> CGFloat {
+    open static func getScreenWidth(applyingMarginFactor percent: CGFloat = 100) -> CGFloat {
         let screenSize = UIScreen.main.bounds
         let availableWidth = screenSize.width * percent / 100
         return availableWidth
     }
 
-    static func getScreenHeight(applyingMarginFactor percent: CGFloat = 100) -> CGFloat {
+    open static func getScreenHeight(applyingMarginFactor percent: CGFloat = 100) -> CGFloat {
         let screenSize = UIScreen.main.bounds
         let availableHeight = screenSize.height * percent / 100
         return availableHeight
@@ -201,7 +201,7 @@ class PXLayout: NSObject {
 }
 
 extension PXLayout {
-    static func getSafeAreaBottomInset() -> CGFloat {
+    open static func getSafeAreaBottomInset() -> CGFloat {
         // iPhoneX or any device with safe area inset > 0
         var bottomDeltaMargin: CGFloat = 0
         if #available(iOS 11.0, *) {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		156526C9209F76E600852D39 /* CustomComponentText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156526C8209F76E600852D39 /* CustomComponentText.swift */; };
 		15AF42AA1D36848100E70343 /* MercadoPagoSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76EF7EFB1D255AA10087C785 /* MercadoPagoSDK.framework */; };
 		15AF42AB1D36848100E70343 /* MercadoPagoSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 76EF7EFB1D255AA10087C785 /* MercadoPagoSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		15C84A981D2D531E002E4988 /* MediosOffTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 15C84A971D2D531E002E4988 /* MediosOffTableViewController.m */; };
@@ -97,6 +98,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		156526C8209F76E600852D39 /* CustomComponentText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomComponentText.swift; sourceTree = "<group>"; };
 		15C84A961D2D531E002E4988 /* MediosOffTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediosOffTableViewController.h; sourceTree = "<group>"; };
 		15C84A971D2D531E002E4988 /* MediosOffTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MediosOffTableViewController.m; sourceTree = "<group>"; };
 		23346C2E1FE83733005FD8C9 /* PaymentPluginViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PaymentPluginViewController.m; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 				23346C301FE83734005FD8C9 /* PaymentMethodPlugins.storyboard */,
 				23346C331FE83734005FD8C9 /* PaymentPluginViewController.h */,
 				23346C2E1FE83733005FD8C9 /* PaymentPluginViewController.m */,
+				156526C8209F76E600852D39 /* CustomComponentText.swift */,
 			);
 			name = PaymentMethodPlugins;
 			sourceTree = "<group>";
@@ -618,6 +621,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				76EF7EC51D2559140087C785 /* AppDelegate.m in Sources */,
+				156526C9209F76E600852D39 /* CustomComponentText.swift in Sources */,
 				767D8DBC1E5541EC0004FCA9 /* CustomItemTableViewCell.m in Sources */,
 				766627571D2AFDF9002EB903 /* SavedCardsTableViewController.m in Sources */,
 				4B7D07DB1E55324700E6CA78 /* SubeTableViewCell.m in Sources */,

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomComponentText.swift
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomComponentText.swift
@@ -1,0 +1,35 @@
+//
+//  CustomComponentText.swift
+//  MercadoPagoSDKExamplesObjectiveC
+//
+//  Created by Demian Tejo on 6/5/18.
+//  Copyright © 2018 MercadoPago. All rights reserved.
+//
+
+import UIKit
+import MercadoPagoSDK
+
+@objc class CustomComponentText: NSObject, PXComponentizable {
+    let HEIGHT : CGFloat = 80.0
+    func render() -> UIView {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let screenSize = UIScreen.main.bounds
+        PXLayout.setWidth(owner: view, width: screenSize.width).isActive = true
+        PXLayout.setHeight(owner: view, height: 80).isActive = true
+        let textLabel = UILabel()
+        textLabel.lineBreakMode = .byWordWrapping
+        textLabel.numberOfLines = 0
+        textLabel.textAlignment = .center
+        textLabel.text = "Sumaste 150 Km YPF Serviclub con tu carga. ¡Ya tienes 2.500 km!"
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(textLabel)
+        PXLayout.matchHeight(ofView: textLabel,toView: view, withPercentage: 80).isActive = true
+        PXLayout.matchWidth(ofView: textLabel,toView: view, withPercentage: 90).isActive = true
+        PXLayout.centerVertically(view: textLabel).isActive = true
+        PXLayout.centerHorizontally(view: textLabel).isActive = true
+        return view
+    }
+    
+
+}

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomComponentText.swift
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/CustomComponentText.swift
@@ -15,8 +15,8 @@ import MercadoPagoSDK
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         let screenSize = UIScreen.main.bounds
-        PXLayout.setWidth(owner: view, width: screenSize.width).isActive = true
-        PXLayout.setHeight(owner: view, height: 80).isActive = true
+        NSLayoutConstraint(item: view, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: screenSize.width).isActive = true
+        NSLayoutConstraint(item: view, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 80).isActive = true
         let textLabel = UILabel()
         textLabel.lineBreakMode = .byWordWrapping
         textLabel.numberOfLines = 0
@@ -24,10 +24,10 @@ import MercadoPagoSDK
         textLabel.text = "Sumaste 150 Km YPF Serviclub con tu carga. ¡Ya tienes 2.500 km!"
         textLabel.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(textLabel)
-        PXLayout.matchHeight(ofView: textLabel,toView: view, withPercentage: 80).isActive = true
-        PXLayout.matchWidth(ofView: textLabel,toView: view, withPercentage: 90).isActive = true
-        PXLayout.centerVertically(view: textLabel).isActive = true
-        PXLayout.centerHorizontally(view: textLabel).isActive = true
+        NSLayoutConstraint(item: textLabel, attribute: NSLayoutAttribute.width, relatedBy: NSLayoutRelation.equal, toItem: view, attribute: NSLayoutAttribute.width, multiplier: 80 / 100, constant: 0).isActive = true
+        NSLayoutConstraint(item: textLabel, attribute: NSLayoutAttribute.height, relatedBy: NSLayoutRelation.equal, toItem: view, attribute: NSLayoutAttribute.height, multiplier: 90 / 100, constant: 0).isActive = true
+        NSLayoutConstraint(item: textLabel, attribute: NSLayoutAttribute.centerX, relatedBy: NSLayoutRelation.equal, toItem: view, attribute: NSLayoutAttribute.centerX, multiplier: 1.0, constant: 0).isActive = true
+        NSLayoutConstraint(item: textLabel, attribute: NSLayoutAttribute.centerY, relatedBy: NSLayoutRelation.equal, toItem: view, attribute: NSLayoutAttribute.centerY, multiplier: 1.0, constant: 0).isActive = true
         return view
     }
     

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -106,7 +106,7 @@
     
     //[self setHooks];
     
-    //[self setPaymentMethodPlugins];
+    [self setPaymentMethodPlugins];
 
     [self setPaymentPlugin];
 
@@ -159,7 +159,7 @@
 
     //[self.mpCheckout setPaymentMethodPluginsWithPlugins:paymentMethodPlugins];
 
-   // [self.mpCheckout setPaymentPluginWithPaymentPlugin:makePaymentComponent];
+    [self.mpCheckout setPaymentPluginWithPaymentPlugin:makePaymentComponent];
 }
 
 -(void)setPaymentPlugin {
@@ -169,7 +169,7 @@
 
     PaymentPluginViewController *makePaymentComponent = [storyboard instantiateViewControllerWithIdentifier:@"paymentPlugin"];
 
-   // [self.mpCheckout setPaymentPluginWithPaymentPlugin:makePaymentComponent];
+    [self.mpCheckout setPaymentPluginWithPaymentPlugin:makePaymentComponent];
 }
 
 -(void)setPaymentResult {

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/PaymentPluginViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/PaymentPluginViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "PaymentPluginViewController.h"
+#import "MercadoPagoSDKExamplesObjectiveC-Swift.h"
 
 @interface PaymentPluginViewController ()
 
@@ -35,14 +36,15 @@
         
         [self.pluginNavigationHandler hideLoading];
         
-        PXComponentAction* popeame = [[PXComponentAction alloc] initWithLabel:@"Aceptar" action:^{
+        CustomComponentText* component = [[CustomComponentText alloc] init];
+        PXComponentAction* popeame = [[PXComponentAction alloc] initWithLabel:@"Continuar" action:^{
             [self.pluginNavigationHandler cancel];
        }];
         PXComponentAction* printeaEnConsola = [[PXComponentAction alloc] initWithLabel:@"Intentar nuevamente" action:^{
             NSLog(@"print !!! action!!");
         }];
         
-        PXBusinessResult* businessResult = [[PXBusinessResult alloc] initWithReceiptId:@"1879867544" status:PXBusinessResultStatusAPPROVED title:@"Sumaste 150 Km YPF Serviclub con tu carga" subtitle:nil icon:[UIImage imageNamed:@"ypf"] mainAction:nil secondaryAction:nil helpMessage:nil showPaymentMethod:YES statementDescription:nil imageUrl:@"https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/YPF.svg/2000px-YPF.svg.png"];
+        PXBusinessResult* businessResult = [[PXBusinessResult alloc] initWithReceiptId:@"1879867544" status:PXBusinessResultStatusAPPROVED title:@"¡Listo! Ya pagaste en YPF" subtitle:nil icon:[UIImage imageNamed:@"ypf"] mainAction:nil secondaryAction:nil helpMessage:nil showPaymentMethod:YES statementDescription:nil imageUrl:@"https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/YPF.svg/2000px-YPF.svg.png" topCustomView:[component render] bottomCustomView: nil];
         [self.pluginNavigationHandler didFinishPaymentWithBusinessResult:businessResult];
 
        // [self.pluginNavigationHandler didFinishPaymentWithPaymentStatus:RemotePaymentStatusAPPROVED statusDetails:@"" receiptId:nil];


### PR DESCRIPTION
- Se agrega la posibilidad de setear vistas custom a mostrar en la pantalla de resultado cuando el pago es un business result.
- Se agrega el ejemplo

![simulator screen shot - iphone se - 2018-05-06 at 15 25 41](https://user-images.githubusercontent.com/16452193/39676496-199cd880-5142-11e8-96e7-c93966fcb678.png)
![simulator screen shot - iphone se - 2018-05-06 at 15 25 48](https://user-images.githubusercontent.com/16452193/39676498-1c96283e-5142-11e8-9a8d-6c04f018064e.png)
