### PR TITLE
1) OneTap v2 / PaymentMethod fixes for descuentos - Item arrow changes

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/Item/PXOneTapItemRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/Item/PXOneTapItemRenderer.swift
@@ -92,7 +92,7 @@ final class PXOneTapItemRenderer {
                 PXLayout.setHeight(owner: arrow, height: PXLayout.XS_MARGIN).isActive = true
                 PXLayout.setWidth(owner: arrow, width: PXLayout.XXS_MARGIN).isActive = true
                 PXLayout.centerVertically(view: arrow, to: itemView.totalAmount).isActive = true
-                PXLayout.pinRight(view: arrow, withMargin: PXLayout.XXL_MARGIN).isActive = true
+                PXLayout.pinRight(view: arrow, withMargin: PXLayout.XL_MARGIN).isActive = true
             }
         }
         return itemView

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -71,8 +71,10 @@ extension PXOneTapViewController {
             contentView.addSubviewToBottom(itemView, withMargin: PXLayout.XXL_MARGIN)
             PXLayout.centerHorizontally(view: itemView).isActive = true
             PXLayout.matchWidth(ofView: itemView).isActive = true
-            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.shouldOpenSummary))
-            itemView.addGestureRecognizer(tapGesture)
+            if viewModel.shouldShowSummaryModal() {
+                let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.shouldOpenSummary))
+                itemView.addGestureRecognizer(tapGesture)
+            }
         }
 
         // Add payment method.

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+ItemComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+ItemComponent.swift
@@ -10,8 +10,7 @@ import Foundation
 extension PXOneTapViewModel {
 
     func getItemComponent() -> PXOneTapItemComponent? {
-
-        let props = PXOneTapItemComponentProps(title: getIconTitle(), collectorImage: getCollectorIcon(), numberOfInstallments: getNumberOfInstallmentsForItem(), installmentAmount: getInstallmentAmountForItem(), totalWithoutDiscount: getAmountWithoutDiscount(), discountDescription: getDiscountDescription(), discountLimit: getDiscountLimit())
+        let props = PXOneTapItemComponentProps(title: getIconTitle(), collectorImage: getCollectorIcon(), numberOfInstallments: getNumberOfInstallmentsForItem(), installmentAmount: getInstallmentAmountForItem(), totalWithoutDiscount: getAmountWithoutDiscount(), discountDescription: getDiscountDescription(), discountLimit: getDiscountLimit(), shouldShowArrow: shouldShowSummaryModal())
         return PXOneTapItemComponent(props: props)
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
@@ -36,3 +36,10 @@ final class PXOneTapViewModel: PXReviewViewModel {
         MPXTracker.sharedInstance.trackScreen(screenId: screenId, screenName: screenName, properties: properties)
     }
 }
+
+extension PXOneTapViewModel {
+    func shouldShowSummaryModal() -> Bool {
+        let summaryModel = getSummaryViewModel(amount: preference.getAmount())
+        return summaryModel.details.count > 1
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer+OneTap.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer+OneTap.swift
@@ -77,33 +77,33 @@ extension PXPaymentMethodComponentRenderer {
             PXLayout.pinRight(view: arrowImageView, withMargin: PXLayout.S_MARGIN).isActive = true
         }
 
-        // No interest label.
-        if let noInterestAttr = component.props.descriptionTitle, let subtitleLabel = pmView.paymentMethodSubtitle {
-            let noInterestLabel = UILabel()
-            noInterestLabel.translatesAutoresizingMaskIntoConstraints = false
-            pmView.addSubview(noInterestLabel)
-            noInterestLabel.attributedText = noInterestAttr
-            noInterestLabel.font = Utils.getFont(size: PXLayout.XXS_FONT)
-            noInterestLabel.textColor = ThemeManager.shared.noTaxAndDiscountLabelTintColor()
-            noInterestLabel.textAlignment = .left
-            PXLayout.setHeight(owner: noInterestLabel, height: PXLayout.M_FONT).isActive = true
-            PXLayout.centerVertically(view: noInterestLabel, to: subtitleLabel).isActive = true
-            PXLayout.put(view: noInterestLabel, rightOf: subtitleLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
+        // Right label description
+        if let rightAttr = component.props.descriptionTitle, let subtitleLabel = pmView.paymentMethodSubtitle {
+            let rightAttrLabel = UILabel()
+            rightAttrLabel.translatesAutoresizingMaskIntoConstraints = false
+            pmView.addSubview(rightAttrLabel)
+            rightAttrLabel.attributedText = rightAttr
+            rightAttrLabel.font = Utils.getFont(size: PXLayout.XXS_FONT)
+            rightAttrLabel.textColor = component.props.lightLabelColor
+            rightAttrLabel.textAlignment = .left
+            PXLayout.setHeight(owner: rightAttrLabel, height: PXLayout.M_FONT).isActive = true
+            PXLayout.centerVertically(view: rightAttrLabel, to: subtitleLabel).isActive = true
+            PXLayout.put(view: rightAttrLabel, rightOf: subtitleLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
+        }
 
-            // CFT label.
-            if let cftAttr = component.props.descriptionDetail {
-                let cftLabel = UILabel()
-                cftLabel.translatesAutoresizingMaskIntoConstraints = false
-                pmView.addSubview(cftLabel)
-                cftLabel.attributedText = cftAttr
-                cftLabel.font = Utils.getFont(size: PXLayout.M_FONT)
-                cftLabel.textColor = cftColor
-                cftLabel.textAlignment = .left
-                PXLayout.setHeight(owner: cftLabel, height: PXLayout.M_FONT).isActive = true
-                PXLayout.pinLeft(view: cftLabel, to: subtitleLabel, withMargin: 0).isActive = true
-                PXLayout.pinBottom(view: cftLabel, to: pmView, withMargin: PXLayout.S_MARGIN).isActive = true
-                defaultHeight += PXLayout.M_MARGIN
-            }
+        // CFT label.
+        if let subtitleLabel = pmView.paymentMethodSubtitle, let cftAttr = component.props.descriptionDetail {
+            let cftLabel = UILabel()
+            cftLabel.translatesAutoresizingMaskIntoConstraints = false
+            pmView.addSubview(cftLabel)
+            cftLabel.attributedText = cftAttr
+            cftLabel.font = Utils.getFont(size: PXLayout.M_FONT)
+            cftLabel.textColor = cftColor
+            cftLabel.textAlignment = .left
+            PXLayout.setHeight(owner: cftLabel, height: PXLayout.M_FONT).isActive = true
+            PXLayout.pinLeft(view: cftLabel, to: subtitleLabel, withMargin: 0).isActive = true
+            PXLayout.pinBottom(view: cftLabel, to: pmView, withMargin: PXLayout.S_MARGIN).isActive = true
+            defaultHeight += PXLayout.M_MARGIN
         }
 
         // Bordered line color.


### PR DESCRIPTION
- Fix para adaptar payment method component de onetap a descuentos UI
- Se arregla el margen derecho del arrow de payment method one tap
- Se utiliza un nuevo metodo de viewModel que indica si hay que mostrar summary o no. En funcion de eso se hace tapeable o no el item component y se muestra/oculta su arrow. @edentorres 