### PR TITLE
💸Change payment method capability 💸

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/PXLifecycleProtocol.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/PXLifecycleProtocol.swift
@@ -21,4 +21,10 @@ import Foundation
      - parameter payment: Optional PXPayment object. (Payment info)
      */
     @objc func finishCheckout(payment: PXPayment?) -> (() -> Void)?
+    /**
+     User tap on our change payment method action. If you return a block,
+     you can override the change payment method action. For example to
+     go to specific viewController, etc.
+     */
+    @objc optional func changePaymentMethodTapped() -> (() -> Void)?
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
@@ -198,9 +198,12 @@ extension MercadoPagoCheckout {
                 strongSelf.viewModel.prepareForClone()
                 strongSelf.collectSecurityCodeForRetry()
             } else if state == PaymentResult.CongratsState.cancel_RETRY || state == PaymentResult.CongratsState.cancel_SELECT_OTHER {
-                strongSelf.viewModel.prepareForNewSelection()
-                strongSelf.executeNextStep()
-
+                if let changePaymentMethodAction = strongSelf.viewModel.lifecycleProtocol?.changePaymentMethodTapped?(), state == PaymentResult.CongratsState.cancel_SELECT_OTHER {
+                    changePaymentMethodAction()
+                } else {
+                    strongSelf.viewModel.prepareForNewSelection()
+                    strongSelf.executeNextStep()
+                }
             } else {
                 strongSelf.finish()
             }

--- a/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/MercadoPagoCheckoutScreens.swift
@@ -143,8 +143,14 @@ extension MercadoPagoCheckout {
             strongSelf.executeNextStep()
 
         }, finishButtonAnimation: {
-                self.executeNextStep()
+            self.executeNextStep()
         })
+
+        if let changePaymentMethodAction = viewModel.lifecycleProtocol?.changePaymentMethodTapped?() {
+            reviewVC.changePaymentMethodCallback = changePaymentMethodAction
+        } else {
+            reviewVC.changePaymentMethodCallback = nil
+        }
 
         viewModel.pxNavigationHandler.pushViewController(viewController: reviewVC, animated: true)
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/PXResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXResultViewController.swift
@@ -22,6 +22,8 @@ class PXResultViewController: PXComponentContainerViewController {
     var bodyView: UIView?
     var footerView: UIView?
 
+    internal var changePaymentMethodCallback: (() -> Void)? = nil
+
     init(viewModel: PXResultViewModelInterface, callback : @escaping ( _ status: PaymentResult.CongratsState) -> Void) {
         self.viewModel = viewModel
         self.viewModel.setCallback(callback: callback)

--- a/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
@@ -32,6 +32,8 @@ class PXReviewViewController: PXComponentContainerViewController {
     let timeOutPayButton: TimeInterval
     let shouldAnimatePayButton: Bool
 
+    internal var changePaymentMethodCallback: (() -> Void)? = nil
+
     // MARK: Lifecycle - Publics
     init(viewModel: PXReviewViewModel, timeOutPayButton: TimeInterval = 15, shouldAnimatePayButton: Bool, callbackPaymentData : @escaping ((PXPaymentData) -> Void), callbackConfirm: @escaping ((PXPaymentData) -> Void), finishButtonAnimation: @escaping (() -> Void)) {
         self.viewModel = viewModel
@@ -234,8 +236,13 @@ extension PXReviewViewController {
     fileprivate func getPaymentMethodComponentView() -> UIView? {
         let action = PXAction(label: "review_change_payment_method_action".localized_beta, action: { [weak self] in
             if let reviewViewModel = self?.viewModel {
-                self?.viewModel.trackChangePaymentMethodEvent()
-                self?.callbackPaymentData(reviewViewModel.getClearPaymentData())
+                if let callBackAction = self?.changePaymentMethodCallback {
+                    self?.viewModel.trackChangePaymentMethodEvent()
+                    callBackAction()
+                } else {
+                    self?.viewModel.trackChangePaymentMethodEvent()
+                    self?.callbackPaymentData(reviewViewModel.getClearPaymentData())
+                }
             }
         })
         if let paymentMethodComponent = viewModel.buildPaymentMethodComponent(withAction: action) {

--- a/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/PXReviewViewController.swift
@@ -236,11 +236,10 @@ extension PXReviewViewController {
     fileprivate func getPaymentMethodComponentView() -> UIView? {
         let action = PXAction(label: "review_change_payment_method_action".localized_beta, action: { [weak self] in
             if let reviewViewModel = self?.viewModel {
+                self?.viewModel.trackChangePaymentMethodEvent()
                 if let callBackAction = self?.changePaymentMethodCallback {
-                    self?.viewModel.trackChangePaymentMethodEvent()
                     callBackAction()
                 } else {
-                    self?.viewModel.trackChangePaymentMethodEvent()
                     self?.callbackPaymentData(reviewViewModel.getClearPaymentData())
                 }
             }
@@ -248,7 +247,6 @@ extension PXReviewViewController {
         if let paymentMethodComponent = viewModel.buildPaymentMethodComponent(withAction: action) {
             return paymentMethodComponent.render()
         }
-
         return nil
     }
 

--- a/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/MercadoPagoSDKExamplesObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -213,6 +213,13 @@ self.checkoutBuilder = [[MercadoPagoCheckoutBuilder alloc] initWithPublicKey:@"T
     };
 }
 
+-(void (^)(void))changePaymentMethodTapped {
+    return ^ {
+        NSLog(@"PXLog - changePaymentMethodTapped Called");
+        [self.navigationController popToRootViewControllerAnimated:YES];
+    };
+}
+
 - (void)trackEventWithScreenName:(NSString * _Nullable)screenName action:(NSString * _Null_unspecified)action result:(NSString * _Nullable)result extraParams:(NSDictionary<NSString *,id> * _Nullable)extraParams {
     // Track event
 }


### PR DESCRIPTION
Nos vimos obligados a contemplar esta funcionalidad nuevamente. Es clave para MoneyIn por ejemplo.

Se resuelve de manera elegante y escalable. Quedando en el LifeCycle protocol que ya teniamos para informar salidas. Es un metodo opcional del LifeCycle. Si lo definen y retornan el bloque, ejecutamos ese bloque y no hacemos nada (solo trackeamos la action). Es optional, por ahora solo lo utilizaria moneIn. 

En Android harán lo mismo. Pero ellos salen del CHO por un callback, no mediante un protocolo. Nosotros tenemos un protocolo que dentro tiene un method con un callback. 

Por ahora se puso solo en Revisa y Confirma. Lo van a probar y si se necesita en Congrats efectivamente, se replicará el mecanismo.