### PR TITLE
Add ServiceLayer for Alamofire request

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Alamofire/Alamofire+PXServiceLayer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Alamofire/Alamofire+PXServiceLayer.swift
@@ -1,0 +1,50 @@
+//
+//  Alamofire+PXServiceLayer.swift
+//  MercadoPagoSDK
+//
+//  Created by Juan sebastian Sanzone on 9/11/18.
+//
+
+import Foundation
+
+internal struct PXServiceLayer {
+    // MARK: - Data Request
+
+    /// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of the specified `url`,
+    /// `method`, `parameters`, `encoding` and `headers`.
+    ///
+    /// - parameter url:        The URL.
+    /// - parameter method:     The HTTP method. `.get` by default.
+    /// - parameter parameters: The parameters. `nil` by default.
+    /// - parameter encoding:   The parameter encoding. `URLEncoding.default` by default.
+    /// - parameter headers:    The HTTP headers. `nil` by default.
+    ///
+    /// - returns: The created `DataRequest`.
+    @discardableResult
+    internal func request(
+        _ url: URLConvertible,
+        method: HTTPMethod = .get,
+        parameters: Parameters? = nil,
+        encoding: ParameterEncoding = URLEncoding.default,
+        headers: HTTPHeaders? = nil)
+        -> DataRequest {
+            return SessionManager.default.request(
+                url,
+                method: method,
+                parameters: parameters,
+                encoding: encoding,
+                headers: headers
+            )
+    }
+
+    /// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
+    /// specified `urlRequest`.
+    ///
+    /// - parameter urlRequest: The URL request
+    ///
+    /// - returns: The created `DataRequest`.
+    @discardableResult
+    internal func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
+        return SessionManager.default.request(urlRequest)
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Alamofire/Alamofire.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Alamofire/Alamofire.swift
@@ -116,46 +116,6 @@ extension URLRequest {
     }
 }
 
-// MARK: - Data Request
-
-/// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of the specified `url`,
-/// `method`, `parameters`, `encoding` and `headers`.
-///
-/// - parameter url:        The URL.
-/// - parameter method:     The HTTP method. `.get` by default.
-/// - parameter parameters: The parameters. `nil` by default.
-/// - parameter encoding:   The parameter encoding. `URLEncoding.default` by default.
-/// - parameter headers:    The HTTP headers. `nil` by default.
-///
-/// - returns: The created `DataRequest`.
-@discardableResult
-internal func request(
-    _ url: URLConvertible,
-    method: HTTPMethod = .get,
-    parameters: Parameters? = nil,
-    encoding: ParameterEncoding = URLEncoding.default,
-    headers: HTTPHeaders? = nil)
-    -> DataRequest {
-    return SessionManager.default.request(
-        url,
-        method: method,
-        parameters: parameters,
-        encoding: encoding,
-        headers: headers
-    )
-}
-
-/// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
-/// specified `urlRequest`.
-///
-/// - parameter urlRequest: The URL request
-///
-/// - returns: The created `DataRequest`.
-@discardableResult
-internal func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
-    return SessionManager.default.request(urlRequest)
-}
-
 // MARK: - Download Request
 
 // MARK: URL Request

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Services/MercadoPagoService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Services/MercadoPagoService.swift
@@ -58,33 +58,18 @@ internal class MercadoPagoService: NSObject {
 
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
 
-        #if PX_PRIVATE_POD
-            MercadoPagoSDKV4.request(request).responseData { response in
-                MercadoPagoService.debugPrint(response: response)
-                UIApplication.shared.isNetworkActivityIndicatorVisible = false
-                if let data = response.result.value, response.error == nil {
-                    success(data)
-                } else if let error = response.error as NSError? {
-                    failure?(error)
-                } else {
-                    let error: NSError = NSError(domain: "com.mercadopago.sdk", code: NSURLErrorCannotDecodeContentData, userInfo: nil)
-                    failure?(error)
-                }
+        PXServiceLayer().request(request).responseData { response in
+            MercadoPagoService.debugPrint(response: response)
+            UIApplication.shared.isNetworkActivityIndicatorVisible = false
+            if let data = response.result.value, response.error == nil {
+                success(data)
+            } else if let error = response.error as NSError? {
+                failure?(error)
+            } else {
+                let error: NSError = NSError(domain: "com.mercadopago.sdk", code: NSURLErrorCannotDecodeContentData, userInfo: nil)
+                failure?(error)
             }
-        #else
-            MercadoPagoSDKV4.request(request).responseData { response in
-                MercadoPagoService.debugPrint(response: response)
-                UIApplication.shared.isNetworkActivityIndicatorVisible = false
-                if let data = response.result.value, response.error == nil {
-                    success(data)
-                } else if let error = response.error as NSError? {
-                    failure?(error)
-                } else {
-                    let error: NSError = NSError(domain: "com.mercadopago.sdk", code: NSURLErrorCannotDecodeContentData, userInfo: nil)
-                    failure?(error)
-                }
-            }
-        #endif
+        }
     }
 }
 


### PR DESCRIPTION
@edentorres 
Se me ocurrió este pequeño cambio, para hacer escalar el problema que teníamos de  MercadoPadoSDK vs MercadopagoSDKV4 y la función Request.

Lo probe bastante y no vi problemas. Las request se efectuan correctamente. Y obviamente escala a CI y a cualquier otro problema que se nos presentaba previamente. Fijate como lo ves.
De todas maneras, la idea no es meterlo en la RC de OneTap. Lo discutimos entre todos el lunes/martes.
Por ahora lo dejo como "do not merge". Por ahi esto abre la puerta a otra idea que se te ocurre, y termina siendo una solución mucho mejor. Evalualo si queres y decime. 

@demtej Revisalo vos tb.