### PR TITLE
Add extra params for TAP_SUMMARY_DETAIL event

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+Summary.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+Summary.swift
@@ -11,7 +11,11 @@ import Foundation
 extension PXOneTapViewModel {
     func shouldShowSummaryModal() -> Bool {
         let itemsCount = buildItemComponents().count
-        return itemsCount > 0 || (MercadoPagoCheckoutViewModel.flowPreference.isDiscountEnable() && paymentData.discount != nil)
+        return itemsCount > 0 || hasDiscount()
+    }
+
+    func hasDiscount() -> Bool {
+        return MercadoPagoCheckoutViewModel.flowPreference.isDiscountEnable() && paymentData.discount != nil
     }
 
     func getSummaryProps() -> [PXSummaryRowProps]? {

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel.swift
@@ -36,7 +36,10 @@ final class PXOneTapViewModel: PXReviewViewModel {
 // MARK: - Extra events
 extension PXOneTapViewModel {
     func trackTapSummaryDetailEvent() {
-        MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_SUMMARY_DETAIL, screenId: screenId, screenName: screenName)
+        var properties: [String: String] = [String: String]()
+        properties[TrackingUtil.Metadata.HAS_DISCOUNT] = hasDiscount().description
+        properties[TrackingUtil.Metadata.INSTALLMENTS] = paymentData.getNumberOfInstallments().stringValue
+        MPXTracker.sharedInstance.trackActionEvent(action: TrackingUtil.Event.TAP_SUMMARY_DETAIL, screenId: screenId, screenName: screenName, properties: properties)
     }
 
     func trackTapBackEvent() {

--- a/MercadoPagoSDK/MercadoPagoSDK/PXTrackingUtil.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXTrackingUtil.swift
@@ -9,6 +9,14 @@
 import Foundation
 import MercadoPagoPXTracking
 
+// MARK: - Metadata/Params
+extension TrackingUtil {
+    struct Metadata {
+        static let INSTALLMENTS = "installments"
+        static let HAS_DISCOUNT = "has_discount"
+    }
+}
+
 // MARK: - Screens
 extension TrackingUtil {
     enum ScreenId {


### PR DESCRIPTION
Se agregan los extra params al evento TAP_SUMMARY_DETAIL llamado para MeliData: OPEN_SUMMARY_DETAIL.

- installments(required: false, description:"Number of installments")
- has_discount(required: false, description:"User has applied discount?")