### PR TITLE
OneTap fix, vertical aligment

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
@@ -145,7 +145,7 @@ extension PXOneTapViewController {
 
         view.layoutIfNeeded()
         refreshContentViewSize()
-        _ = centerContentView()
+        _ = centerContentView(margin: -PXLayout.getStatusBarHeight())
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/PXComponentContainerViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXComponentContainerViewController.swift
@@ -61,10 +61,10 @@ class PXComponentContainerViewController: MercadoPagoUIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func centerContentView() -> Bool {
+    func centerContentView(margin: CGFloat = 0) -> Bool {
         if contentView.frame.height < PXLayout.getScreenHeight() - PXLayout.NAV_BAR_HEIGHT - PXLayout.getStatusBarHeight() {
             topContentConstraint?.isActive = false
-            PXLayout.centerVertically(view: contentView, to: scrollView).isActive = true
+            PXLayout.centerVertically(view: contentView, to: scrollView, withMargin: margin).isActive = true
             return true
         }
         return false

--- a/MercadoPagoSDK/MercadoPagoSDK/PXLayout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXLayout.swift
@@ -184,14 +184,14 @@ class PXLayout: NSObject {
     }
 
     //Centrado Vertical
-    static func centerVertically(view: UIView, to container: UIView? = nil) -> NSLayoutConstraint {
+    static func centerVertically(view: UIView, to container: UIView? = nil, withMargin margin: CGFloat = 0) -> NSLayoutConstraint {
         var superView: UIView!
         if container == nil {
             superView = view.superview
         } else {
             superView = container
         }
-        return checkContraintActivation(NSLayoutConstraint(item: view, attribute: NSLayoutAttribute.centerY, relatedBy: NSLayoutRelation.equal, toItem: superView, attribute: NSLayoutAttribute.centerY, multiplier: 1.0, constant: 0))
+        return checkContraintActivation(NSLayoutConstraint(item: view, attribute: NSLayoutAttribute.centerY, relatedBy: NSLayoutRelation.equal, toItem: superView, attribute: NSLayoutAttribute.centerY, multiplier: 1.0, constant: margin))
     }
 
     static func matchWidth(ofView view: UIView, toView otherView: UIView? = nil, withPercentage percent: CGFloat = 100) -> NSLayoutConstraint {


### PR DESCRIPTION
Como estamos usando navigation transparente, la content queda con mas contenido. Y al ser todo blanco, si bien esta centrado verticalmente, da sensación de que no lo esté. Por eso explicitamente en el Controller de OneTap, que sabe que tiene navigation trans, se le indica un -delta de margin al center.