### PR TITLE
[WIP] Present DynamicViewController from MercadoPagoCheckoutScreens

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckoutScreens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckoutScreens.swift
@@ -160,7 +160,11 @@ extension MercadoPagoCheckout {
             reviewVC.changePaymentMethodCallback = nil
         }
 
-        viewModel.pxNavigationHandler.pushViewController(viewController: reviewVC, animated: true)
+        if let dynamicViewController = self.viewModel.reviewConfirmViewModel().getDynamicViewController() {
+            viewModel.pxNavigationHandler.pushViewController(viewController: reviewVC, presentViewController: dynamicViewController, animated: false)
+        } else {
+            viewModel.pxNavigationHandler.pushViewController(viewController: reviewVC, animated: true)
+        }
     }
 
     func showSecurityCodeScreen() {

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/PXNavigationHandler.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/PXNavigationHandler.swift
@@ -98,6 +98,22 @@ internal class PXNavigationHandler: NSObject {
         }
     }
 
+    internal func pushViewController(viewController: MercadoPagoUIViewController, presentViewController: UIViewController,
+                                     animated: Bool, backToFirstPaymentVault: Bool = false) {
+        viewController.hidesBottomBarWhenPushed = true
+
+        if backToFirstPaymentVault {
+            self.navigationController.navigationBar.isHidden = false
+            viewController.callbackCancel = { [weak self] in self?.backToFirstPaymentVaultViewController() }
+        }
+
+        self.navigationController.pushViewController(viewController, animated: animated)
+        self.cleanCompletedCheckoutsFromNavigationStack()
+        self.dismissLoading(animated: false) {
+            self.navigationController.present(presentViewController, animated: false)
+        }
+    }
+    
     internal func pushViewController(viewController: MercadoPagoUIViewController,
                                      animated: Bool, backToFirstPaymentVault: Bool = false) {
         viewController.hidesBottomBarWhenPushed = true

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewController.swift
@@ -29,8 +29,7 @@ class PXReviewViewController: PXComponentContainerViewController {
     let timeOutPayButton: TimeInterval
     let shouldAnimatePayButton: Bool
     private let SHADOW_DELTA: CGFloat = 1
-    private var DID_ENTER_DYNAMIC_VIEW_CONTROLLER_SHOWED: Bool = false
-
+    
     internal var changePaymentMethodCallback: (() -> Void)?
 
     // MARK: Lifecycle - Publics
@@ -51,16 +50,6 @@ class PXReviewViewController: PXComponentContainerViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if !DID_ENTER_DYNAMIC_VIEW_CONTROLLER_SHOWED {
-
-            trackScreen(path: TrackingPaths.Screens.getReviewAndConfirmPath(), properties: viewModel.getScreenProperties())
-
-            if let dynamicViewController = self.viewModel.getDynamicViewController() {
-                self.present(dynamicViewController, animated: true) { [weak self] in
-                    self?.DID_ENTER_DYNAMIC_VIEW_CONTROLLER_SHOWED = true
-                }
-            }
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
##  Cambios introducidos : 
- Se presenta el DynamicViewController Modal desde MercadoPagoCheckoutScreens para no tener animación al presentar el modal.
