### PR TITLE
Fixes iPad

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Extensions/String+Additions.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Extensions/String+Additions.swift
@@ -50,7 +50,6 @@ internal extension String {
     }
 
     func trimSpaces() -> String {
-
         var stringTrimmed = self.replacingOccurrences(of: " ", with: "")
         stringTrimmed = stringTrimmed.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
         return stringTrimmed

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Extensions/String+Additions.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Extensions/String+Additions.swift
@@ -82,4 +82,8 @@ internal extension String {
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         return dateFormatter.date(from: dateString)
     }
+
+    var isNumber: Bool {
+        return rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
+    }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXIdentificationType.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXIdentificationType.swift
@@ -51,6 +51,10 @@ open class PXIdentificationType: NSObject, Codable {
         try container.encodeIfPresent(self.type, forKey: .type)
     }
 
+    internal func isNumberType() -> Bool {
+        return self.type == "number"
+    }
+
     open func toJSONString() throws -> String? {
         let encoder = JSONEncoder()
         let data = try encoder.encode(self)

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/BankDeals/PXBankDealComponentRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/BankDeals/PXBankDealComponentRenderer.swift
@@ -20,7 +20,6 @@ class PXBankDealComponentRenderer: NSObject {
         //Image View
         let image = PXUIImage(url: component.props.imageUrl, placeholder: component.props.placeholder, fallback: component.props.placeholder)
         let imageView = PXUIImageView(image: image)
-        imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
         bankDealComponentView.imageView = imageView
         bankDealComponentView.addSubview(imageView)

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/BankDeals/PXBankDealDetailsViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/BankDeals/PXBankDealDetailsViewController.swift
@@ -96,6 +96,7 @@ extension PXBankDealDetailsViewController {
         legalsTextView.textColor = ThemeManager.shared.labelTintColor()
         legalsTextView.backgroundColor = .clear
         legalsTextView.isScrollEnabled = false
+        legalsTextView.isEditable = false
         return legalsTextView
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Base/PXUIImageView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Base/PXUIImageView.swift
@@ -22,7 +22,7 @@ class PXUIImageView: UIImageView {
     }
 
     private func loadImage(image: UIImage?) {
-        self.contentMode = .scaleAspectFill
+        self.contentMode = .scaleAspectFit
         if let pxImage = image as? PXUIImage {
             let placeholder = buildPlaceholderView(image: pxImage)
             let fallback = buildFallbackView(image: pxImage)

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Card/CardFormViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Card/CardFormViewController.swift
@@ -482,12 +482,9 @@ internal class CardFormViewController: MercadoPagoUIViewController, UITextFieldD
             let buttonNext = UIBarButtonItem(title: "card_form_next_button".localized_beta, style: .plain, target: self, action: #selector(CardFormViewController.rightArrowKeyTapped))
             let buttonPrev = UIBarButtonItem(title: "card_form_previous_button".localized_beta, style: .plain, target: self, action: #selector(CardFormViewController.leftArrowKeyTapped))
 
-            buttonNext.setTitlePositionAdjustment(UIOffset(horizontal: UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
-            buttonPrev.setTitlePositionAdjustment(UIOffset(horizontal: -UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
-
             let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
-            toolbar.items = [flexibleSpace, buttonPrev, flexibleSpace, buttonNext, flexibleSpace]
+            toolbar.items = [buttonPrev, flexibleSpace, buttonNext]
             if self.viewModel.customerCard != nil || self.viewModel.token != nil {
                 navItem!.leftBarButtonItem?.isEnabled = false
             }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Card/CardFormViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Card/CardFormViewController.swift
@@ -252,12 +252,6 @@ internal class CardFormViewController: MercadoPagoUIViewController, UITextFieldD
     }
 
     open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if string.count == 0 {
-            textField.text = textField.text!.trimmingCharacters(
-                in: CharacterSet.whitespacesAndNewlines
-            )
-        }
-
         let value: Bool = validateInput(textField, shouldChangeCharactersInRange: range, replacementString: string)
         updateLabelsFontColors()
         return value
@@ -399,6 +393,10 @@ internal class CardFormViewController: MercadoPagoUIViewController, UITextFieldD
 
         switch editingLabel! {
         case cardNumberLabel! :
+            if !string.isNumber {
+                return false
+            }
+
             if string.count == 0 {
                 return true
             }
@@ -416,9 +414,16 @@ internal class CardFormViewController: MercadoPagoUIViewController, UITextFieldD
 
         case nameLabel! : return validInputName(textField.text! + string)
 
-        case expirationDateLabel! : return validInputDate(textField, shouldChangeCharactersInRange: range, replacementString: string)
-
-        case cvvLabel! : return self.viewModel.isValidInputCVV(textField.text! + string)
+        case expirationDateLabel! :
+            if !string.isNumber {
+                return false
+            }
+            return validInputDate(textField, shouldChangeCharactersInRange: range, replacementString: string)
+        case cvvLabel! :
+            if !string.isNumber {
+                return false
+            }
+            return self.viewModel.isValidInputCVV(textField.text! + string)
         default : return false
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Card/CardFormViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Card/CardFormViewController.swift
@@ -432,8 +432,8 @@ internal class CardFormViewController: MercadoPagoUIViewController, UITextFieldD
             return true
         }
 
-        //Dont allow empty strings
-        if string == " " {
+        //Dont allow empty strings and unwanted forward slash
+        if string == " " || string == "/" {
             return false
         }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Card/IdentificationViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Card/IdentificationViewController.swift
@@ -244,12 +244,9 @@ internal class IdentificationViewController: MercadoPagoUIViewController, UIText
             let buttonNext = UIBarButtonItem(title: "card_form_next_button".localized_beta, style: .plain, target: self, action: #selector(IdentificationViewController.rightArrowKeyTapped))
             let buttonPrev = UIBarButtonItem(title: "card_form_previous_button".localized_beta, style: .plain, target: self, action: #selector(IdentificationViewController.leftArrowKeyTapped))
 
-            buttonNext.setTitlePositionAdjustment(UIOffset(horizontal: UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
-            buttonPrev.setTitlePositionAdjustment(UIOffset(horizontal: -UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
-
             let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
-            toolbar.items = [flexibleSpace, buttonPrev, flexibleSpace, buttonNext, flexibleSpace]
+            toolbar.items = [buttonPrev, flexibleSpace, buttonNext]
 
             numberTextField.delegate = self
             self.toolbar = toolbar

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Card/IdentificationViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Card/IdentificationViewController.swift
@@ -83,11 +83,10 @@ internal class IdentificationViewController: MercadoPagoUIViewController, UIText
     }
 
     open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-
-        if string.count < 1 {
-            return true
-        }
         guard let identificationType = identificationType else {
+            return false
+        }
+        if identificationType.isNumberType(), !string.isNumber {
             return false
         }
         if textField.text?.count == identificationType.maxLength {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXHeader/PXHeaderRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXHeader/PXHeaderRenderer.swift
@@ -109,17 +109,12 @@ internal final class PXHeaderRenderer: NSObject {
 
     func buildMessageLabel(with text: NSAttributedString) -> UILabel {
         let messageLabel = UILabel()
-        let font = Utils.getFont(size: PXHeaderRenderer.TITLE_FONT_SIZE)
         messageLabel.textAlignment = .center
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
         messageLabel.attributedText = text
         messageLabel.textColor = .white
         messageLabel.lineBreakMode = .byWordWrapping
         messageLabel.numberOfLines = 0
-        messageLabel.font = font
-        let screenWidth = PXLayout.getScreenWidth(applyingMarginFactor: CONTENT_WIDTH_PERCENT)
-        let height = UILabel.requiredHeight(forAttributedText: text, withFont: font, inWidth: screenWidth)
-        PXLayout.setHeight(owner: messageLabel, height: height).isActive = true
         return messageLabel
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/SecurityCode/SecurityCodeViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/SecurityCode/SecurityCodeViewController.swift
@@ -98,12 +98,9 @@ internal class SecurityCodeViewController: MercadoPagoUIViewController, UITextFi
         let buttonNext = UIBarButtonItem(title: "card_form_next_button".localized_beta, style: .plain, target: self, action: #selector(self.continueAction))
         let buttonPrev = UIBarButtonItem(title: "card_form_previous_button".localized_beta, style: .plain, target: self, action: #selector(self.backAction))
 
-        buttonNext.setTitlePositionAdjustment(UIOffset(horizontal: UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
-        buttonPrev.setTitlePositionAdjustment(UIOffset(horizontal: -UIScreen.main.bounds.size.width / 8, vertical: 0), for: UIBarMetrics.default)
-
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
-        toolbar.items = [flexibleSpace, buttonPrev, flexibleSpace, buttonNext, flexibleSpace]
+        toolbar.items = [buttonPrev, flexibleSpace, buttonNext]
 
         self.toolbar = toolbar
         self.securityCodeTextField.delegate = self


### PR DESCRIPTION
##  Problemas solucionados : 
- Alta de tarjeta: botones de continuar y anterior están rotos, es difícil presionarlos.
- Alta de tarjeta: Fecha de expiración -> al ingresar caracteres no numéricos, agrega "/" consecutivas.
- Ingreso de DNI: si se ingresa caracteres no numéricos, el label "nombre" blinkea.
- Pantalla de congrats: el signo $ queda desalineado (también se da en iPhone) 
- Pantalla de promociones bancarias, las imágenes están rotas.
- Detalle de promoción bancaria, textfield editable.
- Crash al hacer undo (shake o botón)

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [ ] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [ ] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada

### Antes
![centavos before](https://user-images.githubusercontent.com/23138661/45833694-aeb8b380-bcdb-11e8-8dd2-f8af973126ce.png)

### Después
![centavos after](https://user-images.githubusercontent.com/23138661/45833693-ae201d00-bcdb-11e8-975a-18556f1aed13.png)

