### PR TITLE
2) OneTap v2 / Summary Modal

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/Item/PXOneTapItemRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/Item/PXOneTapItemRenderer.swift
@@ -92,7 +92,7 @@ final class PXOneTapItemRenderer {
                 PXLayout.setHeight(owner: arrow, height: PXLayout.XS_MARGIN).isActive = true
                 PXLayout.setWidth(owner: arrow, width: PXLayout.XXS_MARGIN).isActive = true
                 PXLayout.centerVertically(view: arrow, to: itemView.totalAmount).isActive = true
-                PXLayout.pinRight(view: arrow, withMargin: PXLayout.XXL_MARGIN).isActive = true
+                PXLayout.pinRight(view: arrow, withMargin: PXLayout.XL_MARGIN).isActive = true
             }
         }
         return itemView

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapSummaryModalViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapSummaryModalViewController.swift
@@ -18,18 +18,34 @@ final class PXOneTapSummaryModalViewController: UIViewController {
         setupView()
     }
 
-    func setProps(summaryProps: [PXSummaryRowProps]?, bottomCustomView:UIView?) {
+    func setProps(summaryProps: [PXSummaryRowProps]?, bottomCustomView: UIView?) {
         props = summaryProps
         customView = bottomCustomView
     }
 
     func setupView() {
         if let summaryProps = props, let smallSummaryView = PXSmallSummaryView(withProps: summaryProps, backgroundColor: .white).oneTapRender() as? PXSmallSummaryView {
-            view.addSubview(smallSummaryView)
-            PXLayout.pinTop(view: smallSummaryView).isActive = true
-            PXLayout.pinBottom(view: smallSummaryView).isActive = true
-            PXLayout.pinLeft(view: smallSummaryView).isActive = true
-            PXLayout.pinRight(view: smallSummaryView).isActive = true
+
+            if let cView = customView {
+                view.addSubview(smallSummaryView)
+                PXLayout.pinTop(view: smallSummaryView).isActive = true
+                PXLayout.pinLeft(view: smallSummaryView).isActive = true
+                PXLayout.pinRight(view: smallSummaryView).isActive = true
+
+                view.addSubview(cView)
+                PXLayout.pinLeft(view: cView).isActive = true
+                PXLayout.pinRight(view: cView).isActive = true
+                PXLayout.pinBottom(view: cView).isActive = true
+                PXLayout.put(view: cView, onBottomOf: smallSummaryView).isActive = true
+                cView.layoutIfNeeded()
+                PXLayout.setHeight(owner: cView, height: cView.frame.height).isActive = true
+            } else {
+                view.addSubview(smallSummaryView)
+                PXLayout.pinTop(view: smallSummaryView).isActive = true
+                PXLayout.pinBottom(view: smallSummaryView).isActive = true
+                PXLayout.pinLeft(view: smallSummaryView).isActive = true
+                PXLayout.pinRight(view: smallSummaryView).isActive = true
+            }
         }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapSummaryModalViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapSummaryModalViewController.swift
@@ -23,7 +23,7 @@ final class PXOneTapSummaryModalViewController: UIViewController {
         customView = bottomCustomView
     }
 
-    func setupView() {
+    private func setupView() {
         if let summaryProps = props, let smallSummaryView = PXSmallSummaryView(withProps: summaryProps, backgroundColor: .white).oneTapRender() as? PXSmallSummaryView {
 
             if let cView = customView {
@@ -45,6 +45,16 @@ final class PXOneTapSummaryModalViewController: UIViewController {
                 PXLayout.pinBottom(view: smallSummaryView).isActive = true
                 PXLayout.pinLeft(view: smallSummaryView).isActive = true
                 PXLayout.pinRight(view: smallSummaryView).isActive = true
+            }
+        } else {
+            if let cView = customView {
+                view.addSubview(cView)
+                PXLayout.pinTop(view: cView).isActive = true
+                PXLayout.pinLeft(view: cView).isActive = true
+                PXLayout.pinRight(view: cView).isActive = true
+                PXLayout.pinBottom(view: cView).isActive = true
+                cView.layoutIfNeeded()
+                PXLayout.setHeight(owner: cView, height: cView.frame.height).isActive = true
             }
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapSummaryModalViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapSummaryModalViewController.swift
@@ -11,14 +11,16 @@ import UIKit
 final class PXOneTapSummaryModalViewController: UIViewController {
 
     private var props: [PXSummaryRowProps]?
+    private var customView: UIView?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupView()
     }
 
-    func setProps(summaryProps: [PXSummaryRowProps]?) {
+    func setProps(summaryProps: [PXSummaryRowProps]?, bottomCustomView:UIView?) {
         props = summaryProps
+        customView = bottomCustomView
     }
 
     func setupView() {

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -128,8 +128,9 @@ extension PXOneTapViewController {
     @objc func shouldOpenSummary() {
         if let summaryProps = viewModel.getSummaryProps(), summaryProps.count > 0 {
             let summaryViewController = PXOneTapSummaryModalViewController()
-            summaryViewController.setProps(summaryProps: viewModel.getSummaryProps())
-            PXComponentFactory.Modal.show(viewController: summaryViewController, title: nil)
+            summaryViewController.setProps(summaryProps: summaryProps)
+            //TODO: "Detalle" translation. Pedir a contenidos.
+            PXComponentFactory.Modal.show(viewController: summaryViewController, title: "Detalle".localized)
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -71,10 +71,8 @@ extension PXOneTapViewController {
             contentView.addSubviewToBottom(itemView, withMargin: PXLayout.XXL_MARGIN)
             PXLayout.centerHorizontally(view: itemView).isActive = true
             PXLayout.matchWidth(ofView: itemView).isActive = true
-            if viewModel.shouldShowSummaryModal() {
-                let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.shouldOpenSummary))
-                itemView.addGestureRecognizer(tapGesture)
-            }
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.shouldOpenSummary))
+            itemView.addGestureRecognizer(tapGesture)
         }
 
         // Add payment method.
@@ -123,8 +121,8 @@ extension PXOneTapViewController {
     }
 
     private func getDiscountDetailView() -> UIView? {
-        //TODO-(Nutria team): Make Discount detail view.
-        let discountDetailView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 400))
+        //TODO: (Nutria team) - Make Discount detail view.
+        let discountDetailView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 900))
         discountDetailView.backgroundColor = .red
         return discountDetailView
     }
@@ -133,16 +131,18 @@ extension PXOneTapViewController {
 // MARK: User Actions.
 extension PXOneTapViewController {
     @objc func shouldOpenSummary() {
-        if let summaryProps = viewModel.getSummaryProps(), summaryProps.count > 0 {
-            let summaryViewController = PXOneTapSummaryModalViewController()
-            summaryViewController.setProps(summaryProps: summaryProps, bottomCustomView: getDiscountDetailView())
-            //TODO: "Detalle" translation. Pedir a contenidos.
-            PXComponentFactory.Modal.show(viewController: summaryViewController, title: "Detalle".localized)
-        } else {
-            if let discountView = getDiscountDetailView() {
+        if viewModel.shouldShowSummaryModal() {
+            if let summaryProps = viewModel.getSummaryProps(), summaryProps.count > 0 {
                 let summaryViewController = PXOneTapSummaryModalViewController()
-                summaryViewController.setProps(summaryProps: nil, bottomCustomView: discountView)
-                PXComponentFactory.Modal.show(viewController: summaryViewController, title: nil)
+                summaryViewController.setProps(summaryProps: summaryProps, bottomCustomView: getDiscountDetailView())
+                //TODO: "Detalle" translation. Pedir a contenidos.
+                PXComponentFactory.Modal.show(viewController: summaryViewController, title: "Detalle".localized)
+            } else {
+                if let discountView = getDiscountDetailView() {
+                    let summaryViewController = PXOneTapSummaryModalViewController()
+                    summaryViewController.setProps(summaryProps: nil, bottomCustomView: discountView)
+                    PXComponentFactory.Modal.show(viewController: summaryViewController, title: nil)
+                }
             }
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -71,8 +71,10 @@ extension PXOneTapViewController {
             contentView.addSubviewToBottom(itemView, withMargin: PXLayout.XXL_MARGIN)
             PXLayout.centerHorizontally(view: itemView).isActive = true
             PXLayout.matchWidth(ofView: itemView).isActive = true
-            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.shouldOpenSummary))
-            itemView.addGestureRecognizer(tapGesture)
+            if viewModel.shouldShowSummaryModal() {
+                let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.shouldOpenSummary))
+                itemView.addGestureRecognizer(tapGesture)
+            }
         }
 
         // Add payment method.

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -121,6 +121,13 @@ extension PXOneTapViewController {
         let footerComponent = PXFooterComponent(props: footerProps)
         return footerComponent.oneTapRender()
     }
+
+    private func getDiscountDetailView() -> UIView? {
+        //TODO-(Nutria team): Make Discount detail view.
+        let discountDetailView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 400))
+        discountDetailView.backgroundColor = .red
+        return discountDetailView
+    }
 }
 
 // MARK: User Actions.
@@ -128,7 +135,7 @@ extension PXOneTapViewController {
     @objc func shouldOpenSummary() {
         if let summaryProps = viewModel.getSummaryProps(), summaryProps.count > 0 {
             let summaryViewController = PXOneTapSummaryModalViewController()
-            summaryViewController.setProps(summaryProps: summaryProps, bottomCustomView: nil)
+            summaryViewController.setProps(summaryProps: summaryProps, bottomCustomView: getDiscountDetailView())
             //TODO: "Detalle" translation. Pedir a contenidos.
             PXComponentFactory.Modal.show(viewController: summaryViewController, title: "Detalle".localized)
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -128,7 +128,7 @@ extension PXOneTapViewController {
     @objc func shouldOpenSummary() {
         if let summaryProps = viewModel.getSummaryProps(), summaryProps.count > 0 {
             let summaryViewController = PXOneTapSummaryModalViewController()
-            summaryViewController.setProps(summaryProps: summaryProps)
+            summaryViewController.setProps(summaryProps: summaryProps, bottomCustomView: nil)
             //TODO: "Detalle" translation. Pedir a contenidos.
             PXComponentFactory.Modal.show(viewController: summaryViewController, title: "Detalle".localized)
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -138,6 +138,12 @@ extension PXOneTapViewController {
             summaryViewController.setProps(summaryProps: summaryProps, bottomCustomView: getDiscountDetailView())
             //TODO: "Detalle" translation. Pedir a contenidos.
             PXComponentFactory.Modal.show(viewController: summaryViewController, title: "Detalle".localized)
+        } else {
+            if let discountView = getDiscountDetailView() {
+                let summaryViewController = PXOneTapSummaryModalViewController()
+                summaryViewController.setProps(summaryProps: nil, bottomCustomView: discountView)
+                PXComponentFactory.Modal.show(viewController: summaryViewController, title: nil)
+            }
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+ItemComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+ItemComponent.swift
@@ -10,8 +10,7 @@ import Foundation
 extension PXOneTapViewModel {
 
     func getItemComponent() -> PXOneTapItemComponent? {
-
-        let props = PXOneTapItemComponentProps(title: getIconTitle(), collectorImage: getCollectorIcon(), numberOfInstallments: getNumberOfInstallmentsForItem(), installmentAmount: getInstallmentAmountForItem(), totalWithoutDiscount: getAmountWithoutDiscount(), discountDescription: getDiscountDescription(), discountLimit: getDiscountLimit())
+        let props = PXOneTapItemComponentProps(title: getIconTitle(), collectorImage: getCollectorIcon(), numberOfInstallments: getNumberOfInstallmentsForItem(), installmentAmount: getInstallmentAmountForItem(), totalWithoutDiscount: getAmountWithoutDiscount(), discountDescription: getDiscountDescription(), discountLimit: getDiscountLimit(), shouldShowArrow: shouldShowSummaryModal())
         return PXOneTapItemComponent(props: props)
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+Summary.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+Summary.swift
@@ -9,8 +9,30 @@
 import Foundation
 
 extension PXOneTapViewModel {
-    //TODO: Align and check. Remove mocked data.
+    func shouldShowSummaryModal() -> Bool {
+        let summaryModel = getSummaryViewModel(amount: preference.getAmount())
+        return summaryModel.details.count > 1
+    }
+
     func getSummaryProps() -> [PXSummaryRowProps]? {
-        return [(title: "AySA", subTitle: "Factura agua", rightText: "$ 1200", backgroundColor: nil), (title: "Edenor", subTitle: "Pago de luz mensual", rightText: "$ 400", backgroundColor: nil)]
+        let currency: Currency = MercadoPagoContext.getCurrency()
+        let itemComponentsModel = buildItemComponents()
+
+        var props = [PXSummaryRowProps]()
+        for itemComponent in itemComponentsModel {
+            if let title = itemComponent.getTitle(), let amountPrice = itemComponent.getUnitAmountPrice() {
+
+                var totalAmount: Double = amountPrice
+                var titleWithQty = title
+                if let qty = itemComponent.props.quantity {
+                    titleWithQty = "\(qty) \(title)"
+                    totalAmount = amountPrice * Double(qty)
+                }
+
+                let formatedAmount = Utils.getAmountFormatted(amount: totalAmount, thousandSeparator: currency.getThousandsSeparatorOrDefault(), decimalSeparator: currency.getDecimalSeparatorOrDefault(), addingCurrencySymbol: currency.getCurrencySymbolOrDefault(), addingParenthesis: false)
+                props.append((title: titleWithQty, subTitle: itemComponent.getDescription(), rightText: formatedAmount, backgroundColor: nil))
+            }
+        }
+        return props
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+Summary.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+Summary.swift
@@ -10,8 +10,8 @@ import Foundation
 
 extension PXOneTapViewModel {
     func shouldShowSummaryModal() -> Bool {
-        let summaryModel = getSummaryViewModel(amount: preference.getAmount())
-        return summaryModel.details.count > 1
+        let itemsCount = buildItemComponents().count
+        return itemsCount > 0 || (MercadoPagoCheckoutViewModel.flowPreference.isDiscountEnable() && paymentData.discount != nil)
     }
 
     func getSummaryProps() -> [PXSummaryRowProps]? {

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
@@ -36,3 +36,10 @@ final class PXOneTapViewModel: PXReviewViewModel {
         MPXTracker.sharedInstance.trackScreen(screenId: screenId, screenName: screenName, properties: properties)
     }
 }
+
+extension PXOneTapViewModel {
+    func shouldShowSummaryModal() -> Bool {
+        let summaryModel = getSummaryViewModel(amount: preference.getAmount())
+        return summaryModel.details.count > 1
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
@@ -36,10 +36,3 @@ final class PXOneTapViewModel: PXReviewViewModel {
         MPXTracker.sharedInstance.trackScreen(screenId: screenId, screenName: screenName, properties: properties)
     }
 }
-
-extension PXOneTapViewModel {
-    func shouldShowSummaryModal() -> Bool {
-        let summaryModel = getSummaryViewModel(amount: preference.getAmount())
-        return summaryModel.details.count > 1
-    }
-}

--- a/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer+OneTap.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXPaymentMethodComponentRenderer+OneTap.swift
@@ -77,33 +77,33 @@ extension PXPaymentMethodComponentRenderer {
             PXLayout.pinRight(view: arrowImageView, withMargin: PXLayout.S_MARGIN).isActive = true
         }
 
-        // No interest label.
-        if let noInterestAttr = component.props.descriptionTitle, let subtitleLabel = pmView.paymentMethodSubtitle {
-            let noInterestLabel = UILabel()
-            noInterestLabel.translatesAutoresizingMaskIntoConstraints = false
-            pmView.addSubview(noInterestLabel)
-            noInterestLabel.attributedText = noInterestAttr
-            noInterestLabel.font = Utils.getFont(size: PXLayout.XXS_FONT)
-            noInterestLabel.textColor = ThemeManager.shared.noTaxAndDiscountLabelTintColor()
-            noInterestLabel.textAlignment = .left
-            PXLayout.setHeight(owner: noInterestLabel, height: PXLayout.M_FONT).isActive = true
-            PXLayout.centerVertically(view: noInterestLabel, to: subtitleLabel).isActive = true
-            PXLayout.put(view: noInterestLabel, rightOf: subtitleLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
+        // Right label description
+        if let rightAttr = component.props.descriptionTitle, let subtitleLabel = pmView.paymentMethodSubtitle {
+            let rightAttrLabel = UILabel()
+            rightAttrLabel.translatesAutoresizingMaskIntoConstraints = false
+            pmView.addSubview(rightAttrLabel)
+            rightAttrLabel.attributedText = rightAttr
+            rightAttrLabel.font = Utils.getFont(size: PXLayout.XXS_FONT)
+            rightAttrLabel.textColor = component.props.lightLabelColor
+            rightAttrLabel.textAlignment = .left
+            PXLayout.setHeight(owner: rightAttrLabel, height: PXLayout.M_FONT).isActive = true
+            PXLayout.centerVertically(view: rightAttrLabel, to: subtitleLabel).isActive = true
+            PXLayout.put(view: rightAttrLabel, rightOf: subtitleLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
+        }
 
-            // CFT label.
-            if let cftAttr = component.props.descriptionDetail {
-                let cftLabel = UILabel()
-                cftLabel.translatesAutoresizingMaskIntoConstraints = false
-                pmView.addSubview(cftLabel)
-                cftLabel.attributedText = cftAttr
-                cftLabel.font = Utils.getFont(size: PXLayout.M_FONT)
-                cftLabel.textColor = cftColor
-                cftLabel.textAlignment = .left
-                PXLayout.setHeight(owner: cftLabel, height: PXLayout.M_FONT).isActive = true
-                PXLayout.pinLeft(view: cftLabel, to: subtitleLabel, withMargin: 0).isActive = true
-                PXLayout.pinBottom(view: cftLabel, to: pmView, withMargin: PXLayout.S_MARGIN).isActive = true
-                defaultHeight += PXLayout.M_MARGIN
-            }
+        // CFT label.
+        if let subtitleLabel = pmView.paymentMethodSubtitle, let cftAttr = component.props.descriptionDetail {
+            let cftLabel = UILabel()
+            cftLabel.translatesAutoresizingMaskIntoConstraints = false
+            pmView.addSubview(cftLabel)
+            cftLabel.attributedText = cftAttr
+            cftLabel.font = Utils.getFont(size: PXLayout.M_FONT)
+            cftLabel.textColor = cftColor
+            cftLabel.textAlignment = .left
+            PXLayout.setHeight(owner: cftLabel, height: PXLayout.M_FONT).isActive = true
+            PXLayout.pinLeft(view: cftLabel, to: subtitleLabel, withMargin: 0).isActive = true
+            PXLayout.pinBottom(view: cftLabel, to: pmView, withMargin: PXLayout.S_MARGIN).isActive = true
+            defaultHeight += PXLayout.M_MARGIN
         }
 
         // Bordered line color.


### PR DESCRIPTION
- Se crea lógica especial para decidir si se muestra el modal o no
- El modal de summary muestra la lista de items con su amountUnitario*unidad y su description (Si corresponde)
- El modal de summary permite que se le inyecte una UIView en el bottom. Eso se utilizará en descuentos.
- La logica de si se muestra summary + view de descuentos o solo view de descuentos dentro del modal ya quedó resuelta. @augustocollerone Fijate que en PXOneTapViewController quedo una función que retorna una UIView llamada `getDiscountDetailView()`. Ahí deberias crear tu vista con la info de descuentos. Con retornar la view ya estaría todo listo y se inyectaría automáticamente. (Con o sin summary segun corresponda automaticamente)
- Se corrige el margin del arrow de ItemComponent
- Se setea shouldShowArrow en el itemsprops a fin de ocultar o mostrar la arrow segun corresponda @edentorres  💃 
