### PR TITLE
One tap - Slide Animation

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapService.swift
@@ -46,11 +46,15 @@ struct OneTapService {
                 PXPayerCost(installmentRate: 0, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 300, totalAmount: 300, installments: 1),
                 PXPayerCost(installmentRate: 0, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 100, totalAmount: 300, installments: 3),
                 PXPayerCost(installmentRate: 10, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 55.55, totalAmount: 330.33, installments: 6)]
+            var leftText: String = ""
+            var rightText: String = ""
             var mockInstallmentData: PXInstallment? = nil
             if i != 2 {
+                leftText = "\(installmentRandom)x $\(String(format: "%.2f", amountRandom))"
+                rightText = "CFT: \(String(format: "%.2f", cftRandom))%"
                 mockInstallmentData = PXInstallment(issuer: nil, payerCosts: payerCost, paymentMethodId: nil, paymentTypeId: nil)
             }
-            let model = PXOneTapInstallmentInfoViewModel(leftText: "\(installmentRandom)x $\(String(format: "%.2f", amountRandom))", rightText: "CFT: \(String(format: "%.2f", cftRandom))%", installmentData: mockInstallmentData)
+            let model = PXOneTapInstallmentInfoViewModel(leftText: leftText, rightText: rightText, installmentData: mockInstallmentData)
             models.append(model)
         }
         return models

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapService.swift
@@ -35,6 +35,24 @@ struct OneTapService {
         return mockedViewModel
     }
 
+    static func getInstallmentTestViewModel(amount: Int) -> [PXOneTapInstallmentInfoViewModel] {
+        var models: [PXOneTapInstallmentInfoViewModel] = []
+
+        for i in 1...10 {
+            let cftRandom = Double.random(in: 1 ... 100)
+            let installmentRandom = Int.random(in: 1 ... 12)
+            let amountRandom = Double.random(in: 200 ... 1000)
+            let payerCost = [
+                PXPayerCost(installmentRate: 0, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 300, totalAmount: 300, installments: 1),
+                PXPayerCost(installmentRate: 0, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 100, totalAmount: 300, installments: 3),
+                PXPayerCost(installmentRate: 10, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 55.55, totalAmount: 330.33, installments: 6)]
+            let mockInstallmentData = PXInstallment(issuer: nil, payerCosts: payerCost, paymentMethodId: nil, paymentTypeId: nil)
+            let model = PXOneTapInstallmentInfoViewModel(leftText: "\(installmentRandom)x $\(String(format: "%.2f", amountRandom))", rightText: "CFT: \(String(format: "%.2f", cftRandom))%", installmentData: mockInstallmentData)
+            models.append(model)
+        }
+        return models
+    }
+
     static func getInstallmentViewModel(cardSliderViewModel: PXCardSliderViewModel) -> PXOneTapInstallmentInfoViewModel {
         if cardSliderViewModel.cardData == nil {
             return PXOneTapInstallmentInfoViewModel(leftText: "", rightText: "", installmentData: nil)

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapService.swift
@@ -35,7 +35,7 @@ struct OneTapService {
         return mockedViewModel
     }
 
-    static func getInstallmentTestViewModel(amount: Int) -> [PXOneTapInstallmentInfoViewModel] {
+    static func getInstallmentsViewModel(amount: Int) -> [PXOneTapInstallmentInfoViewModel] {
         var models: [PXOneTapInstallmentInfoViewModel] = []
 
         for i in 1...amount {
@@ -58,26 +58,5 @@ struct OneTapService {
             models.append(model)
         }
         return models
-    }
-
-    static func getInstallmentViewModel(cardSliderViewModel: PXCardSliderViewModel) -> PXOneTapInstallmentInfoViewModel {
-        if cardSliderViewModel.cardData == nil {
-            return PXOneTapInstallmentInfoViewModel(leftText: "", rightText: "", installmentData: nil)
-        } else {
-            // TODO: Get real installments info for each PaymentMethod.
-            if cardSliderViewModel.cardUI is AccountMoneyCard {
-                return PXOneTapInstallmentInfoViewModel(leftText: "", rightText: "", installmentData: nil)
-            } else {
-                let cftRandom = Double.random(in: 1 ... 100)
-                let installmentRandom = Int.random(in: 1 ... 12)
-                let amountRandom = Double.random(in: 200 ... 1000)
-                let payerCost = [
-                    PXPayerCost(installmentRate: 0, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 300, totalAmount: 300, installments: 1),
-                    PXPayerCost(installmentRate: 0, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 100, totalAmount: 300, installments: 3),
-                    PXPayerCost(installmentRate: 10, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 55.55, totalAmount: 330.33, installments: 6)]
-                let mockInstallmentData = PXInstallment(issuer: nil, payerCosts: payerCost, paymentMethodId: nil, paymentTypeId: nil)
-                return PXOneTapInstallmentInfoViewModel(leftText: "\(installmentRandom)x $\(String(format: "%.2f", amountRandom))", rightText: "CFT: \(String(format: "%.2f", cftRandom))%", installmentData: mockInstallmentData)
-            }
-        }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapService.swift
@@ -38,7 +38,7 @@ struct OneTapService {
     static func getInstallmentTestViewModel(amount: Int) -> [PXOneTapInstallmentInfoViewModel] {
         var models: [PXOneTapInstallmentInfoViewModel] = []
 
-        for i in 1...10 {
+        for i in 1...amount {
             let cftRandom = Double.random(in: 1 ... 100)
             let installmentRandom = Int.random(in: 1 ... 12)
             let amountRandom = Double.random(in: 200 ... 1000)
@@ -46,7 +46,10 @@ struct OneTapService {
                 PXPayerCost(installmentRate: 0, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 300, totalAmount: 300, installments: 1),
                 PXPayerCost(installmentRate: 0, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 100, totalAmount: 300, installments: 3),
                 PXPayerCost(installmentRate: 10, labels: [], minAllowedAmount: 0, maxAllowedAmount: 20000, recommendedMessage: "Sin interes", installmentAmount: 55.55, totalAmount: 330.33, installments: 6)]
-            let mockInstallmentData = PXInstallment(issuer: nil, payerCosts: payerCost, paymentMethodId: nil, paymentTypeId: nil)
+            var mockInstallmentData: PXInstallment? = nil
+            if i != 2 {
+                mockInstallmentData = PXInstallment(issuer: nil, payerCosts: payerCost, paymentMethodId: nil, paymentTypeId: nil)
+            }
             let model = PXOneTapInstallmentInfoViewModel(leftText: "\(installmentRandom)x $\(String(format: "%.2f", amountRandom))", rightText: "CFT: \(String(format: "%.2f", cftRandom))%", installmentData: mockInstallmentData)
             models.append(model)
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
@@ -19,7 +19,13 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
     private let titleLabel = UILabel()
     private let colapsedTag: Int = 2
     private var arrowImage: UIImageView = UIImageView()
+    private var pagerView = FSPagerView(frame: .zero)
     var model: PXOneTapInstallmentInfoViewModel?
+    var testModel: [PXOneTapInstallmentInfoViewModel]? {
+        didSet {
+            pagerView.reloadData()
+        }
+    }
 
     weak var delegate: PXOneTapInstallmentInfoViewProtocol?
 
@@ -35,62 +41,84 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
 
     func updateViewModel(_ viewModel: PXOneTapInstallmentInfoViewModel, updateAnimation: UIView.AnimationOptions? = nil) {
         model = viewModel
-        var animation: UIView.AnimationOptions = .transitionCrossDissolve
-        if let customAnimation = updateAnimation {
-            animation = customAnimation
-        }
-
-        if viewModel.installmentData != nil {
-            if arrowImage.alpha != 1 {
-                UIView.animate(withDuration: 0.20) { [weak self] in
-                    self?.arrowImage.alpha = 1
-                }
-            }
-        } else {
-            UIView.animate(withDuration: 0.20) { [weak self] in
-                self?.arrowImage.alpha = 0
-            }
-        }
-
-        UIView.transition(with: self.rightLabel,
-                          duration: 0.25,
-                          options: animation,
-                          animations: { [weak self] in
-                            self?.rightLabel.text = self?.model?.rightText
-            }, completion: nil)
-        UIView.transition(with: self.leftLabel,
-                          duration: 0.25,
-                          options: animation,
-                          animations: { [weak self] in
-                            self?.leftLabel.text = self?.model?.leftText
-            }, completion: nil)
+//        var animation: UIView.AnimationOptions = .transitionCrossDissolve
+//        if let customAnimation = updateAnimation {
+//            animation = customAnimation
+//        }
+//
+//        if viewModel.installmentData != nil {
+//            if arrowImage.alpha != 1 {
+//                UIView.animate(withDuration: 0.20) { [weak self] in
+//                    self?.arrowImage.alpha = 1
+//                }
+//            }
+//        } else {
+//            UIView.animate(withDuration: 0.20) { [weak self] in
+//                self?.arrowImage.alpha = 0
+//            }
+//        }
+//        
+//        UIView.transition(with: self.rightLabel, duration: 0.25, options: animation, animations: { [weak self] in
+//            self?.rightLabel.text = self?.model?.rightText
+//        }, completion: nil)
+//        UIView.transition(with: self.leftLabel, duration: 0.25, options: animation, animations: { [weak self] in
+//            self?.leftLabel.text = self?.model?.leftText
+//        }, completion: nil)
     }
 
     func render() {
-        guard let model = model else {return}
+//        guard let model = model else {return}
         removeAllSubviews()
+        setupSlider()
+        PXLayout.setHeight(owner: self, height: PXOneTapInstallmentInfoView.DEFAULT_ROW_HEIGHT).isActive = true
 
-        heightConstraint = PXLayout.setHeight(owner: self, height: PXOneTapInstallmentInfoView.DEFAULT_ROW_HEIGHT)
-        heightConstraint?.isActive = true
+        addSubview(arrowImage)
+        arrowImage.contentMode = UIViewContentMode.scaleAspectFit
+        arrowImage.image = ResourceManager.shared.getImage("oneTapDownArrow")
+        PXLayout.pinTop(view: arrowImage, withMargin: PXLayout.M_MARGIN).isActive = true
+        PXLayout.setWidth(owner: arrowImage, width: 14).isActive = true
+        PXLayout.setHeight(owner: arrowImage, height: 14).isActive = true
+        PXLayout.pinRight(view: arrowImage, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
 
-        leftLabel.translatesAutoresizingMaskIntoConstraints = false
-        leftLabel.text = model.leftText
-        leftLabel.textAlignment = .left
-        leftLabel.font = Utils.getSemiBoldFont(size: PXLayout.M_FONT)
-        leftLabel.textColor = ThemeManager.shared.boldLabelTintColor()
-        addSubview(leftLabel)
-        PXLayout.pinLeft(view: leftLabel, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
-        PXLayout.pinTop(view: leftLabel, withMargin: PXLayout.S_MARGIN + 2).isActive = true
 
-        rightLabel.translatesAutoresizingMaskIntoConstraints = false
-        rightLabel.text = model.rightText
-        rightLabel.textAlignment = .left
-        rightLabel.font = Utils.getLightFont(size: PXLayout.XS_FONT)
-        rightLabel.textColor = ThemeManager.shared.greyColor()
-        addSubview(rightLabel)
-        PXLayout.put(view: rightLabel, rightOf: leftLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
-        PXLayout.centerVertically(view: rightLabel, to: leftLabel, withMargin: 0).isActive = true
+//
+//        leftLabel.translatesAutoresizingMaskIntoConstraints = false
+//        leftLabel.text = model.leftText
+//        leftLabel.textAlignment = .left
+//        leftLabel.font = Utils.getSemiBoldFont(size: PXLayout.M_FONT)
+//        leftLabel.textColor = ThemeManager.shared.boldLabelTintColor()
+//        addSubview(leftLabel)
+//        PXLayout.pinLeft(view: leftLabel, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
+//        PXLayout.pinTop(view: leftLabel, withMargin: PXLayout.S_MARGIN + 2).isActive = true
+//
+//        rightLabel.translatesAutoresizingMaskIntoConstraints = false
+//        rightLabel.text = model.rightText
+//        rightLabel.textAlignment = .left
+//        rightLabel.font = Utils.getLightFont(size: PXLayout.XS_FONT)
+//        rightLabel.textColor = ThemeManager.shared.greyColor()
+//        addSubview(rightLabel)
+//        PXLayout.put(view: rightLabel, rightOf: leftLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
+//        PXLayout.centerVertically(view: rightLabel, to: leftLabel, withMargin: 0).isActive = true
+//
+//        addSubview(arrowImage)
+//        arrowImage.contentMode = UIViewContentMode.scaleAspectFit
+//        arrowImage.image = ResourceManager.shared.getImage("oneTapDownArrow")
+//        PXLayout.pinTop(view: arrowImage, withMargin: PXLayout.M_MARGIN).isActive = true
+//        PXLayout.setWidth(owner: arrowImage, width: 14).isActive = true
+//        PXLayout.setHeight(owner: arrowImage, height: 14).isActive = true
+//        PXLayout.pinRight(view: arrowImage, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
+//
+//        arrowImage.tag = colapsedTag
+//        if model.installmentData == nil {
+//            arrowImage.alpha = 0
+//        }
+//
+//        setupTitleLabel()
+//
+//        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleInstallments)))
+    }
 
+    private func updateArroyImage(model: PXOneTapInstallmentInfoViewModel) {
         addSubview(arrowImage)
         arrowImage.contentMode = UIViewContentMode.scaleAspectFit
         arrowImage.image = ResourceManager.shared.getImage("oneTapDownArrow")
@@ -103,10 +131,30 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
         if model.installmentData == nil {
             arrowImage.alpha = 0
         }
+    }
 
-        setupTitleLabel()
-        
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleInstallments)))
+    private func setupSlider() {
+        addSubview(pagerView)
+//        pagerView.layer.borderWidth = 4
+        PXLayout.setHeight(owner: pagerView, height: PXOneTapInstallmentInfoView.DEFAULT_ROW_HEIGHT).isActive = true
+        PXLayout.pinLeft(view: pagerView).isActive = true
+        PXLayout.pinRight(view: pagerView).isActive = true
+        PXLayout.matchWidth(ofView: pagerView).isActive = true
+        PXLayout.pinTop(view: pagerView).isActive = true
+        pagerView.dataSource = self
+        pagerView.delegate = self
+        pagerView.register(PXCardSliderPagerCell.getCell(), forCellWithReuseIdentifier: PXCardSliderPagerCell.identifier)
+        pagerView.register(FSPagerViewCell.self, forCellWithReuseIdentifier: "cell")
+        pagerView.isInfinite = false
+        pagerView.automaticSlidingInterval = 0
+        pagerView.bounces = true
+        pagerView.interitemSpacing = 0
+        pagerView.decelerationDistance = 1
+        pagerView.itemSize = CGSize(width: PXCardSliderSizeManager.getItemSize().width, height: PXOneTapInstallmentInfoView.DEFAULT_ROW_HEIGHT)
+    }
+
+    func setSliderOffset(offset: CGPoint) {
+        pagerView.scrollToOffset(offset)
     }
 
     @objc func toggleInstallments() {
@@ -147,5 +195,127 @@ extension PXOneTapInstallmentInfoView {
         addSubview(titleLabel)
         PXLayout.pinLeft(view: titleLabel, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
         PXLayout.pinTop(view: titleLabel, withMargin: PXLayout.S_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
+    }
+}
+
+// MARK: DataSource
+extension PXOneTapInstallmentInfoView: FSPagerViewDataSource {
+
+    func numberOfItems(in pagerView: FSPagerView) -> Int {
+        guard let testModel = testModel else {return 0}
+        return testModel.count
+    }
+
+    func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewCell {
+        guard let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index) as? FSPagerViewCell else {
+            return FSPagerViewCell()
+        }
+
+        guard let testModel = testModel else {return FSPagerViewCell()}
+
+        let model = testModel[index]
+        cell.removeAllSubviews()
+
+//        cell.layer.borderWidth = 2
+//        PXLayout.matchWidth(ofView: cell).isActive = true
+//        PXLayout.setWidth(owner: cell, width: PXLayout.getScreenWidth()).isActive = true
+//        PXLayout.setHeight(owner: cell, height: PXOneTapInstallmentInfoView.DEFAULT_ROW_HEIGHT).isActive = true
+
+        let leftLabel = UILabel()
+        leftLabel.translatesAutoresizingMaskIntoConstraints = false
+        leftLabel.text = model.leftText
+        leftLabel.textAlignment = .left
+        leftLabel.font = Utils.getSemiBoldFont(size: PXLayout.M_FONT)
+        leftLabel.textColor = ThemeManager.shared.boldLabelTintColor()
+        cell.addSubview(leftLabel)
+        PXLayout.pinLeft(view: leftLabel, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
+        PXLayout.pinTop(view: leftLabel, withMargin: PXLayout.S_MARGIN + 2).isActive = true
+
+        let rightLabel = UILabel()
+        rightLabel.translatesAutoresizingMaskIntoConstraints = false
+        rightLabel.text = model.rightText
+        rightLabel.textAlignment = .left
+        rightLabel.font = Utils.getLightFont(size: PXLayout.XS_FONT)
+        rightLabel.textColor = ThemeManager.shared.greyColor()
+        cell.addSubview(rightLabel)
+        PXLayout.put(view: rightLabel, rightOf: leftLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
+        PXLayout.centerVertically(view: rightLabel, to: leftLabel, withMargin: 0).isActive = true
+
+//        addSubview(arrowImage)
+//        arrowImage.contentMode = UIViewContentMode.scaleAspectFit
+//        arrowImage.image = ResourceManager.shared.getImage("oneTapDownArrow")
+//        PXLayout.pinTop(view: arrowImage, withMargin: PXLayout.M_MARGIN).isActive = true
+//        PXLayout.setWidth(owner: arrowImage, width: 14).isActive = true
+//        PXLayout.setHeight(owner: arrowImage, height: 14).isActive = true
+//        PXLayout.pinRight(view: arrowImage, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
+//
+//        arrowImage.tag = colapsedTag
+//        if model.installmentData == nil {
+//            arrowImage.alpha = 0
+//        }
+
+//        setupTitleLabel()
+
+//        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleInstallments)))
+
+
+
+
+
+
+
+//        if model.indices.contains(index) {
+//            let targetModel = model[index]
+//            if let cardData = targetModel.cardData, let cell = pagerView.dequeueReusableCell(withReuseIdentifier: PXCardSliderPagerCell.identifier, at: index) as? PXCardSliderPagerCell {
+//                if targetModel.cardUI is AccountMoneyCard {
+//                    // AM card.
+//                    cell.renderAccountMoneyCard(balanceText: cardData.name)
+//                } else {
+//                    // Other cards.
+//                    cell.render(withCard: targetModel.cardUI, cardData: cardData)
+//                }
+//                return cell
+//            } else {
+//                // Add new card scenario.
+//                if let cell = pagerView.dequeueReusableCell(withReuseIdentifier: PXCardSliderPagerCell.identifier, at: index) as? PXCardSliderPagerCell {
+//                    cell.renderEmptyCard()
+//                    return cell
+//                }
+//            }
+//        }
+        return cell
+    }
+}
+
+// MARK: Delegate
+extension PXOneTapInstallmentInfoView: FSPagerViewDelegate {
+
+    func pagerViewDidScroll(_ pagerView: FSPagerView) {
+        print(pagerView.scrollOffset)
+    }
+
+    func pagerViewWillEndDragging(_ pagerView: FSPagerView, targetIndex: Int) {
+//        if selectedIndex != targetIndex {
+//            PXFeedbackGenerator.selectionFeedback()
+//            selectedIndex = targetIndex
+//            if model.indices.contains(targetIndex) {
+//                let modelData = model[targetIndex]
+//                delegate?.newCardDidSelected(targetModel: modelData)
+//            }
+//        }
+    }
+
+    func pagerView(_ pagerView: FSPagerView, didSelectItemAt index: Int) {
+//        if model.indices.contains(index) {
+//            let modelData = model[index]
+//            if modelData.cardData == nil {
+//                delegate?.addPaymentMethodCardDidTap()
+//            } else {
+//                //TODO: Remove. This is only for tets flip capability.
+//                if let cell = pagerView.cellForItem(at: index) as? PXCardSliderPagerCell {
+//                    cell.flipToBack()
+//                }
+//            }
+//        }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
@@ -51,7 +51,6 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
         arrowImage.tag = colapsedTag
 
         setupTitleLabel()
-
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleInstallments)))
     }
 
@@ -80,7 +79,7 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
     }
 
     func setSliderOffset(offset: CGPoint) {
-        pagerView.scrollToOffset(offset)
+        pagerView.scrollToOffset(offset, animated: false)
     }
 
     @objc func toggleInstallments() {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
@@ -67,7 +67,6 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
     }
 
     func render() {
-//        guard let model = model else {return}
         removeAllSubviews()
         setupSlider()
         PXLayout.setHeight(owner: self, height: PXOneTapInstallmentInfoView.DEFAULT_ROW_HEIGHT).isActive = true
@@ -79,63 +78,20 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
         PXLayout.setWidth(owner: arrowImage, width: 14).isActive = true
         PXLayout.setHeight(owner: arrowImage, height: 14).isActive = true
         PXLayout.pinRight(view: arrowImage, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
+        arrowImage.tag = colapsedTag
 
-
-//
-//        leftLabel.translatesAutoresizingMaskIntoConstraints = false
-//        leftLabel.text = model.leftText
-//        leftLabel.textAlignment = .left
-//        leftLabel.font = Utils.getSemiBoldFont(size: PXLayout.M_FONT)
-//        leftLabel.textColor = ThemeManager.shared.boldLabelTintColor()
-//        addSubview(leftLabel)
-//        PXLayout.pinLeft(view: leftLabel, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
-//        PXLayout.pinTop(view: leftLabel, withMargin: PXLayout.S_MARGIN + 2).isActive = true
-//
-//        rightLabel.translatesAutoresizingMaskIntoConstraints = false
-//        rightLabel.text = model.rightText
-//        rightLabel.textAlignment = .left
-//        rightLabel.font = Utils.getLightFont(size: PXLayout.XS_FONT)
-//        rightLabel.textColor = ThemeManager.shared.greyColor()
-//        addSubview(rightLabel)
-//        PXLayout.put(view: rightLabel, rightOf: leftLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
-//        PXLayout.centerVertically(view: rightLabel, to: leftLabel, withMargin: 0).isActive = true
-//
-//        addSubview(arrowImage)
-//        arrowImage.contentMode = UIViewContentMode.scaleAspectFit
-//        arrowImage.image = ResourceManager.shared.getImage("oneTapDownArrow")
-//        PXLayout.pinTop(view: arrowImage, withMargin: PXLayout.M_MARGIN).isActive = true
-//        PXLayout.setWidth(owner: arrowImage, width: 14).isActive = true
-//        PXLayout.setHeight(owner: arrowImage, height: 14).isActive = true
-//        PXLayout.pinRight(view: arrowImage, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
-//
-//        arrowImage.tag = colapsedTag
-//        if model.installmentData == nil {
-//            arrowImage.alpha = 0
-//        }
-//
 //        setupTitleLabel()
-//
-//        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleInstallments)))
+
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleInstallments)))
     }
 
-    private func updateArroyImage(model: PXOneTapInstallmentInfoViewModel) {
-        addSubview(arrowImage)
-        arrowImage.contentMode = UIViewContentMode.scaleAspectFit
-        arrowImage.image = ResourceManager.shared.getImage("oneTapDownArrow")
-        PXLayout.pinTop(view: arrowImage, withMargin: PXLayout.M_MARGIN).isActive = true
-        PXLayout.setWidth(owner: arrowImage, width: 14).isActive = true
-        PXLayout.setHeight(owner: arrowImage, height: 14).isActive = true
-        PXLayout.pinRight(view: arrowImage, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
-
-        arrowImage.tag = colapsedTag
-        if model.installmentData == nil {
-            arrowImage.alpha = 0
-        }
+    private func updateArroyImage(alpha: CGFloat) {
+        arrowImage.alpha = alpha
     }
 
     private func setupSlider() {
         addSubview(pagerView)
-//        pagerView.layer.borderWidth = 4
+        pagerView.isUserInteractionEnabled = false
         PXLayout.setHeight(owner: pagerView, height: PXOneTapInstallmentInfoView.DEFAULT_ROW_HEIGHT).isActive = true
         PXLayout.pinLeft(view: pagerView).isActive = true
         PXLayout.pinRight(view: pagerView).isActive = true
@@ -158,8 +114,9 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
     }
 
     @objc func toggleInstallments() {
+        print("tapped")
         if tapEnabled {
-            if let installMentData = model?.installmentData {
+            if let installmentData = testModel?[getCurrentIndex()].installmentData {
                 if arrowImage.tag != colapsedTag {
                     delegate?.hideInstallments()
                     UIView.animate(withDuration: 0.3) { [weak self] in
@@ -170,7 +127,7 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
                     }
                     arrowImage.tag = colapsedTag
                 } else {
-                    delegate?.showInstallments(installmentData: installMentData)
+                    delegate?.showInstallments(installmentData: installmentData)
                     UIView.animate(withDuration: 0.3) { [weak self] in
                         self?.arrowImage.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
                         self?.rightLabel.alpha = 0
@@ -207,19 +164,12 @@ extension PXOneTapInstallmentInfoView: FSPagerViewDataSource {
     }
 
     func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewCell {
-        guard let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index) as? FSPagerViewCell else {
-            return FSPagerViewCell()
-        }
+        let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index)
 
         guard let testModel = testModel else {return FSPagerViewCell()}
 
         let model = testModel[index]
         cell.removeAllSubviews()
-
-//        cell.layer.borderWidth = 2
-//        PXLayout.matchWidth(ofView: cell).isActive = true
-//        PXLayout.setWidth(owner: cell, width: PXLayout.getScreenWidth()).isActive = true
-//        PXLayout.setHeight(owner: cell, height: PXOneTapInstallmentInfoView.DEFAULT_ROW_HEIGHT).isActive = true
 
         let leftLabel = UILabel()
         leftLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -241,48 +191,6 @@ extension PXOneTapInstallmentInfoView: FSPagerViewDataSource {
         PXLayout.put(view: rightLabel, rightOf: leftLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
         PXLayout.centerVertically(view: rightLabel, to: leftLabel, withMargin: 0).isActive = true
 
-//        addSubview(arrowImage)
-//        arrowImage.contentMode = UIViewContentMode.scaleAspectFit
-//        arrowImage.image = ResourceManager.shared.getImage("oneTapDownArrow")
-//        PXLayout.pinTop(view: arrowImage, withMargin: PXLayout.M_MARGIN).isActive = true
-//        PXLayout.setWidth(owner: arrowImage, width: 14).isActive = true
-//        PXLayout.setHeight(owner: arrowImage, height: 14).isActive = true
-//        PXLayout.pinRight(view: arrowImage, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
-//
-//        arrowImage.tag = colapsedTag
-//        if model.installmentData == nil {
-//            arrowImage.alpha = 0
-//        }
-
-//        setupTitleLabel()
-
-//        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleInstallments)))
-
-
-
-
-
-
-
-//        if model.indices.contains(index) {
-//            let targetModel = model[index]
-//            if let cardData = targetModel.cardData, let cell = pagerView.dequeueReusableCell(withReuseIdentifier: PXCardSliderPagerCell.identifier, at: index) as? PXCardSliderPagerCell {
-//                if targetModel.cardUI is AccountMoneyCard {
-//                    // AM card.
-//                    cell.renderAccountMoneyCard(balanceText: cardData.name)
-//                } else {
-//                    // Other cards.
-//                    cell.render(withCard: targetModel.cardUI, cardData: cardData)
-//                }
-//                return cell
-//            } else {
-//                // Add new card scenario.
-//                if let cell = pagerView.dequeueReusableCell(withReuseIdentifier: PXCardSliderPagerCell.identifier, at: index) as? PXCardSliderPagerCell {
-//                    cell.renderEmptyCard()
-//                    return cell
-//                }
-//            }
-//        }
         return cell
     }
 }
@@ -290,32 +198,18 @@ extension PXOneTapInstallmentInfoView: FSPagerViewDataSource {
 // MARK: Delegate
 extension PXOneTapInstallmentInfoView: FSPagerViewDelegate {
 
+    func getCurrentIndex() -> Int {
+        let scrollOffset = pagerView.scrollOffset
+        let floorOffset = floor(scrollOffset)
+        return Int(floorOffset)
+    }
+
     func pagerViewDidScroll(_ pagerView: FSPagerView) {
-        print(pagerView.scrollOffset)
-    }
-
-    func pagerViewWillEndDragging(_ pagerView: FSPagerView, targetIndex: Int) {
-//        if selectedIndex != targetIndex {
-//            PXFeedbackGenerator.selectionFeedback()
-//            selectedIndex = targetIndex
-//            if model.indices.contains(targetIndex) {
-//                let modelData = model[targetIndex]
-//                delegate?.newCardDidSelected(targetModel: modelData)
-//            }
-//        }
-    }
-
-    func pagerView(_ pagerView: FSPagerView, didSelectItemAt index: Int) {
-//        if model.indices.contains(index) {
-//            let modelData = model[index]
-//            if modelData.cardData == nil {
-//                delegate?.addPaymentMethodCardDidTap()
-//            } else {
-//                //TODO: Remove. This is only for tets flip capability.
-//                if let cell = pagerView.cellForItem(at: index) as? PXCardSliderPagerCell {
-//                    cell.flipToBack()
-//                }
-//            }
-//        }
+        let newAlpha = 1 - (pagerView.scrollOffset - CGFloat(integerLiteral: getCurrentIndex()))
+        if newAlpha < 0.5 {
+            pagerView.alpha = 1 - newAlpha
+        } else {
+            pagerView.alpha = newAlpha
+        }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
@@ -14,14 +14,11 @@ protocol PXOneTapInstallmentInfoViewProtocol: NSObjectProtocol {
 
 final class PXOneTapInstallmentInfoView: PXComponentView {
     static let DEFAULT_ROW_HEIGHT: CGFloat = 50
-    private let leftLabel = UILabel()
-    private let rightLabel = UILabel()
     private let titleLabel = UILabel()
     private let colapsedTag: Int = 2
     private var arrowImage: UIImageView = UIImageView()
     private var pagerView = FSPagerView(frame: .zero)
-    var model: PXOneTapInstallmentInfoViewModel?
-    var testModel: [PXOneTapInstallmentInfoViewModel]? {
+    var model: [PXOneTapInstallmentInfoViewModel]? {
         didSet {
             pagerView.reloadData()
         }
@@ -39,33 +36,6 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
         tapEnabled = true
     }
 
-    func updateViewModel(_ viewModel: PXOneTapInstallmentInfoViewModel, updateAnimation: UIView.AnimationOptions? = nil) {
-        model = viewModel
-//        var animation: UIView.AnimationOptions = .transitionCrossDissolve
-//        if let customAnimation = updateAnimation {
-//            animation = customAnimation
-//        }
-//
-//        if viewModel.installmentData != nil {
-//            if arrowImage.alpha != 1 {
-//                UIView.animate(withDuration: 0.20) { [weak self] in
-//                    self?.arrowImage.alpha = 1
-//                }
-//            }
-//        } else {
-//            UIView.animate(withDuration: 0.20) { [weak self] in
-//                self?.arrowImage.alpha = 0
-//            }
-//        }
-//        
-//        UIView.transition(with: self.rightLabel, duration: 0.25, options: animation, animations: { [weak self] in
-//            self?.rightLabel.text = self?.model?.rightText
-//        }, completion: nil)
-//        UIView.transition(with: self.leftLabel, duration: 0.25, options: animation, animations: { [weak self] in
-//            self?.leftLabel.text = self?.model?.leftText
-//        }, completion: nil)
-    }
-
     func render() {
         removeAllSubviews()
         setupSlider()
@@ -80,7 +50,7 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
         PXLayout.pinRight(view: arrowImage, withMargin: PXLayout.M_MARGIN + PXLayout.XXXS_MARGIN).isActive = true
         arrowImage.tag = colapsedTag
 
-//        setupTitleLabel()
+        setupTitleLabel()
 
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleInstallments)))
     }
@@ -114,15 +84,13 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
     }
 
     @objc func toggleInstallments() {
-        print("tapped")
         if tapEnabled {
-            if let installmentData = testModel?[getCurrentIndex()].installmentData {
+            if let installmentData = model?[getCurrentIndex()].installmentData {
                 if arrowImage.tag != colapsedTag {
                     delegate?.hideInstallments()
                     UIView.animate(withDuration: 0.3) { [weak self] in
                         self?.arrowImage.transform = CGAffineTransform.identity
-                        self?.rightLabel.alpha = 1
-                        self?.leftLabel.alpha = 1
+                        self?.pagerView.alpha = 1
                         self?.titleLabel.alpha = 0
                     }
                     arrowImage.tag = colapsedTag
@@ -130,8 +98,7 @@ final class PXOneTapInstallmentInfoView: PXComponentView {
                     delegate?.showInstallments(installmentData: installmentData)
                     UIView.animate(withDuration: 0.3) { [weak self] in
                         self?.arrowImage.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
-                        self?.rightLabel.alpha = 0
-                        self?.leftLabel.alpha = 0
+                        self?.pagerView.alpha = 0
                         self?.titleLabel.alpha = 1
                     }
                     arrowImage.tag = 1
@@ -159,21 +126,21 @@ extension PXOneTapInstallmentInfoView {
 extension PXOneTapInstallmentInfoView: FSPagerViewDataSource {
 
     func numberOfItems(in pagerView: FSPagerView) -> Int {
-        guard let testModel = testModel else {return 0}
-        return testModel.count
+        guard let model = model else {return 0}
+        return model.count
     }
 
     func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewCell {
         let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index)
 
-        guard let testModel = testModel else {return FSPagerViewCell()}
+        guard let model = model else {return FSPagerViewCell()}
 
-        let model = testModel[index]
+        let itemModel = model[index]
         cell.removeAllSubviews()
 
         let leftLabel = UILabel()
         leftLabel.translatesAutoresizingMaskIntoConstraints = false
-        leftLabel.text = model.leftText
+        leftLabel.text = itemModel.leftText
         leftLabel.textAlignment = .left
         leftLabel.font = Utils.getSemiBoldFont(size: PXLayout.M_FONT)
         leftLabel.textColor = ThemeManager.shared.boldLabelTintColor()
@@ -183,7 +150,7 @@ extension PXOneTapInstallmentInfoView: FSPagerViewDataSource {
 
         let rightLabel = UILabel()
         rightLabel.translatesAutoresizingMaskIntoConstraints = false
-        rightLabel.text = model.rightText
+        rightLabel.text = itemModel.rightText
         rightLabel.textAlignment = .left
         rightLabel.font = Utils.getLightFont(size: PXLayout.XS_FONT)
         rightLabel.textColor = ThemeManager.shared.greyColor()

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentsSelectorView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentsSelectorView.swift
@@ -145,6 +145,7 @@ final class PXOneTapInstallmentsSelectorView: PXComponentView, UITableViewDelega
     }
 
     var tableViewHeightConstraint: NSLayoutConstraint?
+    let tableViewTopSeparator = UIView()
 
     func render() {
         removeAllSubviews()
@@ -160,30 +161,39 @@ final class PXOneTapInstallmentsSelectorView: PXComponentView, UITableViewDelega
         tableView.delegate = self
         tableView.dataSource = self
         tableView.tableFooterView = UIView()
+
+        tableViewTopSeparator.translatesAutoresizingMaskIntoConstraints = false
+        tableViewTopSeparator.backgroundColor = tableView.separatorColor
+        PXLayout.setHeight(owner: tableViewTopSeparator, height: 0.5).isActive = true
+        PXLayout.setWidth(owner: tableViewTopSeparator, width: PXLayout.getScreenWidth()).isActive = true
+        tableView.tableHeaderView = tableViewTopSeparator
         tableView.reloadData()
     }
 
     func expand(animator: PXAnimator, completion: @escaping () -> ()) {
         self.layoutIfNeeded()
-
+        self.tableViewTopSeparator.alpha = 1
         animateTableViewHeight(tableViewHeight: self.frame.height, completion: completion)
         animator.animate()
     }
 
     func collapse(animator: PXAnimator, completion: @escaping () -> ()) {
         self.layoutIfNeeded()
-
-        animateTableViewHeight(tableViewHeight: 0, completion: completion)
+        animateTableViewHeight(tableViewHeight: 0, hideTopSeparator: true, completion: completion)
         animator.animate()
     }
 
-    func animateTableViewHeight(tableViewHeight: CGFloat, completion: @escaping () -> ()) {
+    func animateTableViewHeight(tableViewHeight: CGFloat, hideTopSeparator: Bool = false, completion: @escaping () -> ()) {
         self.superview?.layoutIfNeeded()
 
         var pxAnimator = PXAnimator(duration: 0.5, dampingRatio: 1)
         pxAnimator.addAnimation(animation: { [weak self] in
             guard let strongSelf = self else {
                 return
+            }
+
+            if hideTopSeparator {
+                strongSelf.tableViewTopSeparator.alpha = 0
             }
             strongSelf.tableViewHeightConstraint?.constant = tableViewHeight
             strongSelf.layoutIfNeeded()

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
@@ -139,7 +139,6 @@ extension PXOneTapViewController {
         PXLayout.pinRight(view: installmentRow).isActive = true
         PXLayout.matchWidth(ofView: installmentRow).isActive = true
         PXLayout.pinTop(view: installmentRow, withMargin: PXLayout.XXXS_MARGIN).isActive = true
-        installmentInfoRow?.testModel = OneTapService.getInstallmentTestViewModel(amount: 7)
 
         // Add card slider
         let cardSliderContentView = UIView()
@@ -213,7 +212,7 @@ extension PXOneTapViewController {
 
     private func getInstallmentInfoView() -> UIView {
         installmentInfoRow = PXOneTapInstallmentInfoView()
-        installmentInfoRow?.model = PXOneTapInstallmentInfoViewModel(leftText: "", rightText: "", installmentData: nil)
+        installmentInfoRow?.model = OneTapService.getInstallmentTestViewModel(amount: OneTapService.getCardSliderViewModel().count)
         installmentInfoRow?.render()
         installmentInfoRow?.delegate = self
         if let targetView = installmentInfoRow {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
@@ -212,7 +212,7 @@ extension PXOneTapViewController {
 
     private func getInstallmentInfoView() -> UIView {
         installmentInfoRow = PXOneTapInstallmentInfoView()
-        installmentInfoRow?.model = OneTapService.getInstallmentTestViewModel(amount: OneTapService.getCardSliderViewModel().count)
+        installmentInfoRow?.model = OneTapService.getInstallmentsViewModel(amount: OneTapService.getCardSliderViewModel().count)
         installmentInfoRow?.render()
         installmentInfoRow?.delegate = self
         if let targetView = installmentInfoRow {
@@ -297,8 +297,6 @@ extension PXOneTapViewController: PXCardSliderProtocol {
             print("newCardDidSelected: \(String(describing: targetModel.cardData?.number))")
             loadingButtonComponent?.setEnabled()
         }
-//        installmentInfoRow?.updateViewModel(OneTapService.getInstallmentViewModel(cardSliderViewModel: targetModel), updateAnimation: UIView.AnimationOptions.curveLinear)
-//        installmentInfoRow?.updateViewModel(OneTapService.getInstallmentViewModel(cardSliderViewModel: targetModel))
     }
 
     func addPaymentMethodCardDidTap() {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
@@ -139,6 +139,7 @@ extension PXOneTapViewController {
         PXLayout.pinRight(view: installmentRow).isActive = true
         PXLayout.matchWidth(ofView: installmentRow).isActive = true
         PXLayout.pinTop(view: installmentRow, withMargin: PXLayout.XXXS_MARGIN).isActive = true
+        installmentInfoRow?.testModel = OneTapService.getInstallmentTestViewModel(amount: 7)
 
         // Add card slider
         let cardSliderContentView = UIView()
@@ -297,12 +298,17 @@ extension PXOneTapViewController: PXCardSliderProtocol {
             print("newCardDidSelected: \(String(describing: targetModel.cardData?.number))")
             loadingButtonComponent?.setEnabled()
         }
-        installmentInfoRow?.updateViewModel(OneTapService.getInstallmentViewModel(cardSliderViewModel: targetModel))
+//        installmentInfoRow?.updateViewModel(OneTapService.getInstallmentViewModel(cardSliderViewModel: targetModel), updateAnimation: UIView.AnimationOptions.curveLinear)
+//        installmentInfoRow?.updateViewModel(OneTapService.getInstallmentViewModel(cardSliderViewModel: targetModel))
     }
 
     func addPaymentMethodCardDidTap() {
         // TODO: Go to grupos -> add new card
         shouldChangePaymentMethod()
+    }
+
+    func didScroll(offset: CGPoint) {
+        installmentInfoRow?.setSliderOffset(offset: offset)
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/FSPager/FSPagerView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/FSPager/FSPagerView.swift
@@ -509,12 +509,6 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// - Parameters:
     ///   - index: The index of the item to scroll into view.
     ///   - animated: Specify true to animate the scrolling behavior or false to adjust the pager view’s visible content immediately.
-    open func scrollToOffset(_ offset: CGPoint) {
-//        let contentOffset = self.collectionViewLayout.contentOffset(for: int ?? )
-        self.collectionView.setContentOffset(offset, animated: false)
-    }
-
-
     @objc(scrollToItemAtIndex:animated:)
     open func scrollToItem(at index: Int, animated: Bool) {
         guard index < self.numberOfItems else {
@@ -532,7 +526,16 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
         let contentOffset = self.collectionViewLayout.contentOffset(for: indexPath)
         self.collectionView.setContentOffset(contentOffset, animated: animated)
     }
-    
+
+    /// Scrolls the pager view contents until the specified offset
+    ///
+    /// - Parameters:
+    ///   - offset: The desired offset
+    ///   - animated: Specify true to animate the scrolling behavior or false to adjust the pager view’s visible content immediately.
+    open func scrollToOffset(_ offset: CGPoint, animated: Bool) {
+        self.collectionView.setContentOffset(offset, animated: animated)
+    }
+
     /// Returns the index of the specified cell.
     ///
     /// - Parameter cell: The cell object whose index you want.

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/FSPager/FSPagerView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/FSPager/FSPagerView.swift
@@ -207,6 +207,10 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
         let scrollOffset = Double(contentOffset/self.collectionViewLayout.itemSpacing)
         return fmod(CGFloat(scrollOffset), CGFloat(Double(self.numberOfItems)))
     }
+
+    open var literalScrollOffset: CGPoint {
+        return self.collectionView.contentOffset
+    }
     
     /// The underlying gesture recognizer for pan gestures.
     @objc
@@ -505,6 +509,12 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// - Parameters:
     ///   - index: The index of the item to scroll into view.
     ///   - animated: Specify true to animate the scrolling behavior or false to adjust the pager view’s visible content immediately.
+    open func scrollToOffset(_ offset: CGPoint) {
+//        let contentOffset = self.collectionViewLayout.contentOffset(for: int ?? )
+        self.collectionView.setContentOffset(offset, animated: false)
+    }
+
+
     @objc(scrollToItemAtIndex:animated:)
     open func scrollToItem(at index: Int, animated: Bool) {
         guard index < self.numberOfItems else {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/PXCardSlider.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/PXCardSlider.swift
@@ -11,6 +11,7 @@ internal typealias PXCardSliderViewModel = (cardUI: CardUI, cardData: CardData?)
 protocol PXCardSliderProtocol: NSObjectProtocol {
     func newCardDidSelected(targetModel: PXCardSliderViewModel)
     func addPaymentMethodCardDidTap()
+    func didScroll(offset: CGPoint)
 }
 
 final class PXCardSlider: NSObject {
@@ -60,6 +61,10 @@ extension PXCardSlider: FSPagerViewDataSource {
 
 // MARK: Delegate
 extension PXCardSlider: FSPagerViewDelegate {
+    func pagerViewDidScroll(_ pagerView: FSPagerView) {
+        delegate?.didScroll(offset: pagerView.literalScrollOffset)
+    }
+
     func pagerViewWillEndDragging(_ pagerView: FSPagerView, targetIndex: Int) {
         pageControl.currentPage = targetIndex
         if selectedIndex != targetIndex {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/PXCardSlider.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/PXCardSlider.swift
@@ -141,7 +141,8 @@ extension PXCardSlider {
 
     private func setupPager(_ containerView: UIView) {
         let pagerYMargin: CGFloat = PXLayout.XS_MARGIN
-        let pagerHeight: CGFloat = 25
+        let pagerHeight: CGFloat = 10
+        pageControl.radius = 3
         pageControl.contentHorizontalAlignment = .center
         pageControl.numberOfPages = model.count
         pageControl.currentPage = 0


### PR DESCRIPTION
##  Cambios introducidos : 
- Se agrega la animacion del slide en el selector de cuotasç
- Se cambia el tamaño del UIPageControl del seleccionador de tarjetas
- Se agrega la linea separadora en el top del selector de cuotas

### Revisión
- [x] Todos los textos se encuentran localizables
- [x] No se introducen warnings al proyecto
- [x] Se incluyen cambios de UX ? se verificó que se vean bien tanto en iPhone SE y S6 : NA
- [x] No se agregan logs / prints innecesarios
- [x] No se agregan comentarios basura
- [ ] Correr Swiftlint

### Testeo
- [x] Testeado en BETA con emulador
- [x] Testeado en BETA con dispositivo
- [ ] Test unitarios OK
- [ ] Test funcionales OK
- [ ] Documentación actualizada
