### PR TITLE
navigationBarExplosion bug fixed

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PXComponentContainerViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXComponentContainerViewController.swift
@@ -40,6 +40,13 @@ class PXComponentContainerViewController: MercadoPagoUIViewController {
         PXLayout.matchWidth(ofView: contentView, toView: scrollView).isActive = true
         contentView.backgroundColor = .pxWhite
         super.init(nibName: nil, bundle: nil)
+
+        if #available(iOS 11.0, *) {
+            scrollView.contentInsetAdjustmentBehavior = .never
+        } else {
+            automaticallyAdjustsScrollViewInsets = false
+        }
+
         view.addSubview(scrollView)
 
         PXLayout.pinLeft(view: scrollView, to: view).isActive = true

--- a/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
@@ -198,7 +198,7 @@ extension PXReviewViewController {
 
         contentView.backgroundColor = ThemeManager.shared.detailedBackgroundColor()
         scrollView.backgroundColor = ThemeManager.shared.detailedBackgroundColor()
-        
+
         // Add elastic header.
         addElasticHeader(headerBackgroundColor: summaryView.backgroundColor, navigationCustomTitle: PXReviewTitleComponentProps.DEFAULT_TITLE.localized, textColor: ThemeManager.shared.getTitleColorForReviewConfirmNavigation())
 


### PR DESCRIPTION
##  Cambios introducidos : 
- Se arreglo el bug en la pantalla de RyC cuando el boton explota y transiciona hacia la pantalla de congrats.

### Revisión
- [ ] Todos los textos se encuentran localizables
- [ ] No se introducen warnings al proyecto
- [ ] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [ ] No se agregan logs / prints innecesarios
- [ ] No se agregan comentarios basura
- [ ] Correr Swiftlint

### Testeo
- [ ] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
