### PR TITLE
[Fix] Save esc after tokenization in one tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.4.1
+🚀Private RC - 4.4.1 🚀
+MercadoPagoSDKV4 - Private Version
+- Hotfix save ESC in one tap
+
 # v4.4.0
 🚀Private RC - 4.4.0 🚀
 MercadoPagoSDKV4 - Private Version

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+PaymentFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+PaymentFlow.swift
@@ -35,8 +35,10 @@ extension OneTapFlow: PXPaymentResultHandlerProtocol {
         self.model.paymentResult = paymentResult
         self.model.instructionsInfo = instructionsInfo
         if self.model.needToShowLoading() {
+            model.saveEsc()
             self.executeNextStep()
         } else {
+            model.saveEsc()
             PXAnimatedButton.animateButtonWith(status: paymentResult.status, statusDetail: paymentResult.statusDetail)
         }
     }
@@ -44,8 +46,10 @@ extension OneTapFlow: PXPaymentResultHandlerProtocol {
     func finishPaymentFlow(businessResult: PXBusinessResult) {
         self.model.businessResult = businessResult
         if self.model.needToShowLoading() {
+            model.saveEsc()
             self.executeNextStep()
         } else {
+            model.saveEsc()
             PXAnimatedButton.animateButtonWith(status: businessResult.getStatus().getDescription())
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
@@ -121,6 +121,19 @@ internal extension OneTapFlowModel {
             self.paymentData.cleanToken()
         }
     }
+
+    func saveEsc() {
+        guard let token = paymentData.token else {
+            return
+        }
+        if !token.cardId.isEmpty {
+            if let esc = token.esc {
+                mpESCManager.saveESC(cardId: token.cardId, esc: esc)
+            } else {
+                mpESCManager.deleteESC(cardId: token.cardId)
+            }
+        }
+    }
 }
 
 // MARK: Flow logic

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
@@ -112,14 +112,6 @@ internal extension OneTapFlowModel {
     }
 
     func updateCheckoutModel(token: PXToken) {
-        if !token.cardId.isEmpty {
-            if let esc = token.esc {
-                mpESCManager.saveESC(cardId: token.cardId, esc: esc)
-            } else {
-                mpESCManager.deleteESC(cardId: token.cardId)
-            }
-        }
-
         self.paymentData.updatePaymentDataWith(token: token)
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Plist/mpsdk_settings.plist
+++ b/MercadoPagoSDK/MercadoPagoSDK/Plist/mpsdk_settings.plist
@@ -5,7 +5,7 @@
 	<key>flow_sdk_type_hybrid</key>
 	<false/>
 	<key>sdk_version</key>
-	<string>4.4.0</string>
+	<string>4.4.1</string>
 	<key>tracking_settings</key>
 	<dict>
 		<key>tracking_enabled</key>

--- a/MercadoPagoSDKV4.podspec
+++ b/MercadoPagoSDKV4.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDKV4"
-  s.version          = "4.4.0"
+  s.version          = "4.4.1"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
##  Cambios introducidos : 
- Se soluciona un bug al guardar el esc después de tokenizar en one tap. Se estaba guardando antes de checkear si hay que animar el botón o ir a la pantalla de cvv y eso fallaba
