### PR TITLE
Bug idioma titulo congrats

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Config/PXPaymentResultConfiguration.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Config/PXPaymentResultConfiguration.swift
@@ -53,7 +53,7 @@ import Foundation
     open var approvedBadge: ApprovedBadge? = ApprovedBadge.check
     private var _approvedLabelText = ""
     private var _disableApprovedLabelText = true
-    internal var approvedTitle = PXHeaderResutlConstants.APPROVED_HEADER_TITLE.localized
+    internal lazy var approvedTitle = PXHeaderResutlConstants.APPROVED_HEADER_TITLE.localized
     internal var approvedSubtitle = ""
     internal var approvedURLImage: String?
     internal var approvedIconName = "default_item_icon"
@@ -63,9 +63,9 @@ import Foundation
     // To deprecate post v4. SP integration.
     private var _pendingLabelText = ""
     private var _disablePendingLabelText = true
-    internal var pendingTitle = PXHeaderResutlConstants.PENDING_HEADER_TITLE.localized
+    internal lazy var pendingTitle = PXHeaderResutlConstants.PENDING_HEADER_TITLE.localized
     internal var pendingSubtitle = ""
-    internal var pendingContentTitle = PXPaymentResultConfiguration.PENDING_CONTENT_TITLE.localized
+    internal lazy var pendingContentTitle = PXPaymentResultConfiguration.PENDING_CONTENT_TITLE.localized
     internal var pendingContentText = ""
     internal var pendingIconName = "default_item_icon"
     internal var pendingIconBundle = ResourceManager.shared.getBundle()!
@@ -76,17 +76,17 @@ import Foundation
     // MARK: Rejected
     // To deprecate post v4. SP integration.
     private var disableRejectedLabelText = false
-    internal var rejectedTitle = PXHeaderResutlConstants.REJECTED_HEADER_TITLE.localized
+    internal lazy var rejectedTitle = PXHeaderResutlConstants.REJECTED_HEADER_TITLE.localized
     internal var rejectedSubtitle = ""
     internal var rejectedTitleSetted = false
-    internal var rejectedIconSubtext = PXHeaderResutlConstants.REJECTED_ICON_SUBTEXT.localized
+    internal lazy var rejectedIconSubtext = PXHeaderResutlConstants.REJECTED_ICON_SUBTEXT.localized
     internal var rejectedBolbradescoIconName = "MPSDK_payment_result_bolbradesco_error"
     internal var rejectedPaymentMethodPluginIconName = "MPSDK_payment_result_plugin_error"
     internal var rejectedIconBundle = ResourceManager.shared.getBundle()!
     internal var rejectedDefaultIconName: String?
     internal var rejectedURLImage: String?
     internal var rejectedIconName: String?
-    internal var rejectedContentTitle = PXPaymentResultConfiguration.REJECTED_CONTENT_TITLE.localized
+    internal lazy var rejectedContentTitle = PXPaymentResultConfiguration.REJECTED_CONTENT_TITLE.localized
     internal var rejectedContentText = ""
     internal var hideRejectedContentText = false
     internal var hideRejectedContentTitle = false


### PR DESCRIPTION
##  Cambios introducidos : 
- Fixea bug que hace que el titulo de la congrats se vea en otro idioma la primera vez que se corre el flujo

![simulator screen shot - iphone 8 plus - 2018-08-24 at 14 25 24](https://user-images.githubusercontent.com/9399970/44598505-9bccc500-a7a9-11e8-8d26-63afae95cb08.png)
