### PR TITLE
Feature/fixing add card navigation on start - Follow up de PR 1838

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Add_card/AddCardFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Add_card/AddCardFlow.swift
@@ -99,7 +99,6 @@ public class AddCardFlow: NSObject, PXFlow {
 
     private func getIdentificationTypes() {
         self.mercadoPagoServicesAdapter.getIdentificationTypes(callback: { [weak self] identificationTypes in
-            self?.navigationHandler.dismissLoading()
             self?.model.identificationTypes = identificationTypes
             self?.executeNextStep()
         }, failure: { [weak self] error in
@@ -107,11 +106,11 @@ public class AddCardFlow: NSObject, PXFlow {
             if error.code == ErrorTypes.NO_INTERNET_ERROR {
                 let sdkError = MPSDKError.convertFrom(error, requestOrigin: ApiUtil.RequestOrigin.GET_IDENTIFICATION_TYPES.rawValue)
                 self?.navigationHandler.showErrorScreen(error: sdkError, callbackCancel: {
+                    self?.navigationHandler.dismissLoading()
                     self?.finish()
                 }, errorCallback: nil)
             } else {
                 if let status = error.userInfo["status"] as? Int, status == 404 {
-                    self?.navigationHandler.dismissLoading()
                     self?.model.identificationTypes = []
                     self?.model.lastStepFailed = false
                     self?.executeNextStep()

--- a/MercadoPagoSDK/MercadoPagoSDK/Add_card/AddCardFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Add_card/AddCardFlow.swift
@@ -106,7 +106,6 @@ public class AddCardFlow: NSObject, PXFlow {
             if error.code == ErrorTypes.NO_INTERNET_ERROR {
                 let sdkError = MPSDKError.convertFrom(error, requestOrigin: ApiUtil.RequestOrigin.GET_IDENTIFICATION_TYPES.rawValue)
                 self?.navigationHandler.showErrorScreen(error: sdkError, callbackCancel: {
-                    self?.navigationHandler.dismissLoading()
                     self?.finish()
                 }, errorCallback: nil)
             } else {


### PR DESCRIPTION
## Follow up de https://github.com/mercadopago/px-ios/pull/1838

##  Cambios Introducidos: 
- El flujo de inicio de AddCard está mostrando una transición rara cuando arranca. Se está sacando la loading screen cuando aún faltan un par de cosas para hacer el push del VC, así que estoy moviendo el dismiss al método que hace el push.
- También agregué el dismiss en el control de errores en los casos correspondientes y controlé sacando el dismiss de getIdentificationTypes no se esté rompiendo otro flujo (getIdentificationTypes siempre llama a openCardForm).

- Los tests están pasando (a excepción de uno que está roto pero no está relacionado y lo están refactorizando).

- Se probó con la librería integrada en meli y wallet, todo ok
