### PR TITLE
Onetap/v2 Metricas

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDK/MercadoPagoSDK.xcodeproj/project.pbxproj
@@ -456,7 +456,7 @@
 		53EB434E1F601D09009510BC /* AvailableCardsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EB434D1F601D09009510BC /* AvailableCardsViewModelTests.swift */; };
 		554BD3642062BEC700F6C631 /* MPCustomRowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554BD3632062BEC700F6C631 /* MPCustomRowDelegate.swift */; };
 		554BD3652062C08B00F6C631 /* MPCustomRowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554BD3632062BEC700F6C631 /* MPCustomRowDelegate.swift */; };
-		560A9120879F97A96BBF4C43 /* Pods_MercadoPagoSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0216F960B6A1E5A242690BB /* Pods_MercadoPagoSDKTests.framework */; };
+		65EE9B5283D874C05817A88A /* Pods_MercadoPagoSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A0EB046900059FD16D38D80C /* Pods_MercadoPagoSDKTests.framework */; };
 		76062BC41C4D1EFD0067A14B /* PaymentMethodSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76062BC31C4D1EFD0067A14B /* PaymentMethodSearch.swift */; };
 		76062BC51C4D1EFD0067A14B /* PaymentMethodSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76062BC31C4D1EFD0067A14B /* PaymentMethodSearch.swift */; };
 		76062BC71C4D1F220067A14B /* PaymentMethodSearchItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76062BC61C4D1F220067A14B /* PaymentMethodSearchItem.swift */; };
@@ -852,7 +852,6 @@
 		0F9883B91AD2AD1600F750F0 /* UIColor+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Additions.swift"; sourceTree = "<group>"; };
 		0FC4FC171B0FAA6400CF7148 /* BankDeal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BankDeal.swift; sourceTree = "<group>"; };
 		0FE3E37E1AE706B600C27B97 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
-		112DFA7AE739D3CE4FC48730 /* Pods-MercadoPagoSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKTests/Pods-MercadoPagoSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		150786A21CD7CD1E0034C5B1 /* IdentificationCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentificationCardView.swift; sourceTree = "<group>"; };
 		150786A51CD7CD340034C5B1 /* IdentificationCardView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IdentificationCardView.xib; sourceTree = "<group>"; };
 		150E4BFD1FB37FD300773565 /* PXComponentContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXComponentContainerViewController.swift; sourceTree = "<group>"; };
@@ -956,7 +955,6 @@
 		23E306462049B36E003E4FB0 /* PXSummaryCompactComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXSummaryCompactComponentView.swift; sourceTree = "<group>"; };
 		23ECADC41EF1C7CC003E4539 /* ApiUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiUtil.swift; sourceTree = "<group>"; };
 		23F5FEE6205078A9005382E9 /* PXCFTComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXCFTComponentView.swift; sourceTree = "<group>"; };
-		29A31F5E69396F6C1E180640 /* Pods-MercadoPagoSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKTests/Pods-MercadoPagoSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4B08AC8420AC6E62008AF845 /* PXOneTapItemComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXOneTapItemComponent.swift; sourceTree = "<group>"; };
 		4B08AC8720AC6E7D008AF845 /* PXOneTapItemRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXOneTapItemRenderer.swift; sourceTree = "<group>"; };
 		4B08AC8A20AC6EA5008AF845 /* PXOneTapItemComponentProps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXOneTapItemComponentProps.swift; sourceTree = "<group>"; };
@@ -1071,7 +1069,8 @@
 		537CA8AE1F4F22D200C10006 /* MPCardFormToolbarLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPCardFormToolbarLabel.swift; sourceTree = "<group>"; };
 		53EB434D1F601D09009510BC /* AvailableCardsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvailableCardsViewModelTests.swift; sourceTree = "<group>"; };
 		554BD3632062BEC700F6C631 /* MPCustomRowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPCustomRowDelegate.swift; sourceTree = "<group>"; };
-		64D8A564ECDD7A384CA2B1E5 /* Pods-MercadoPagoSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDK.release.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK.release.xcconfig"; sourceTree = "<group>"; };
+		57A89C38D20A736E3FA1D55B /* Pods-MercadoPagoSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKTests/Pods-MercadoPagoSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
+		636ED555EEC4DD28BE7D2163 /* Pods_MercadoPagoSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		76062BC31C4D1EFD0067A14B /* PaymentMethodSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodSearch.swift; sourceTree = "<group>"; };
 		76062BC61C4D1F220067A14B /* PaymentMethodSearchItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodSearchItem.swift; sourceTree = "<group>"; };
 		76062BD51C4D20C30067A14B /* PaymentVaultViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentVaultViewController.swift; sourceTree = "<group>"; };
@@ -1177,11 +1176,13 @@
 		81ACC8121F9A6A4700206F7B /* PXResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXResultViewModel.swift; sourceTree = "<group>"; };
 		81F090E020177EDA008A69C1 /* PXContainedActionButtonComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXContainedActionButtonComponent.swift; sourceTree = "<group>"; };
 		81F090E3201784BE008A69C1 /* PXContainedActionButtonRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXContainedActionButtonRenderer.swift; sourceTree = "<group>"; };
-		B77D51BCE93451B587DD0695 /* Pods_MercadoPagoSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A0EB046900059FD16D38D80C /* Pods_MercadoPagoSDKTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDKTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B080D29E5A662590F0A114C4 /* Pods-MercadoPagoSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKTests/Pods-MercadoPagoSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		C5D27F441EEF155500768C1C /* PaymentVaultViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentVaultViewModel.swift; sourceTree = "<group>"; };
 		CC8AA14F1DC5612300503910 /* UILabel+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UILabel+Additions.swift"; sourceTree = "<group>"; };
 		CCDD005C1DC52E4100858CF8 /* PaymentMethodSearch.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PaymentMethodSearch.plist; sourceTree = "<group>"; };
-		F0216F960B6A1E5A242690BB /* Pods_MercadoPagoSDKTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDKTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2B794178DAA563921A24BEA /* Pods-MercadoPagoSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDK.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK.debug.xcconfig"; sourceTree = "<group>"; };
+		F8BF43379A337A5E9118E3A2 /* Pods-MercadoPagoSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDK.release.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK.release.xcconfig"; sourceTree = "<group>"; };
 		FC05808D20A5D90200BBECB8 /* PXBankDealCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXBankDealCollectionCell.swift; sourceTree = "<group>"; };
 		FC0F6CBB20179A01006E3EA1 /* PXContainedLabelComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXContainedLabelComponent.swift; sourceTree = "<group>"; };
 		FC0F6CBD20179A08006E3EA1 /* PXContainedLabelRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXContainedLabelRenderer.swift; sourceTree = "<group>"; };
@@ -1194,7 +1195,6 @@
 		FC2A09531FEC3EF2009EFDB0 /* PXPaymentMethodIconComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXPaymentMethodIconComponent.swift; sourceTree = "<group>"; };
 		FC2A09561FEC3F0B009EFDB0 /* PXPaymentMethodIconRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXPaymentMethodIconRenderer.swift; sourceTree = "<group>"; };
 		FC2E9B9720A5EB2300D43B1E /* PXUIImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXUIImageView.swift; sourceTree = "<group>"; };
-		FC38D6B600436DD89A757C8C /* Pods-MercadoPagoSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDK.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK.debug.xcconfig"; sourceTree = "<group>"; };
 		FC3918B5208E1A2900B75366 /* PXBankDealsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXBankDealsViewModel.swift; sourceTree = "<group>"; };
 		FC3FC8411FBCC00000CF29E1 /* PXInstructionsComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXInstructionsComponent.swift; sourceTree = "<group>"; };
 		FC3FC8441FBCC1B800CF29E1 /* PXInstructionsRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PXInstructionsRenderer.swift; sourceTree = "<group>"; };
@@ -1284,7 +1284,7 @@
 				4B6954AF20A3687200CCF735 /* MercadoPagoServices.framework in Frameworks */,
 				4B6954AD20A3678600CCF735 /* MLUI.framework in Frameworks */,
 				4B0E72AA1FA8F9E8006A3853 /* MercadoPagoPXTracking.framework in Frameworks */,
-				560A9120879F97A96BBF4C43 /* Pods_MercadoPagoSDKTests.framework in Frameworks */,
+				65EE9B5283D874C05817A88A /* Pods_MercadoPagoSDKTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1299,7 +1299,7 @@
 				0F9883191AD2A97A00F750F0 /* MercadoPagoSDKTests */,
 				0F98830B1AD2A97A00F750F0 /* Products */,
 				C21B34312E09C5D174785343 /* Frameworks */,
-				2C89D770094291F210089A21 /* Pods */,
+				4F2BF8AACC9E9DBBBAA08572 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1833,17 +1833,6 @@
 			name = CFT;
 			sourceTree = "<group>";
 		};
-		2C89D770094291F210089A21 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				FC38D6B600436DD89A757C8C /* Pods-MercadoPagoSDK.debug.xcconfig */,
-				64D8A564ECDD7A384CA2B1E5 /* Pods-MercadoPagoSDK.release.xcconfig */,
-				29A31F5E69396F6C1E180640 /* Pods-MercadoPagoSDKTests.debug.xcconfig */,
-				112DFA7AE739D3CE4FC48730 /* Pods-MercadoPagoSDKTests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		4B08AC9320AC9A4C008AF845 /* Item */ = {
 			isa = PBXGroup;
 			children = (
@@ -2040,6 +2029,17 @@
 				814139BD202A052700824A10 /* PXPluginConfigViewController.swift */,
 			);
 			path = PaymentMethodPlugins;
+			sourceTree = "<group>";
+		};
+		4F2BF8AACC9E9DBBBAA08572 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F2B794178DAA563921A24BEA /* Pods-MercadoPagoSDK.debug.xcconfig */,
+				F8BF43379A337A5E9118E3A2 /* Pods-MercadoPagoSDK.release.xcconfig */,
+				57A89C38D20A736E3FA1D55B /* Pods-MercadoPagoSDKTests.debug.xcconfig */,
+				B080D29E5A662590F0A114C4 /* Pods-MercadoPagoSDKTests.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 		5305BEF11F59A93C008EBFC7 /* Screens */ = {
@@ -2416,8 +2416,8 @@
 				4B5E77471FA8F78500D813AF /* MercadoPagoPXTracking.framework */,
 				4B5E77481FA8F78500D813AF /* MercadoPagoServices.framework */,
 				7622E32B1DF5EF8800490C4E /* Foundation.framework */,
-				B77D51BCE93451B587DD0695 /* Pods_MercadoPagoSDK.framework */,
-				F0216F960B6A1E5A242690BB /* Pods_MercadoPagoSDKTests.framework */,
+				636ED555EEC4DD28BE7D2163 /* Pods_MercadoPagoSDK.framework */,
+				A0EB046900059FD16D38D80C /* Pods_MercadoPagoSDKTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -2714,14 +2714,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0F9883201AD2A97A00F750F0 /* Build configuration list for PBXNativeTarget "MercadoPagoSDK" */;
 			buildPhases = (
-				B35B95575AE0BF0C1C3B175F /* [CP] Check Pods Manifest.lock */,
+				DDC226F793BC5B09452AED49 /* [CP] Check Pods Manifest.lock */,
 				0F9883051AD2A97A00F750F0 /* Sources */,
 				0F9883061AD2A97A00F750F0 /* Frameworks */,
 				0F9883071AD2A97A00F750F0 /* Headers */,
 				0F9883081AD2A97A00F750F0 /* Resources */,
 				157FAE9C1D1C161C00AB13B0 /* CopyFiles */,
 				4BCA62FA1EBA48D8006D8131 /* SwiftLint */,
-				ACEF8D2D217E2843B51FDDF9 /* [CP] Copy Pods Resources */,
+				DCBC7D1595DCCF8BE57DF082 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2736,13 +2736,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0F9883231AD2A97A00F750F0 /* Build configuration list for PBXNativeTarget "MercadoPagoSDKTests" */;
 			buildPhases = (
-				0F3B4885CBAADDBA1FDB6381 /* [CP] Check Pods Manifest.lock */,
+				57EB1EF18977A906515959A0 /* [CP] Check Pods Manifest.lock */,
 				0F9883111AD2A97A00F750F0 /* Sources */,
 				0F9883131AD2A97A00F750F0 /* Resources */,
 				0F9883121AD2A97A00F750F0 /* Frameworks */,
 				7622E33F1DF5F5F900490C4E /* Headers */,
-				F9B981AB0970D81D7672C6DD /* [CP] Embed Pods Frameworks */,
-				2B775A3C0B400B6D6541094D /* [CP] Copy Pods Resources */,
+				F3119976B9F69426997F43C0 /* [CP] Embed Pods Frameworks */,
+				BE9D6D4A6D0208117148AA90 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2895,7 +2895,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0F3B4885CBAADDBA1FDB6381 /* [CP] Check Pods Manifest.lock */ = {
+		4BCA62FA1EBA48D8006D8131 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\necho \"Swiftlint disabled\"\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		57EB1EF18977A906515959A0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2913,7 +2927,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2B775A3C0B400B6D6541094D /* [CP] Copy Pods Resources */ = {
+		BE9D6D4A6D0208117148AA90 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2928,21 +2942,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKTests/Pods-MercadoPagoSDKTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4BCA62FA1EBA48D8006D8131 /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\necho \"Swiftlint disabled\"\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
-		};
-		ACEF8D2D217E2843B51FDDF9 /* [CP] Copy Pods Resources */ = {
+		DCBC7D1595DCCF8BE57DF082 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2957,7 +2957,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDK/Pods-MercadoPagoSDK-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B35B95575AE0BF0C1C3B175F /* [CP] Check Pods Manifest.lock */ = {
+		DDC226F793BC5B09452AED49 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2975,7 +2975,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F9B981AB0970D81D7672C6DD /* [CP] Embed Pods Frameworks */ = {
+		F3119976B9F69426997F43C0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3879,7 +3879,7 @@
 		};
 		0F9883211AD2A97A00F750F0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FC38D6B600436DD89A757C8C /* Pods-MercadoPagoSDK.debug.xcconfig */;
+			baseConfigurationReference = F2B794178DAA563921A24BEA /* Pods-MercadoPagoSDK.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_MODULES = YES;
@@ -3917,7 +3917,7 @@
 		};
 		0F9883221AD2A97A00F750F0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 64D8A564ECDD7A384CA2B1E5 /* Pods-MercadoPagoSDK.release.xcconfig */;
+			baseConfigurationReference = F8BF43379A337A5E9118E3A2 /* Pods-MercadoPagoSDK.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_MODULES = YES;
@@ -3954,7 +3954,7 @@
 		};
 		0F9883241AD2A97A00F750F0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 29A31F5E69396F6C1E180640 /* Pods-MercadoPagoSDKTests.debug.xcconfig */;
+			baseConfigurationReference = 57A89C38D20A736E3FA1D55B /* Pods-MercadoPagoSDKTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
@@ -3984,7 +3984,7 @@
 		};
 		0F9883251AD2A97A00F750F0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 112DFA7AE739D3CE4FC48730 /* Pods-MercadoPagoSDKTests.release.xcconfig */;
+			baseConfigurationReference = B080D29E5A662590F0A114C4 /* Pods-MercadoPagoSDKTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -11,7 +11,7 @@ import MercadoPagoPXTracking
 
 final class PXOneTapViewController: PXComponentContainerViewController {
     // MARK: Tracking
-    override var screenName: String { return TrackingUtil.ScreenName.REVIEW_AND_CONFIRM_ONE_TAP }
+    override var screenName: String { return TrackingUtil.ScreenId.REVIEW_AND_CONFIRM_ONE_TAP }
     override var screenId: String { return TrackingUtil.ScreenId.REVIEW_AND_CONFIRM_ONE_TAP }
 
     // MARK: Definitions

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -11,8 +11,8 @@ import MercadoPagoPXTracking
 
 final class PXOneTapViewController: PXComponentContainerViewController {
     // MARK: Tracking
-    override var screenName: String { return TrackingUtil.SCREEN_NAME_REVIEW_AND_CONFIRM_ONE_TAP }
-    override var screenId: String { return TrackingUtil.SCREEN_ID_REVIEW_AND_CONFIRM_ONE_TAP }
+    override var screenName: String { return TrackingUtil.ScreenName.REVIEW_AND_CONFIRM_ONE_TAP }
+    override var screenId: String { return TrackingUtil.ScreenId.REVIEW_AND_CONFIRM_ONE_TAP }
 
     // MARK: Definitions
     lazy var itemViews = [UIView]()
@@ -135,6 +135,7 @@ extension PXOneTapViewController {
 // MARK: User Actions.
 extension PXOneTapViewController {
     @objc func shouldOpenSummary() {
+        viewModel.trackTapSummaryDetailEvent()
         if viewModel.shouldShowSummaryModal() {
             if let summaryProps = viewModel.getSummaryProps(), summaryProps.count > 0 {
                 let summaryViewController = PXOneTapSummaryModalViewController()

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewController.swift
@@ -43,6 +43,13 @@ final class PXOneTapViewController: PXComponentContainerViewController {
         setupUI()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if isMovingToParentViewController {
+            viewModel.trackTapBackEvent()
+        }
+    }
+
     override func trackInfo() {
         self.viewModel.trackInfo()
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+PaymentMethodComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+PaymentMethodComponent.swift
@@ -62,7 +62,7 @@ extension PXOneTapViewModel {
 
         // CFT.
         if let payerCost = paymentData.getPayerCost(), let cftValue = payerCost.getCFTValue(), payerCost.hasCFTValue() {
-            cftText = cftValue.toAttributedString()
+            cftText = "CFT: \(cftValue)".toAttributedString()
         }
 
         let props = PXPaymentMethodProps(paymentMethodIcon: image, title: title, subtitle: subtitle, descriptionTitle: subtitleRight, descriptionDetail: cftText, disclaimer: nil, action: nil, backgroundColor: backgroundColor, lightLabelColor: lightLabelColor, boldLabelColor: boldLabelColor)

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
@@ -12,12 +12,8 @@ import MercadoPagoPXTracking
 final class PXOneTapViewModel: PXReviewViewModel {
 
     // Tracking overrides.
-    override var screenName: String { return TrackingUtil.ScreenName.REVIEW_AND_CONFIRM_ONE_TAP }
+    override var screenName: String { return TrackingUtil.ScreenId.REVIEW_AND_CONFIRM_ONE_TAP }
     override var screenId: String { return TrackingUtil.ScreenId.REVIEW_AND_CONFIRM_ONE_TAP }
-
-    override func trackChangePaymentMethodEvent() {
-        MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_CHANGE_PAYMENT_METHOD, screenId: screenId, screenName: screenName)
-    }
 
     override func trackConfirmActionEvent() {
         //TODO: Ver si podemos negociar un evento de pagar mas descriptivo.
@@ -38,7 +34,7 @@ final class PXOneTapViewModel: PXReviewViewModel {
     }
 }
 
-//MARK: - Extra events
+// MARK: - Extra events
 extension PXOneTapViewModel {
     func trackTapSummaryDetailEvent() {
         MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_SUMMARY_DETAIL, screenId: screenId, screenName: screenName)
@@ -46,9 +42,5 @@ extension PXOneTapViewModel {
 
     func trackTapBackEvent() {
         MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_BACK, screenId: screenId, screenName: screenName)
-    }
-
-    func trackTapDiscountTermAndConditionEvent() {
-        MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_TC_DISCOUNT, screenId: screenId, screenName: screenName)
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
@@ -12,14 +12,15 @@ import MercadoPagoPXTracking
 final class PXOneTapViewModel: PXReviewViewModel {
 
     // Tracking overrides.
-    override var screenName: String { return TrackingUtil.SCREEN_NAME_REVIEW_AND_CONFIRM_ONE_TAP }
-    override var screenId: String { return TrackingUtil.SCREEN_ID_REVIEW_AND_CONFIRM_ONE_TAP }
+    override var screenName: String { return TrackingUtil.ScreenName.REVIEW_AND_CONFIRM_ONE_TAP }
+    override var screenId: String { return TrackingUtil.ScreenId.REVIEW_AND_CONFIRM_ONE_TAP }
 
     override func trackChangePaymentMethodEvent() {
-        MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.ACTION_ONE_TAP_CHANGE_PAYMENT_METHOD, screenId: screenId, screenName: screenName)
+        MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_CHANGE_PAYMENT_METHOD, screenId: screenId, screenName: screenName)
     }
 
     override func trackConfirmActionEvent() {
+        //TODO: Ver si podemos negociar un evento de pagar mas descriptivo.
         MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.ACTION_CHECKOUT_CONFIRMED, screenId: screenId, screenName: screenName)
     }
 
@@ -34,5 +35,20 @@ final class PXOneTapViewModel: PXReviewViewModel {
         }
 
         MPXTracker.sharedInstance.trackScreen(screenId: screenId, screenName: screenName, properties: properties)
+    }
+}
+
+//MARK: - Extra events
+extension PXOneTapViewModel {
+    func trackTapSummaryDetailEvent() {
+        MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_SUMMARY_DETAIL, screenId: screenId, screenName: screenName)
+    }
+
+    func trackTapBackEvent() {
+        MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_BACK, screenId: screenId, screenName: screenName)
+    }
+
+    func trackTapDiscountTermAndConditionEvent() {
+        MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_TC_DISCOUNT, screenId: screenId, screenName: screenName)
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
@@ -16,7 +16,6 @@ final class PXOneTapViewModel: PXReviewViewModel {
     override var screenId: String { return TrackingUtil.ScreenId.REVIEW_AND_CONFIRM_ONE_TAP }
 
     override func trackConfirmActionEvent() {
-        //TODO: Ver si podemos negociar un evento de pagar mas descriptivo.
         MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.ACTION_CHECKOUT_CONFIRMED, screenId: screenId, screenName: screenName)
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/PXTrackingUtil.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXTrackingUtil.swift
@@ -20,7 +20,7 @@ extension TrackingUtil {
 // MARK: - Events
 extension TrackingUtil {
     struct Event {
-        static let TAP_SUMMARY_DETAIL = "/open_summary_detail" //TODO: Ver con MeliData
-        static let TAP_BACK = "/back_action" //TODO: Ver con MeliData
+        static let TAP_SUMMARY_DETAIL = "/open_summary_detail"
+        static let TAP_BACK = "/back_action"
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXTrackingUtil.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXTrackingUtil.swift
@@ -9,13 +9,25 @@
 import Foundation
 import MercadoPagoPXTracking
 
+//MARK: - Screens
 extension TrackingUtil {
-    //Screen IDs
-    open static let SCREEN_ID_REVIEW_AND_CONFIRM_ONE_TAP = "/express"
+    //TODO: Revisar las screen id y name. (La semantica)
+    enum ScreenId {
+        static let REVIEW_AND_CONFIRM_ONE_TAP = "/express"
+    }
 
-    //Screen Names
-    open static let SCREEN_NAME_REVIEW_AND_CONFIRM_ONE_TAP = "ONE_TAP"
+    enum ScreenName {
+        static let REVIEW_AND_CONFIRM_ONE_TAP = "ONE_TAP"
+    }
+}
 
-    // MARK: Action events
-    open static let ACTION_ONE_TAP_CHANGE_PAYMENT_METHOD = "/one_tap_change"
+//MARK: - Events
+extension TrackingUtil {
+    struct Event {
+        //OLD: "/one_tap_change"
+        static let TAP_CHANGE_PAYMENT_METHOD = "TAP_CHANGE_PAYMENT_METHOD"
+        static let TAP_SUMMARY_DETAIL = "TAP_SUMMARY_DETAIL"
+        static let TAP_BACK = "TAP_BACK"
+        static let TAP_TC_DISCOUNT = "TAP_TC_DISCOUNT"
+    }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXTrackingUtil.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXTrackingUtil.swift
@@ -9,25 +9,18 @@
 import Foundation
 import MercadoPagoPXTracking
 
-//MARK: - Screens
+// MARK: - Screens
 extension TrackingUtil {
-    //TODO: Revisar las screen id y name. (La semantica)
     enum ScreenId {
         static let REVIEW_AND_CONFIRM_ONE_TAP = "/express"
-    }
-
-    enum ScreenName {
-        static let REVIEW_AND_CONFIRM_ONE_TAP = "ONE_TAP"
+        static let DISCOUNT_TERM_CONDITION = "/discount_terms_conditions"
     }
 }
 
-//MARK: - Events
+// MARK: - Events
 extension TrackingUtil {
     struct Event {
-        //OLD: "/one_tap_change"
-        static let TAP_CHANGE_PAYMENT_METHOD = "TAP_CHANGE_PAYMENT_METHOD"
-        static let TAP_SUMMARY_DETAIL = "TAP_SUMMARY_DETAIL"
-        static let TAP_BACK = "TAP_BACK"
-        static let TAP_TC_DISCOUNT = "TAP_TC_DISCOUNT"
+        static let TAP_SUMMARY_DETAIL = "/open_summary_detail" //TODO: Ver con MeliData
+        static let TAP_BACK = "/back_action" //TODO: Ver con MeliData
     }
 }

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC.xcodeproj/project.pbxproj
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		23346C361FE83734005FD8C9 /* PaymentMethodPluginConfigViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 23346C311FE83734005FD8C9 /* PaymentMethodPluginConfigViewController.m */; };
 		2385C5DA20125871002C147D /* MeliTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2385C5D920125871002C147D /* MeliTheme.swift */; };
 		23CF4ECE20994D1A00EC9399 /* MPTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CF4ECC20994D1A00EC9399 /* MPTheme.swift */; };
-		44B47CE6D75D67A020028F34 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C3C3095028EAB83AFC53F6A2 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework */; };
 		4B1A74F0209204B900E39587 /* MLMyMPPXTrackListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B1A74EF209204B900E39587 /* MLMyMPPXTrackListener.m */; };
 		4B34DC331E5DA33100FDD295 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EF7EC41D2559140087C785 /* AppDelegate.m */; };
 		4B7AA9801E55E64C000902B9 /* DineroEnCuentaTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B7AA97E1E55E64C000902B9 /* DineroEnCuentaTableViewCell.m */; };
@@ -29,6 +28,7 @@
 		4B811DF01FCDD49A000611AD /* FirstHookViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B811DEA1FCDD499000611AD /* FirstHookViewController.m */; };
 		4B811DF11FCDD49A000611AD /* ThirdHookViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B811DEC1FCDD49A000611AD /* ThirdHookViewController.m */; };
 		4B811DF21FCDD49A000611AD /* SecondHookViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B811DED1FCDD49A000611AD /* SecondHookViewController.m */; };
+		6E641A8422331A905EF2BE85 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42E6999264B84D5E0BBD8F43 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework */; };
 		763B44F91D2BFEB0002E2B39 /* SelectPaymentMethodTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 763B44F81D2BFEB0002E2B39 /* SelectPaymentMethodTableViewController.m */; };
 		763B45021D2C02DE002E2B39 /* InstallmentsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 763B45011D2C02DE002E2B39 /* InstallmentsTableViewController.m */; };
 		766627571D2AFDF9002EB903 /* SavedCardsTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 766627561D2AFDF9002EB903 /* SavedCardsTableViewController.m */; };
@@ -50,7 +50,7 @@
 		76EF7F601D2706720087C785 /* ServicesExamplesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EF7F5F1D2706720087C785 /* ServicesExamplesViewController.m */; };
 		81488CC11FE93E0C003C35B1 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81488CC01FE93E0C003C35B1 /* TestComponent.swift */; };
 		81488CC21FE94196003C35B1 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81488CC01FE93E0C003C35B1 /* TestComponent.swift */; };
-		A731D0704676ADB2DBFEC126 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00D828F2A3109C03A371E073 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework */; };
+		C95402EFD90BF1019402ABF4 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D64FB3DFDB811607746889A9 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,7 +99,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		00D828F2A3109C03A371E073 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDKExamplesObjectiveCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		156526C8209F76E600852D39 /* CustomComponentText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomComponentText.swift; sourceTree = "<group>"; };
 		15C84A961D2D531E002E4988 /* MediosOffTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediosOffTableViewController.h; sourceTree = "<group>"; };
 		15C84A971D2D531E002E4988 /* MediosOffTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MediosOffTableViewController.m; sourceTree = "<group>"; };
@@ -110,6 +109,8 @@
 		23346C331FE83734005FD8C9 /* PaymentPluginViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PaymentPluginViewController.h; sourceTree = "<group>"; };
 		2385C5D920125871002C147D /* MeliTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeliTheme.swift; sourceTree = "<group>"; };
 		23CF4ECC20994D1A00EC9399 /* MPTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPTheme.swift; sourceTree = "<group>"; };
+		2CC929EA2617FBCA3F0823A2 /* Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig"; sourceTree = "<group>"; };
+		42E6999264B84D5E0BBD8F43 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDKExamplesObjectiveC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B1A74EF209204B900E39587 /* MLMyMPPXTrackListener.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MLMyMPPXTrackListener.m; sourceTree = "<group>"; };
 		4B1A74F22092068700E39587 /* MLMyMPPXTrackListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MLMyMPPXTrackListener.h; sourceTree = "<group>"; };
 		4B7AA97D1E55E64C000902B9 /* DineroEnCuentaTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DineroEnCuentaTableViewCell.h; sourceTree = "<group>"; };
@@ -166,11 +167,10 @@
 		76EF7F5F1D2706720087C785 /* ServicesExamplesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ServicesExamplesViewController.m; sourceTree = "<group>"; };
 		81488CC01FE93E0C003C35B1 /* TestComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestComponent.swift; sourceTree = "<group>"; };
 		81760F3A1FD5981B00237A81 /* MercadoPagoPXTracking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MercadoPagoPXTracking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		876A6B39880B9E902E673C5A /* Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveCTests/Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig"; sourceTree = "<group>"; };
-		906F115BDEA14C93B5A8F138 /* Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig"; sourceTree = "<group>"; };
-		A13B357CCD6A4252392988A2 /* Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveCTests/Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig"; sourceTree = "<group>"; };
-		AB7D375A6E02AA79990EDDA7 /* Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig"; sourceTree = "<group>"; };
-		C3C3095028EAB83AFC53F6A2 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDKExamplesObjectiveC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A540E3D581F4E252388DF81A /* Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig"; sourceTree = "<group>"; };
+		A6D66A3D4B89DF94ADC09062 /* Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveCTests/Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig"; sourceTree = "<group>"; };
+		B085B81394B60A0315088156 /* Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveCTests/Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D64FB3DFDB811607746889A9 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MercadoPagoSDKExamplesObjectiveCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,7 +179,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				15AF42AA1D36848100E70343 /* MercadoPagoSDK.framework in Frameworks */,
-				44B47CE6D75D67A020028F34 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework in Frameworks */,
+				6E641A8422331A905EF2BE85 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -187,7 +187,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A731D0704676ADB2DBFEC126 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework in Frameworks */,
+				C95402EFD90BF1019402ABF4 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -220,8 +220,8 @@
 			isa = PBXGroup;
 			children = (
 				81760F3A1FD5981B00237A81 /* MercadoPagoPXTracking.framework */,
-				C3C3095028EAB83AFC53F6A2 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework */,
-				00D828F2A3109C03A371E073 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework */,
+				42E6999264B84D5E0BBD8F43 /* Pods_MercadoPagoSDKExamplesObjectiveC.framework */,
+				D64FB3DFDB811607746889A9 /* Pods_MercadoPagoSDKExamplesObjectiveCTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -280,7 +280,7 @@
 				76EF7EE41D2559140087C785 /* MercadoPagoSDKExamplesObjectiveCUITests */,
 				76EF7EBE1D2559140087C785 /* Products */,
 				250DBD73536A8A42B1E606E9 /* Frameworks */,
-				EDCDBFD2C4B5845A0D8AA762 /* Pods */,
+				F51DBAF7A40D9D9DC65C7FBD /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -366,13 +366,13 @@
 			name = "Component Examples";
 			sourceTree = "<group>";
 		};
-		EDCDBFD2C4B5845A0D8AA762 /* Pods */ = {
+		F51DBAF7A40D9D9DC65C7FBD /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				AB7D375A6E02AA79990EDDA7 /* Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig */,
-				906F115BDEA14C93B5A8F138 /* Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig */,
-				A13B357CCD6A4252392988A2 /* Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig */,
-				876A6B39880B9E902E673C5A /* Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig */,
+				A540E3D581F4E252388DF81A /* Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig */,
+				2CC929EA2617FBCA3F0823A2 /* Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig */,
+				B085B81394B60A0315088156 /* Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig */,
+				A6D66A3D4B89DF94ADC09062 /* Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -384,13 +384,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 76EF7EEA1D2559140087C785 /* Build configuration list for PBXNativeTarget "MercadoPagoSDKExamplesObjectiveC" */;
 			buildPhases = (
-				84BD4EE94891E0B5AD9D271D /* [CP] Check Pods Manifest.lock */,
+				47BCB3007C09351A9B9FB3FE /* [CP] Check Pods Manifest.lock */,
 				76EF7EB91D2559140087C785 /* Sources */,
 				76EF7EBA1D2559140087C785 /* Frameworks */,
 				76EF7EBB1D2559140087C785 /* Resources */,
 				15AF42AE1D36848100E70343 /* Embed Frameworks */,
-				8BE5CB1FB2CB0EA8BC7FB3C7 /* [CP] Embed Pods Frameworks */,
-				BCFB21BADC9673AC418B1D63 /* [CP] Copy Pods Resources */,
+				51B9DC865EED69E0DA3E3C67 /* [CP] Embed Pods Frameworks */,
+				5AEADA796BB7F04AD592DFDC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -406,12 +406,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 76EF7EED1D2559140087C785 /* Build configuration list for PBXNativeTarget "MercadoPagoSDKExamplesObjectiveCTests" */;
 			buildPhases = (
-				E5DC17066586D652484B63D3 /* [CP] Check Pods Manifest.lock */,
+				6C414C8DBCE663DF8AEBE8E9 /* [CP] Check Pods Manifest.lock */,
 				76EF7ED21D2559140087C785 /* Sources */,
 				76EF7ED31D2559140087C785 /* Frameworks */,
 				76EF7ED41D2559140087C785 /* Resources */,
-				2BFB3374AFB0AD520CCFC53C /* [CP] Embed Pods Frameworks */,
-				F6BED9433543E3083FBFDC30 /* [CP] Copy Pods Resources */,
+				AC5B7551CCAE3ADE15A5C718 /* [CP] Embed Pods Frameworks */,
+				5535C60C6E8727CBC390C8F7 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -513,22 +513,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2BFB3374AFB0AD520CCFC53C /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveCTests/Pods-MercadoPagoSDKExamplesObjectiveCTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		84BD4EE94891E0B5AD9D271D /* [CP] Check Pods Manifest.lock */ = {
+		47BCB3007C09351A9B9FB3FE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -546,7 +531,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8BE5CB1FB2CB0EA8BC7FB3C7 /* [CP] Embed Pods Frameworks */ = {
+		51B9DC865EED69E0DA3E3C67 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -572,7 +557,22 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BCFB21BADC9673AC418B1D63 /* [CP] Copy Pods Resources */ = {
+		5535C60C6E8727CBC390C8F7 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveCTests/Pods-MercadoPagoSDKExamplesObjectiveCTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5AEADA796BB7F04AD592DFDC /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -587,7 +587,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E5DC17066586D652484B63D3 /* [CP] Check Pods Manifest.lock */ = {
+		6C414C8DBCE663DF8AEBE8E9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -605,19 +605,19 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F6BED9433543E3083FBFDC30 /* [CP] Copy Pods Resources */ = {
+		AC5B7551CCAE3ADE15A5C718 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "[CP] Copy Pods Resources";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveCTests/Pods-MercadoPagoSDKExamplesObjectiveCTests-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveCTests/Pods-MercadoPagoSDKExamplesObjectiveCTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -795,7 +795,7 @@
 		};
 		76EF7EEB1D2559140087C785 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB7D375A6E02AA79990EDDA7 /* Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig */;
+			baseConfigurationReference = A540E3D581F4E252388DF81A /* Pods-MercadoPagoSDKExamplesObjectiveC.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -815,7 +815,7 @@
 		};
 		76EF7EEC1D2559140087C785 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 906F115BDEA14C93B5A8F138 /* Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig */;
+			baseConfigurationReference = 2CC929EA2617FBCA3F0823A2 /* Pods-MercadoPagoSDKExamplesObjectiveC.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -834,7 +834,7 @@
 		};
 		76EF7EEE1D2559140087C785 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A13B357CCD6A4252392988A2 /* Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig */;
+			baseConfigurationReference = B085B81394B60A0315088156 /* Pods-MercadoPagoSDKExamplesObjectiveCTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -848,7 +848,7 @@
 		};
 		76EF7EEF1D2559140087C785 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 876A6B39880B9E902E673C5A /* Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig */;
+			baseConfigurationReference = A6D66A3D4B89DF94ADC09062 /* Pods-MercadoPagoSDKExamplesObjectiveCTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";


### PR DESCRIPTION
- Aproveche y metí lo de CFT aca también. No hice nada raro. Repliqué lo que ya veniamos "manejando" en otras pantallas. La sigla CFT esta totalmente harcoded y descentralizada.
- Se crearon los nuevos eventos. 
- Se refactorizo muy minor el manejo nuestro desde el lado de la sdk de la extension de tracking util. Haciendo un poco mas descriptivo todo con structs que agrupan la semantica. De todas maneras tenemos una gran dauda pendiente historica ahi, de unificar el repo de tracking y todo lo que ya sabemos.
- Se ejecuta el track event desde el viewModel para cada evento nuevo correspondiente.

Queda implementar:
- Llamar desde el controller al tracking method del viewModel al hacer back.
- Cuando este la row de descuentos terms and conditions. Llamar a el evento correspondiente que ya esta como event en el viewmodel. Esto lo va a hacer @augustocollerone 
- Y por ultimo antes de mergear o correr esto, hacer un check con Mati y Andre sobre los nombres de los eventos.

