### PR TITLE
Remove payment method description on congrats.

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Models/BusinessResult/PXBusinessResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/BusinessResult/PXBusinessResultViewModel.swift
@@ -132,7 +132,7 @@ class PXBusinessResultViewModel: NSObject, PXResultViewModelInterface {
         let image = getPaymentMethodIcon(paymentMethod: pm)
         let currency = SiteManager.shared.getCurrency()
         var amountTitle = Utils.getAmountFormated(amount: self.amountHelper.amountToPay, forCurrency: currency)
-        var subtitle: NSMutableAttributedString?  = pm.paymentMethodDescription?.toAttributedString()
+        var subtitle: NSMutableAttributedString?  = nil
         if let payerCost = self.paymentData.payerCost {
             if payerCost.installments > 1 {
                 amountTitle = String(payerCost.installments) + "x " + Utils.getAmountFormated(amount: payerCost.installmentAmount, forCurrency: currency)

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXBody/PXBodyComponent.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXBody/PXBodyComponent.swift
@@ -49,7 +49,7 @@ internal class PXBodyComponent: PXComponentizable {
         let image = getPaymentMethodIcon(paymentMethod: pm)
         let currency = SiteManager.shared.getCurrency()
         var amountTitle: NSMutableAttributedString = Utils.getAmountFormated(amount: self.props.amountHelper.amountToPay, forCurrency: currency).toAttributedString()
-        var subtitle: NSMutableAttributedString? = pm.paymentMethodDescription?.toAttributedString()
+        var subtitle: NSMutableAttributedString? = nil
         if let payerCost = self.props.paymentResult.paymentData?.payerCost {
             if payerCost.installments > 1 {
                 amountTitle = String(String(payerCost.installments) + "x " + Utils.getAmountFormated(amount: payerCost.installmentAmount, forCurrency: currency)).toAttributedString()


### PR DESCRIPTION
Se remueve la descripción del payment method para las pantallas de resultado de pago y de negocio.

- Testeado para business result, payment result & one tap.