### PR TITLE
Custom payment method option hot fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.5.4
+🚀Private RC - 4.5.4 🚀
+MercadoPagoSDKV4 - Private Version
+- Autoselect payment method hot fix
+
 # v4.5.3
 🚀Private RC - 4.5.3 🚀
 MercadoPagoSDKV4 - Private Version

--- a/MercadoPagoSDK/MercadoPagoSDK/Plist/mpsdk_settings.plist
+++ b/MercadoPagoSDK/MercadoPagoSDK/Plist/mpsdk_settings.plist
@@ -5,7 +5,7 @@
 	<key>flow_sdk_type_hybrid</key>
 	<false/>
 	<key>sdk_version</key>
-	<string>4.5.2</string>
+	<string>4.5.4</string>
 	<key>tracking_settings</key>
 	<dict>
 		<key>tracking_enabled</key>

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCustomOptionSearchItem+PaymentMethodOption.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCustomOptionSearchItem+PaymentMethodOption.swift
@@ -1,0 +1,42 @@
+//
+//  PXCustomOptionSearchItem+PaymentMethod.swift
+//  MercadoPagoSDK
+//
+//  Created by Federico Bustos Fierro on 06/02/2019.
+//
+
+import UIKit
+
+extension PXCustomOptionSearchItem : PaymentMethodOption {
+    func getId() -> String {
+        return self.id
+    }
+    
+    func getDescription() -> String {
+        return self._description ?? ""
+    }
+    
+    func getComment() -> String {
+        return self.comment ?? ""
+    }
+    
+    func hasChildren() -> Bool {
+        return false
+    }
+    
+    func getChildren() -> [PaymentMethodOption]? {
+        return nil
+    }
+    
+    func isCard() -> Bool {
+        return false
+    }
+    
+    func isCustomerPaymentMethod() -> Bool {
+        return true
+    }
+    
+    func getPaymentType() -> String {
+        return self.paymentTypeId ?? self.id
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCustomOptionSearchItem.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCustomOptionSearchItem.swift
@@ -9,7 +9,7 @@
 import Foundation
 /// :nodoc:
 open class PXCustomOptionSearchItem: NSObject, Codable {
-    open var id: String!
+    open var id: String
     open var _description: String?
     open var paymentMethodId: String?
     open var paymentTypeId: String?

--- a/MercadoPagoSDKV4.podspec
+++ b/MercadoPagoSDKV4.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDKV4"
-  s.version          = "4.5.3"
+  s.version          = "4.5.4"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
Hot fix para que deje de crashear la autoseleccion de un solo medio de pago

##  Cambios introducidos : 
- PXCustomOptionSearchItem implementa el protocolo PaymentMethodOption 
- Cambio 2
