### PR TITLE
Add xibs to podspec

### DIFF
--- a/MercadoPagoSDK.podspec
+++ b/MercadoPagoSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDK"
-  s.version          = "3.7.7"
+  s.version          = "3.7.8"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/MercadoPagoSDK.podspec
+++ b/MercadoPagoSDK.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Default'
 
   s.subspec 'Default' do |default|
-    default.resources = ['MercadoPagoSDK/MercadoPagoSDK/*.xcassets', 'MercadoPagoSDK/MercadoPagoSDK/*.ttf', 'MercadoPagoSDK/MercadoPagoSDK/*.lproj', 'MercadoPagoSDK/MercadoPagoSDK/Translations/**/**.{plist,strings}', 'MercadoPagoSDK/MercadoPagoSDK/Plist/*.plist']
+    default.resources = ['MercadoPagoSDK/MercadoPagoSDK/*.xcassets', 'MercadoPagoSDK/MercadoPagoSDK/*.ttf', 'MercadoPagoSDK/MercadoPagoSDK/*.lproj', 'MercadoPagoSDK/MercadoPagoSDK/Translations/**/**.{plist,strings}', 'MercadoPagoSDK/MercadoPagoSDK/Plist/*.plist', 'MercadoPagoSDK/MercadoPagoSDK/**/**.{xib,strings}']
     default.source_files = ['MercadoPagoSDK/MercadoPagoSDK/**/**/**.{h,m,swift}']
     s.dependency 'MercadoPagoPXTracking', '2.0.1.1'
     s.dependency 'MercadoPagoServices', '1.0.2.2'

--- a/MercadoPagoSDK.podspec
+++ b/MercadoPagoSDK.podspec
@@ -17,16 +17,6 @@ Pod::Spec.new do |s|
     s.dependency 'MercadoPagoPXTracking', '2.0.1.1'
     s.dependency 'MercadoPagoServices', '1.0.2.2'
   end
-
-  s.subspec 'ESC' do |esc|	
-	esc.dependency 'MercadoPagoSDK/Default'  
-    	esc.dependency 'MLESCManager', '1.0.0' 
-     esc.pod_target_xcconfig = { 
-       'OTHER_SWIFT_FLAGS[config=Debug]' => '-D MPESC_ENABLE', 
-       'OTHER_SWIFT_FLAGS[config=Release]' => '-D MPESC_ENABLE', 
-       'OTHER_SWIFT_FLAGS[config=Testflight]' => '-D MPESC_ENABLE' 
-     } 
-   end
   
 s.pod_target_xcconfig = {
   'SWIFT_VERSION' => '3.0.1'

--- a/MercadoPagoSDK/MercadoPagoSDK/Plist/mpsdk_settings.plist
+++ b/MercadoPagoSDK/MercadoPagoSDK/Plist/mpsdk_settings.plist
@@ -5,7 +5,7 @@
 	<key>flow_sdk_type_hybrid</key>
 	<false/>
 	<key>sdk_version</key>
-	<string>3.7.7</string>
+	<string>3.7.8</string>
 	<key>tracking_settings</key>
 	<dict>
 		<key>tracking_enabled</key>


### PR DESCRIPTION
##  Cambios introducidos : 
- Soluciona el crash importando la sdk como podspec. Se agregan los xibs a los resources en el podspec

