### PR TITLE
🌀 Improvement - ForceBinaryMode capability 🌀

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Config/PXAdvancedConfiguration.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Config/PXAdvancedConfiguration.swift
@@ -39,4 +39,18 @@ open class PXAdvancedConfiguration: NSObject {
      Enable to preset configurations to customize visualization on the 'Congrats' screen / 'PaymentResult' screen.
      */
     open var paymentResultConfiguration: PXPaymentResultConfiguration = PXPaymentResultConfiguration()
+
+    /**
+     Internal use. To force binary mode.
+     */
+    internal var binaryModeForced: Bool = false
+}
+
+extension PXAdvancedConfiguration {
+    /**
+     Use this method to force the binary mode. (Set binary mode to `TRUE`). If you use this method, you can override any backend configuration related to binary mode flag.
+     */
+    open func forceBinaryMode() {
+        binaryModeForced = true
+    }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow+Services.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow+Services.swift
@@ -38,7 +38,7 @@ internal extension PXPaymentFlow {
             return
         }
 
-        let mpPayment = MPPayment(preferenceId: checkoutPreference.id, publicKey: model.mercadoPagoServicesAdapter.mercadoPagoServices.merchantPublicKey, paymentData: paymentData, binaryMode: model.checkoutPreference?.isBinaryMode() ?? false)
+        let mpPayment = MPPayment(preferenceId: checkoutPreference.id, publicKey: model.mercadoPagoServicesAdapter.mercadoPagoServices.merchantPublicKey, paymentData: paymentData, binaryMode: model.binaryMode)
         guard let paymentBody = (try? mpPayment.toJSONString()) as? String else {
             fatalError("Cannot make payment json body")
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow.swift
@@ -16,8 +16,8 @@ internal final class PXPaymentFlow: NSObject, PXFlow {
 
     var pxNavigationHandler: PXNavigationHandler
 
-    init(paymentPlugin: PXPaymentProcessor?, mercadoPagoServicesAdapter: MercadoPagoServicesAdapter, paymentErrorHandler: PXPaymentErrorHandlerProtocol, navigationHandler: PXNavigationHandler, paymentData: PXPaymentData?, checkoutPreference: PXCheckoutPreference?) {
-        model = PXPaymentFlowModel(paymentPlugin: paymentPlugin, mercadoPagoServicesAdapter: mercadoPagoServicesAdapter)
+    init(paymentPlugin: PXPaymentProcessor?, mercadoPagoServicesAdapter: MercadoPagoServicesAdapter, paymentErrorHandler: PXPaymentErrorHandlerProtocol, navigationHandler: PXNavigationHandler, paymentData: PXPaymentData?, checkoutPreference: PXCheckoutPreference?, binaryMode: Bool) {
+        model = PXPaymentFlowModel(paymentPlugin: paymentPlugin, mercadoPagoServicesAdapter: mercadoPagoServicesAdapter, binaryMode: binaryMode)
         self.paymentErrorHandler = paymentErrorHandler
         self.pxNavigationHandler = navigationHandler
         self.model.paymentData = paymentData

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlowModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlowModel.swift
@@ -19,9 +19,12 @@ internal final class PXPaymentFlowModel: NSObject {
     var instructionsInfo: PXInstructions?
     var businessResult: PXBusinessResult?
 
-    init(paymentPlugin: PXPaymentProcessor?, mercadoPagoServicesAdapter: MercadoPagoServicesAdapter) {
+    let binaryMode: Bool
+
+    init(paymentPlugin: PXPaymentProcessor?, mercadoPagoServicesAdapter: MercadoPagoServicesAdapter, binaryMode: Bool) {
         self.paymentPlugin = paymentPlugin
         self.mercadoPagoServicesAdapter = mercadoPagoServicesAdapter
+        self.binaryMode = binaryMode
     }
 
     enum Steps: String {

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutViewModel.swift
@@ -791,7 +791,13 @@ extension MercadoPagoCheckoutViewModel {
 extension MercadoPagoCheckoutViewModel {
     func createPaymentFlow(paymentErrorHandler: PXPaymentErrorHandlerProtocol) -> PXPaymentFlow {
         guard let paymentFlow = paymentFlow else {
-            let paymentFlow = PXPaymentFlow(paymentPlugin: paymentPlugin, mercadoPagoServicesAdapter: mercadoPagoServicesAdapter, paymentErrorHandler: paymentErrorHandler, navigationHandler: pxNavigationHandler, paymentData: paymentData, checkoutPreference: checkoutPreference)
+            // Override binaryMode if need.
+            var binaryModeEnabled = checkoutPreference.isBinaryMode()
+            if advancedConfig.binaryModeForced {
+                binaryModeEnabled = true
+            }
+
+            let paymentFlow = PXPaymentFlow(paymentPlugin: paymentPlugin, mercadoPagoServicesAdapter: mercadoPagoServicesAdapter, paymentErrorHandler: paymentErrorHandler, navigationHandler: pxNavigationHandler, paymentData: paymentData, checkoutPreference: checkoutPreference, binaryMode: binaryModeEnabled)
             self.paymentFlow = paymentFlow
             return paymentFlow
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXCheckoutPreference+Business.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXCheckoutPreference+Business.swift
@@ -143,21 +143,13 @@ extension PXCheckoutPreference {
 // MARK: BinaryMode
 extension PXCheckoutPreference {
     /**
-     Determinate if binaryMode feature is enabled/disabled.
+     Default value is `FALSE`. If return `TRUE` value processed payment can only be APPROVED or REJECTED.
+     Non compatible with PaymentProcessor or off payments methods.
+     Determinate if binaryMode backend feature is enabled or disabled. This is the raw value from backend.
+     If you need to force and override this backend value, use the method `forceBinaryMode()` in `PXAdvancedConfiguration`
      */
     open func isBinaryMode() -> Bool {
         return binaryModeEnabled
-    }
-
-    /**
-     Default value is `FALSE`.
-     `TRUE` value processed payment can only be APPROVED or REJECTED.
-     Non compatible with PaymentProcessor or off payments methods.
-     - parameter isBinaryMode: Binary mode Bool value.
-     */
-    open func setBinaryMode(isBinaryMode: Bool) -> PXCheckoutPreference {
-        self.binaryModeEnabled = isBinaryMode
-        return self
     }
 }
 


### PR DESCRIPTION
Hoy el binaryMode no se esta levantando del backend. Pero igual le estamos consultando a la CheckoutPreference su valor. Eso se mantiene. Ya que el día que lo levantemos de backend seria transparente para el integrador. 
Ahora se agrega la capacidad de forzar el binaryMode a true desde Advanced Configuration.

Porque? Porque hay integradores que no hablan con una CheckoutPreference (entran con pref id) y entonces necesitan habilitar igual el binaryMode. Para eso esta el force. El día que ese valor venga de backend, se hará la asociacion interna de binaryMode con el field de backend y se le informará a los integradores que el forceBinary ya no es necesario que queda deprecado y que cuando creen la preferencia en su backend definan el binary.  