### PR TITLE
Add helper image in summary (for discounts)

### DIFF
--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -82,11 +82,11 @@ self.checkoutBuilder = [[MercadoPagoCheckoutBuilder alloc] initWithPublicKey:@"T
     PXAdvancedConfiguration* advancedConfig = [[PXAdvancedConfiguration alloc] init];
 
     // Add theme to advanced config.
-    //MeliTheme *meliTheme = [[MeliTheme alloc] init];
-    //[advancedConfig setTheme:meliTheme];
+    MeliTheme *meliTheme = [[MeliTheme alloc] init];
+    [advancedConfig setTheme:meliTheme];
 
-    MPTheme *mpTheme = [[MPTheme alloc] init];
-    [advancedConfig setTheme:mpTheme];
+    //MPTheme *mpTheme = [[MPTheme alloc] init];
+    //[advancedConfig setTheme:mpTheme];
 
     // Add ReviewConfirm configuration to advanced config.
     [advancedConfig setReviewConfirmConfiguration: [self getReviewScreenConfiguration]];

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-typealias OneTapHeaderSummaryData = (title: String, value: String, highlightedColor: UIColor, alpha: CGFloat, isTotal: Bool)
+typealias OneTapHeaderSummaryData = (title: String, value: String, highlightedColor: UIColor, alpha: CGFloat, isTotal: Bool, image: UIImage?)
 
 protocol PXOneTapHeaderProtocol: NSObjectProtocol {
     func didTapSummary()
@@ -110,6 +110,18 @@ class PXOneTapHeaderView: PXComponentView {
         rowView.addSubview(titleLabel)
         PXLayout.pinLeft(view: titleLabel, withMargin: PXLayout.M_MARGIN).isActive = true
         PXLayout.centerVertically(view: titleLabel).isActive = true
+
+        if let rightImage = data.image {
+            let imageView: UIImageView = UIImageView()
+            let imageSize: CGFloat = 16
+            imageView.image = rightImage
+            imageView.contentMode = .scaleAspectFit
+            rowView.addSubview(imageView)
+            PXLayout.setWidth(owner: imageView, width: imageSize).isActive = true
+            PXLayout.setHeight(owner: imageView, height: imageSize).isActive = true
+            PXLayout.centerVertically(view: imageView, to: titleLabel).isActive = true
+            PXLayout.put(view: imageView, rightOf: titleLabel, withMargin: PXLayout.XXS_MARGIN).isActive = true
+        }
 
         let valueLabel = UILabel()
         valueLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
@@ -131,12 +131,13 @@ extension PXOneTapViewModel {
 
         if let discount = amountHelper.discount {
             // TODO: Translations and Set proper colors / localized or beta_localize
-            customData.append(OneTapHeaderSummaryData("Tu compra".localized, yourPurchaseToShow, summaryColor, summaryAlpha, false))
+            customData.append(OneTapHeaderSummaryData("Tu compra".localized, yourPurchaseToShow, summaryColor, summaryAlpha, false, nil))
             let discountToShow = Utils.getAmountFormated(amount: discount.couponAmount, forCurrency: currency)
-            customData.append(OneTapHeaderSummaryData(discount.getDiscountDescription(), "- \(discountToShow)", discountColor, discountAlpha, false))
+            let helperImage: UIImage? = isDefaultStatusBarStyle ? ResourceManager.shared.getImage("helper_ico") : ResourceManager.shared.getImage("helper_ico_light")
+            customData.append(OneTapHeaderSummaryData(discount.getDiscountDescription(), "- \(discountToShow)", discountColor, discountAlpha, false, helperImage))
         }
 
-        customData.append(OneTapHeaderSummaryData("Total a pagar".localized, totalAmountToShow, totalColor, totalAlpha, true))
+        customData.append(OneTapHeaderSummaryData("Total a pagar".localized, totalAmountToShow, totalColor, totalAlpha, true, nil))
 
         // HeaderImage
         var headerImage: UIImage = UIImage()


### PR DESCRIPTION
Se agrega ícono helper de "?" al lado del descuento.
Para Meli y MP.
Ver screens.

![image](https://user-images.githubusercontent.com/972199/47724711-fc5b0100-dc35-11e8-8ffe-7dc4862d8262.png)
![image](https://user-images.githubusercontent.com/972199/47724727-01b84b80-dc36-11e8-9ed4-107e8b16bcf0.png)
