### PR TITLE
Set external Payment Method Image

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel+Plugins.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel+Plugins.swift
@@ -46,6 +46,7 @@ internal extension MercadoPagoCheckoutViewModel {
 
     func paymentMethodPluginToPaymentMethod(plugin: PXPaymentMethodPlugin) {
         let paymentMethod = PXPaymentMethod(additionalInfoNeeded: nil, id: plugin.getId(), name: plugin.getTitle(), paymentTypeId: PXPaymentMethodPlugin.PAYMENT_METHOD_TYPE_ID, status: nil, secureThumbnail: nil, thumbnail: nil, deferredCapture: nil, settings: [], minAllowedAmount: nil, maxAllowedAmount: nil, accreditationTime: nil, merchantAccountId: nil, financialInstitutions: financialInstitutions, description: plugin.paymentMethodPluginDescription)
+            paymentMethod.setExternalPaymentMethodImage(externalImage: plugin.getImage())
         self.paymentData.paymentMethod = paymentMethod
     }
 }


### PR DESCRIPTION
Se corrige el bug que hacia que no se muestre la image de los plugines de payment method en revisa y confirma y en congrats.