### PR TITLE
Subtitle UI Support on OneTap - SP Support

### DIFF
--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC.xcodeproj/project.pbxproj
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 				566C2527E61696E3F28310A3 /* [CP] Embed Pods Frameworks */,
 				241F85E381FBE0F789D9F57E /* [CP] Embed Pods Frameworks */,
 				4BEC4396223C12ED0023A58E /* ShellScript */,
+				60BBEF1FC84DCD82B0DB5EF9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -409,24 +410,41 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/FXBlurView/FXBlurView.framework",
 				"${BUILT_PRODUCTS_DIR}/JRSwizzle/JRSwizzle.framework",
-				"${BUILT_PRODUCTS_DIR}/MLESCManager/MLESCManager.framework",
 				"${BUILT_PRODUCTS_DIR}/MLUI/MLUI.framework",
-				"${BUILT_PRODUCTS_DIR}/MercadoPagoSDKV4/MercadoPagoSDKV4.framework",
+				"${BUILT_PRODUCTS_DIR}/MercadoPagoSDK/MercadoPagoSDK.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FXBlurView.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JRSwizzle.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MLESCManager.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MLUI.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MercadoPagoSDKV4.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MercadoPagoSDK.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		60BBEF1FC84DCD82B0DB5EF9 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MercadoPagoSDKExamplesObjectiveC/Pods-MercadoPagoSDKExamplesObjectiveC-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		61C8862CD350C1973262282D /* [CP] Check Pods Manifest.lock */ = {

--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/PaymentPluginViewController.m
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/PaymentPluginViewController.m
@@ -45,7 +45,7 @@
 
 #pragma mark - Payment Plugin implementation.
 - (UIViewController * _Nullable)paymentProcessorViewController {
-    return self;
+    return nil;
 }
 
 - (BOOL)support {
@@ -53,7 +53,7 @@
 }
 
 - (BOOL)shouldSkipUserConfirmation {
-    return YES;
+    return NO;
 }
 
 -(void)startPaymentWithCheckoutStore:(PXCheckoutStore *)checkoutStore errorHandler:(id<PXPaymentProcessorErrorHandler>)errorHandler successWithBasePayment:(void (^)(id<PXBasePayment> _Nonnull))successWithBasePayment {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderMerchantLayout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderMerchantLayout.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct PXOneTapHeaderMerchantLayout {
-    enum LayoutType: String {
+    enum LayoutType {
         case onlyTitle
         case titleSubtitle
     }
@@ -25,7 +25,10 @@ struct PXOneTapHeaderMerchantLayout {
 // MARK: Factory make factory.
 extension PXOneTapHeaderMerchantLayout {
     mutating func makeConstraints(_ containerView: UIView, _ imageContainerView: UIView, _ titleLabel: UILabel) {
-        let horizontalConstraints = [PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+        horizontalLayoutConstraints.removeAll()
+        let horizontalConstraints = [PXLayout.pinBottom(view: containerView),
+                                     PXLayout.pinLeft(view: containerView, withMargin: PXLayout.XL_MARGIN),
+                                     PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
                                      PXLayout.pinBottom(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
                                      PXLayout.pinLeft(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
                                      PXLayout.pinRight(view: titleLabel, withMargin: PXLayout.XXS_MARGIN),
@@ -33,7 +36,10 @@ extension PXOneTapHeaderMerchantLayout {
                                      PXLayout.centerVertically(view: imageContainerView, to: titleLabel)]
         horizontalLayoutConstraints.append(contentsOf: horizontalConstraints)
 
-        let verticalConstraints = [PXLayout.centerHorizontally(view: imageContainerView),
+        verticalLayoutConstraints.removeAll()
+        let verticalConstraints = [PXLayout.pinBottom(view: containerView),
+                                   PXLayout.centerHorizontally(view: containerView),
+                                   PXLayout.centerHorizontally(view: imageContainerView),
                                    PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
                                    PXLayout.centerHorizontally(view: titleLabel),
                                    PXLayout.put(view: titleLabel, onBottomOf: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
@@ -43,7 +49,10 @@ extension PXOneTapHeaderMerchantLayout {
     }
 
     mutating func makeConstraints(_ containerView: UIView, _ imageContainerView: UIView, _ titleLabel: UILabel, _ subTitleLabel: UILabel) {
-        let horizontalConstraints = [PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+        horizontalLayoutConstraints.removeAll()
+        let horizontalConstraints = [PXLayout.pinBottom(view: containerView),
+                                     PXLayout.pinLeft(view: containerView, withMargin: PXLayout.XL_MARGIN),
+                                     PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
                                      PXLayout.pinBottom(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
                                      PXLayout.pinLeft(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
                                      PXLayout.pinRight(view: titleLabel, withMargin: PXLayout.XXS_MARGIN),
@@ -54,7 +63,10 @@ extension PXOneTapHeaderMerchantLayout {
         ]
         horizontalLayoutConstraints.append(contentsOf: horizontalConstraints)
 
-        let verticalConstraints = [PXLayout.centerHorizontally(view: imageContainerView),
+        verticalLayoutConstraints.removeAll()
+        let verticalConstraints = [PXLayout.pinBottom(view: containerView),
+                                   PXLayout.centerHorizontally(view: containerView),
+                                   PXLayout.centerHorizontally(view: imageContainerView),
                                    PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
                                    PXLayout.centerHorizontally(view: titleLabel),
                                    PXLayout.put(view: titleLabel, onBottomOf: imageContainerView, withMargin: PXLayout.XXS_MARGIN),

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderMerchantLayout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderMerchantLayout.swift
@@ -1,0 +1,82 @@
+//
+//  PXOneTapHeaderMerchantLayout.swift
+//  MercadoPagoSDK
+//
+//  Created by Juan sebastian Sanzone on 3/23/19.
+//
+
+import Foundation
+
+struct PXOneTapHeaderMerchantLayout {
+    enum LayoutType: String {
+        case onlyTitle
+        case titleSubtitle
+    }
+
+    private let layoutType: LayoutType
+    private var horizontalLayoutConstraints: [NSLayoutConstraint] = []
+    private var verticalLayoutConstraints: [NSLayoutConstraint] = []
+
+    init(layoutType: PXOneTapHeaderMerchantLayout.LayoutType) {
+        self.layoutType = layoutType
+    }
+}
+
+// MARK: Factory make factory.
+extension PXOneTapHeaderMerchantLayout {
+    mutating func makeConstraints(_ containerView: UIView, _ imageContainerView: UIView, _ titleLabel: UILabel) {
+        let horizontalConstraints = [PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                     PXLayout.pinBottom(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                     PXLayout.pinLeft(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                     PXLayout.pinRight(view: titleLabel, withMargin: PXLayout.XXS_MARGIN),
+                                     PXLayout.put(view: imageContainerView, leftOf: titleLabel, withMargin: PXLayout.XXS_MARGIN, relation: .equal),
+                                     PXLayout.centerVertically(view: imageContainerView, to: titleLabel)]
+        horizontalLayoutConstraints.append(contentsOf: horizontalConstraints)
+
+        let verticalConstraints = [PXLayout.centerHorizontally(view: imageContainerView),
+                                   PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                   PXLayout.centerHorizontally(view: titleLabel),
+                                   PXLayout.put(view: titleLabel, onBottomOf: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                   PXLayout.pinBottom(view: titleLabel, withMargin: PXLayout.XXS_MARGIN),
+                                   PXLayout.matchWidth(ofView: containerView)]
+        verticalLayoutConstraints.append(contentsOf: verticalConstraints)
+    }
+
+    mutating func makeConstraints(_ containerView: UIView, _ imageContainerView: UIView, _ titleLabel: UILabel, _ subTitleLabel: UILabel) {
+        let horizontalConstraints = [PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                     PXLayout.pinBottom(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                     PXLayout.pinLeft(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                     PXLayout.pinRight(view: titleLabel, withMargin: PXLayout.XXS_MARGIN),
+                                     PXLayout.put(view: imageContainerView, leftOf: titleLabel, withMargin: PXLayout.XXS_MARGIN, relation: .equal),
+                                     PXLayout.pinBottom(view: titleLabel, to: subTitleLabel, withMargin: PXLayout.XS_MARGIN),
+                                     PXLayout.pinLeft(view: subTitleLabel, to: titleLabel, withMargin: 0),
+                                     PXLayout.pinTop(view: titleLabel, to: imageContainerView, withMargin: 0)
+        ]
+        horizontalLayoutConstraints.append(contentsOf: horizontalConstraints)
+
+        let verticalConstraints = [PXLayout.centerHorizontally(view: imageContainerView),
+                                   PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                   PXLayout.centerHorizontally(view: titleLabel),
+                                   PXLayout.put(view: titleLabel, onBottomOf: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
+                                   PXLayout.centerHorizontally(view: subTitleLabel),
+                                   PXLayout.put(view: subTitleLabel, onBottomOf: titleLabel, withMargin: PXLayout.XXXS_MARGIN),
+                                   PXLayout.pinBottom(view: subTitleLabel, withMargin: PXLayout.XXS_MARGIN),
+                                   PXLayout.matchWidth(ofView: containerView)]
+        verticalLayoutConstraints.append(contentsOf: verticalConstraints)
+    }
+}
+
+// MARK: Publics
+extension PXOneTapHeaderMerchantLayout {
+    func getLayoutType() -> LayoutType {
+        return layoutType
+    }
+
+    func getHorizontalContrainsts() -> [NSLayoutConstraint] {
+        return horizontalLayoutConstraints
+    }
+
+    func getVerticalContrainsts() -> [NSLayoutConstraint] {
+        return verticalLayoutConstraints
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderMerchantView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderMerchantView.swift
@@ -73,8 +73,6 @@ class PXOneTapHeaderMerchantView: PXComponentView {
         containerView.addSubview(titleLabel)
 
         addSubviewToBottom(containerView)
-        PXLayout.pinBottom(view: containerView).isActive = true
-        PXLayout.centerHorizontally(view: containerView).isActive = true
 
         if layout.getLayoutType() == .onlyTitle {
             layout.makeConstraints(containerView, imageContainerView, titleLabel)

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderMerchantView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderMerchantView.swift
@@ -10,14 +10,16 @@ import UIKit
 class PXOneTapHeaderMerchantView: PXComponentView {
     let image: UIImage
     let title: String
+    private var subTitle: String?
     private var showHorizontally: Bool
-    private var horizontalLayoutConstraints: [NSLayoutConstraint] = []
-    private var verticalLayoutConstraints: [NSLayoutConstraint] = []
+    private var layout: PXOneTapHeaderMerchantLayout
 
-    init(image: UIImage, title: String, showHorizontally: Bool) {
+    init(image: UIImage, title: String, subTitle: String? = nil, showHorizontally: Bool) {
         self.image = image
         self.title = title
         self.showHorizontally = showHorizontally
+        self.subTitle = subTitle
+        self.layout = PXOneTapHeaderMerchantLayout(layoutType: subTitle == nil ? .onlyTitle : .titleSubtitle)
         super.init()
         render()
     }
@@ -70,27 +72,26 @@ class PXOneTapHeaderMerchantView: PXComponentView {
         titleLabel.textAlignment = .center
         containerView.addSubview(titleLabel)
 
-        self.addSubviewToBottom(containerView)
+        addSubviewToBottom(containerView)
         PXLayout.pinBottom(view: containerView).isActive = true
         PXLayout.centerHorizontally(view: containerView).isActive = true
 
-        let horizontalConstraints = [PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
-                                     PXLayout.pinBottom(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
-                                     PXLayout.pinLeft(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
-                                     PXLayout.pinRight(view: titleLabel, withMargin: PXLayout.XXS_MARGIN),
-                                     PXLayout.put(view: imageContainerView, leftOf: titleLabel, withMargin: PXLayout.XXS_MARGIN, relation: .equal),
-                                     PXLayout.centerVertically(view: imageContainerView, to: titleLabel)]
-
-        horizontalLayoutConstraints.append(contentsOf: horizontalConstraints)
-
-        let verticalConstraints = [PXLayout.centerHorizontally(view: imageContainerView),
-                                   PXLayout.pinTop(view: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
-                                   PXLayout.centerHorizontally(view: titleLabel),
-                                   PXLayout.put(view: titleLabel, onBottomOf: imageContainerView, withMargin: PXLayout.XXS_MARGIN),
-                                   PXLayout.pinBottom(view: titleLabel, withMargin: PXLayout.XXS_MARGIN),
-                                   PXLayout.matchWidth(ofView: containerView)]
-
-        verticalLayoutConstraints.append(contentsOf: verticalConstraints)
+        if layout.getLayoutType() == .onlyTitle {
+            layout.makeConstraints(containerView, imageContainerView, titleLabel)
+        } else {
+            let subTitleAlpha: CGFloat = 0.48
+            let subTitleLabel = UILabel()
+            subTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+            subTitleLabel.text = subTitle
+            subTitleLabel.numberOfLines = 1
+            subTitleLabel.alpha = subTitleAlpha
+            subTitleLabel.lineBreakMode = .byTruncatingTail
+            subTitleLabel.font = Utils.getFont(size: PXLayout.XXXS_FONT)
+            subTitleLabel.textColor = ThemeManager.shared.statusBarStyle() == UIStatusBarStyle.default ? UIColor.black : ThemeManager.shared.whiteColor()
+            subTitleLabel.textAlignment = .center
+            containerView.addSubview(subTitleLabel)
+            layout.makeConstraints(containerView, imageContainerView, titleLabel, subTitleLabel)
+        }
 
         if showHorizontally {
             animateToHorizontal()
@@ -118,11 +119,11 @@ class PXOneTapHeaderMerchantView: PXComponentView {
 
             strongSelf.layoutIfNeeded()
 
-            for constraint in strongSelf.horizontalLayoutConstraints {
+            for constraint in strongSelf.layout.getHorizontalContrainsts() {
                 constraint.isActive = false
             }
 
-            for constraint in strongSelf.verticalLayoutConstraints {
+            for constraint in strongSelf.layout.getVerticalContrainsts() {
                 constraint.isActive = true
             }
             strongSelf.layoutIfNeeded()
@@ -141,11 +142,11 @@ class PXOneTapHeaderMerchantView: PXComponentView {
 
             strongSelf.layoutIfNeeded()
             strongSelf.pinContentViewToTop()
-            for constraint in strongSelf.horizontalLayoutConstraints {
+            for constraint in strongSelf.layout.getHorizontalContrainsts() {
                 constraint.isActive = true
             }
 
-            for constraint in strongSelf.verticalLayoutConstraints {
+            for constraint in strongSelf.layout.getVerticalContrainsts() {
                 constraint.isActive = false
             }
             strongSelf.layoutIfNeeded()

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderView.swift
@@ -290,7 +290,7 @@ extension PXOneTapHeaderView {
         PXLayout.put(view: splitPaymentView, onBottomOf: summaryView).isActive = true
 
         let showHorizontally = shouldShowHorizontally(model: model)
-        let merchantView = PXOneTapHeaderMerchantView(image: model.icon, title: model.title, showHorizontally: showHorizontally)
+        let merchantView = PXOneTapHeaderMerchantView(image: model.icon, title: model.title, subTitle: model.subTitle, showHorizontally: showHorizontally)
         self.merchantView = merchantView
         self.addSubview(merchantView)
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeaderViewModel.swift
@@ -12,12 +12,14 @@ typealias OneTapHeaderSummaryData = (title: String, value: String, highlightedCo
 class PXOneTapHeaderViewModel {
     let icon: UIImage
     let title: String
+    let subTitle: String?
     let data: [OneTapHeaderSummaryData]
     let splitConfiguration: PXSplitConfiguration?
 
-    init(icon: UIImage, title: String, data: [OneTapHeaderSummaryData], splitConfiguration: PXSplitConfiguration?) {
+    init(icon: UIImage, title: String, subTitle: String?, data: [OneTapHeaderSummaryData], splitConfiguration: PXSplitConfiguration?) {
         self.icon = icon
         self.title = title
+        self.subTitle = subTitle
         self.data = data
         self.splitConfiguration = splitConfiguration
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
@@ -191,14 +191,14 @@ extension PXOneTapViewModel {
             }
         }
 
-        // HeaderTitle
+        // TODO: Q2 2019 - SP Integration - Get title and subtitle from Preference.
         if let headerTitleStr = items.first?._description {
             headerTitle = headerTitleStr
         } else if let headerTitleStr = items.first?.title {
             headerTitle = headerTitleStr
         }
 
-        let headerVM = PXOneTapHeaderViewModel(icon: headerImage, title: headerTitle, data: customData, splitConfiguration: splitConfiguration)
+        let headerVM = PXOneTapHeaderViewModel(icon: headerImage, title: headerTitle, subTitle: nil, data: customData, splitConfiguration: splitConfiguration)
         return headerVM
     }
 


### PR DESCRIPTION
##  Cambios introducidos : 
- Se agrega la capacidad visual de soportar subtitulo opcional en OneTap. 
- Este cambio es netamente visual. Todavia el subtitulo no se consumirá por lo cual siempre renderizará el "viejo" y actual layout.
- Dada la complejidad (y cantidad de codigo) de los renders via código. Desarrollé para este caso, un objeto Layout. Que es el encargado segun el caso de generar las constraints de cada tipo de layout.

## Importante:
El TODO:  _Q2 2019 - SP Integration - Get title and subtitle from Preference_.
hace referencia a una tarea que no esta relacionada con este PR. Y es una tarea que haremos
en Q2. Que tiene que ver con resolver de que lugar de la preferencia tomaremos el title y subtitle para OneTap. Sin afectar obviamente integraciones actuales.

La idea de este PR es que ya tengamos soportado esto en el ViewModel de OneTap y en el Render
visual, para así en Q2, nuestra tarea este resumida a levantar el dato de la preferencia y pasarsela al modelo.

## Caps Escenarios Soportados
![image](https://user-images.githubusercontent.com/972199/54930465-169fbf00-4ef6-11e9-97e5-24296857f2da.png)



