### PR TITLE
Add description to Payment Method plugin

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel+Plugins.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel+Plugins.swift
@@ -50,6 +50,7 @@ extension MercadoPagoCheckoutViewModel {
         paymentMethod.name = plugin.getTitle()
         paymentMethod.paymentTypeId = PXPaymentMethodPlugin.PAYMENT_METHOD_TYPE_ID
         paymentMethod.setExternalPaymentMethodImage(externalImage: plugin.getImage())
+        paymentMethod.paymentMethodDescription = plugin.paymentMethodPluginDescription
         self.paymentData.paymentMethod = paymentMethod
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+PaymentMethodComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/One tap/UI/PXOneTapViewModel+PaymentMethodComponent.swift
@@ -19,7 +19,7 @@ extension PXOneTapViewModel {
         let paymentMethodName = pm.name ?? ""
         let image = PXImageService.getIconImageFor(paymentMethod: pm)
         var title = NSAttributedString(string: "")
-        var subtitle: NSAttributedString? = nil
+        var subtitle: NSAttributedString? = pm.paymentMethodDescription?.toAttributedString()
         var cftText: NSAttributedString? = nil
         var subtitleRight: NSMutableAttributedString? = nil
         let backgroundColor = ThemeManager.shared.whiteColor()

--- a/MercadoPagoSDK/MercadoPagoSDK/PXBodyComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXBodyComponent.swift
@@ -50,11 +50,11 @@ open class PXBodyComponent: NSObject, PXComponentizable {
         let image = getPaymentMethodIcon(paymentMethod: pm)
         let currency = MercadoPagoContext.getCurrency()
         var amountTitle = Utils.getAmountFormated(amount: self.props.amountHelper.amountToPay, forCurrency: currency)
-        var amountDetail: NSMutableAttributedString?
+        var subtitle: NSMutableAttributedString? = pm.paymentMethodDescription?.toAttributedString()
         if let payerCost = self.props.paymentResult.paymentData?.payerCost {
             if payerCost.installments > 1 {
                 amountTitle = String(payerCost.installments) + "x " + Utils.getAmountFormated(amount: payerCost.installmentAmount, forCurrency: currency)
-                amountDetail = Utils.getAmountFormated(amount: payerCost.totalAmount, forCurrency: currency, addingParenthesis: true).toAttributedString()
+                subtitle = Utils.getAmountFormated(amount: payerCost.totalAmount, forCurrency: currency, addingParenthesis: true).toAttributedString()
             }
         }
         if self.props.amountHelper.discount != nil {
@@ -67,11 +67,11 @@ open class PXBodyComponent: NSObject, PXComponentizable {
             let attributes: [NSAttributedStringKey: Any] = [NSAttributedStringKey.strikethroughStyle: 1]
             let preferenceAmountString = Utils.getAttributedAmount(withAttributes: attributes, amount: amount, currency: currency, negativeAmount: false)
 
-            if amountDetail == nil {
-                amountDetail = preferenceAmountString
+            if subtitle == nil {
+                subtitle = preferenceAmountString
             } else {
-                amountDetail?.append(String.NON_BREAKING_LINE_SPACE.toAttributedString())
-                amountDetail?.append(preferenceAmountString)
+                subtitle?.append(String.NON_BREAKING_LINE_SPACE.toAttributedString())
+                subtitle?.append(preferenceAmountString)
             }
 
         }
@@ -98,7 +98,7 @@ open class PXBodyComponent: NSObject, PXComponentizable {
             disclaimerText =  ("En tu estado de cuenta verás el cargo como %0".localized as NSString).replacingOccurrences(of: "%0", with: "\(statementDescription)")
         }
 
-        let bodyProps = PXPaymentMethodProps(paymentMethodIcon: image, title: amountTitle.toAttributedString(), subtitle: amountDetail, descriptionTitle: pmDescription.toAttributedString(), descriptionDetail: descriptionDetail, disclaimer: disclaimerText?.toAttributedString(), backgroundColor: ThemeManager.shared.detailedBackgroundColor(), lightLabelColor: ThemeManager.shared.labelTintColor(), boldLabelColor: ThemeManager.shared.boldLabelTintColor())
+        let bodyProps = PXPaymentMethodProps(paymentMethodIcon: image, title: amountTitle.toAttributedString(), subtitle: subtitle, descriptionTitle: pmDescription.toAttributedString(), descriptionDetail: descriptionDetail, disclaimer: disclaimerText?.toAttributedString(), backgroundColor: ThemeManager.shared.detailedBackgroundColor(), lightLabelColor: ThemeManager.shared.labelTintColor(), boldLabelColor: ThemeManager.shared.boldLabelTintColor())
 
         return PXPaymentMethodComponent(props: bodyProps)
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXBusinessResultViewModel.swift
@@ -133,11 +133,11 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
         let image = getPaymentMethodIcon(paymentMethod: pm)
         let currency = MercadoPagoContext.getCurrency()
         var amountTitle = Utils.getAmountFormated(amount: self.amountHelper.amountToPay, forCurrency: currency)
-        var amountDetail: NSMutableAttributedString?
+        var subtitle: NSMutableAttributedString?  = pm.paymentMethodDescription?.toAttributedString()
         if let payerCost = self.paymentData.payerCost {
             if payerCost.installments > 1 {
                 amountTitle = String(payerCost.installments) + "x " + Utils.getAmountFormated(amount: payerCost.installmentAmount, forCurrency: currency)
-                amountDetail = Utils.getAmountFormated(amount: payerCost.totalAmount, forCurrency: currency, addingParenthesis: true).toAttributedString()
+                subtitle = Utils.getAmountFormated(amount: payerCost.totalAmount, forCurrency: currency, addingParenthesis: true).toAttributedString()
             }
         }
 
@@ -151,11 +151,11 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
             let attributes: [NSAttributedStringKey: Any] = [NSAttributedStringKey.strikethroughStyle: 1]
             let preferenceAmountString = Utils.getAttributedAmount(withAttributes: attributes, amount: amount, currency: currency, negativeAmount: false)
 
-            if amountDetail == nil {
-                amountDetail = preferenceAmountString
+            if subtitle == nil {
+                subtitle = preferenceAmountString
             } else {
-                amountDetail?.append(String.NON_BREAKING_LINE_SPACE.toAttributedString())
-                amountDetail?.append(preferenceAmountString)
+                subtitle?.append(String.NON_BREAKING_LINE_SPACE.toAttributedString())
+                subtitle?.append(preferenceAmountString)
             }
 
         }
@@ -183,7 +183,7 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
             disclaimerText =  ("En tu estado de cuenta verás el cargo como %0".localized as NSString).replacingOccurrences(of: "%0", with: "\(statementDescription)")
         }
 
-        let bodyProps = PXPaymentMethodProps(paymentMethodIcon: image, title: amountTitle.toAttributedString(), subtitle: amountDetail, descriptionTitle: pmDescription.toAttributedString(), descriptionDetail: descriptionDetail, disclaimer: disclaimerText?.toAttributedString(), backgroundColor: ThemeManager.shared.detailedBackgroundColor(), lightLabelColor: ThemeManager.shared.labelTintColor(), boldLabelColor: ThemeManager.shared.boldLabelTintColor())
+        let bodyProps = PXPaymentMethodProps(paymentMethodIcon: image, title: amountTitle.toAttributedString(), subtitle: subtitle, descriptionTitle: pmDescription.toAttributedString(), descriptionDetail: descriptionDetail, disclaimer: disclaimerText?.toAttributedString(), backgroundColor: ThemeManager.shared.detailedBackgroundColor(), lightLabelColor: ThemeManager.shared.labelTintColor(), boldLabelColor: ThemeManager.shared.boldLabelTintColor())
 
         return PXPaymentMethodComponent(props: bodyProps)
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewModel.swift
@@ -216,7 +216,7 @@ extension PXReviewViewModel {
 
         let image = PXImageService.getIconImageFor(paymentMethod: pm)
         var title = NSAttributedString(string: "")
-        var subtitle: NSAttributedString? = nil
+        var subtitle: NSAttributedString? = pm.paymentMethodDescription?.toAttributedString()
         var accreditationTime: NSAttributedString? = nil
         var action = withAction
         let backgroundColor = ThemeManager.shared.detailedBackgroundColor()
@@ -238,7 +238,7 @@ extension PXReviewViewModel {
         if paymentMethodIssuerName.lowercased() != paymentMethodName.lowercased() && !paymentMethodIssuerName.isEmpty {
             subtitle = paymentMethodIssuerName.toAttributedString()
         }
-
+       
         if !self.reviewScreenPreference.isChangeMethodOptionEnabled() {
             action = nil
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/PaymentMethod.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PaymentMethod.swift
@@ -27,6 +27,7 @@ import UIKit
     open var maxAllowedAmount: Double!
     open var merchantAccountId: String?
     open var externalPaymentPluginImageData: NSData?
+    open var paymentMethodDescription: String? = nil
 
     public override init() {
         super.init()

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -156,7 +156,7 @@
 
     PaymentPluginViewController *makePaymentComponent = [storyboard instantiateViewControllerWithIdentifier:@"paymentPlugin"];
 
-    PXPaymentMethodPlugin * bitcoinPaymentMethodPlugin = [[PXPaymentMethodPlugin alloc] initWithPaymentMethodPluginId:@"account_money" name:@"Bitcoin" image:[UIImage imageNamed:@"bitcoin_payment"] description:@"" paymentPlugin:makePaymentComponent];
+    PXPaymentMethodPlugin * bitcoinPaymentMethodPlugin = [[PXPaymentMethodPlugin alloc] initWithPaymentMethodPluginId:@"account_money" name:@"Bitcoin" image:[UIImage imageNamed:@"bitcoin_payment"] description:@"Hola mundo" paymentPlugin:makePaymentComponent];
 
     // Payment method config plugin component.
     PaymentMethodPluginConfigViewController *configPaymentComponent = [storyboard instantiateViewControllerWithIdentifier:@"paymentMethodConfigPlugin"];


### PR DESCRIPTION
Se propaga el campo de descripcion de los plugins de medio de pago en la creacion del medio de pago correspondiente y se utiliza para mostrar el subtitulo en la celda de PM.