### PR TITLE
Fix navigation bar explosion

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/PXComponentContainerViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXComponentContainerViewController.swift
@@ -40,6 +40,13 @@ class PXComponentContainerViewController: MercadoPagoUIViewController {
         PXLayout.matchWidth(ofView: contentView, toView: scrollView).isActive = true
         contentView.backgroundColor = .pxWhite
         super.init(nibName: nil, bundle: nil)
+
+        if #available(iOS 11.0, *) {
+            scrollView.contentInsetAdjustmentBehavior = .never
+        } else {
+            automaticallyAdjustsScrollViewInsets = false
+        }
+
         view.addSubview(scrollView)
 
         PXLayout.pinLeft(view: scrollView, to: view).isActive = true


### PR DESCRIPTION
##  Cambios introducidos : 
- Se arreglo el bug en la pantalla de RyC cuando el boton explota y transiciona hacia la pantalla de congrats.

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [ ] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
