### PR TITLE
SP Support - AdditionalInfo by CheckoutPref

### DIFF
--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -211,7 +211,7 @@
 
 -(void)setCheckoutPrefAdditionalInfo {
     // Example SP support for custom additional info.
-    self.pref.additionalInfo = @"{\"px_summary\":{\"title\":\"Titulo en additional info\",\"image_url\":\"https://pbs.twimg.com/profile_images/589556737876844544/Gz0_UguO_400x400.jpg\",\"subtitle\":\"Subtítulo en additional info\",\"purpose\":\"Tu vieja\"}}";
+    self.pref.additionalInfo = @"{\"px_summary\":{\"title\":\"Recarga Claro\",\"image_url\":\"https://www.rondachile.cl/wordpress/wp-content/uploads/2018/03/Logo-Claro-1.jpg\",\"subtitle\":\"Celular 1159199234\",\"purpose\":\"Tu recarga\"}}";
 }
 
 -(void)setCheckoutPref_WithId {

--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -67,6 +67,7 @@
 //
 
     [self setCheckoutPref_CreditCardNotExcluded];
+    [self setCheckoutPrefAdditionalInfo];
 
     self.checkoutBuilder = [[MercadoPagoCheckoutBuilder alloc] initWithPublicKey:@"APP_USR-ba2e6b8c-8b6d-4fc3-8a47-0ab241d0dba4" checkoutPreference:self.pref paymentConfiguration:[self getPaymentConfiguration]];
 
@@ -206,6 +207,11 @@
 
     self.pref = [[PXCheckoutPreference alloc] initWithSiteId:@"MLA" payerEmail:@"sara@gmail.com" items:items];
 //    [self.pref addExcludedPaymentType:@"ticket"];
+}
+
+-(void)setCheckoutPrefAdditionalInfo {
+    // Example SP support for custom additional info.
+    self.pref.additionalInfo = @"{\"px_summary\":{\"title\":\"Titulo en additional info\",\"image_url\":\"https://pbs.twimg.com/profile_images/589556737876844544/Gz0_UguO_400x400.jpg\",\"subtitle\":\"Subtítulo en additional info\",\"purpose\":\"Tu vieja\"}}";
 }
 
 -(void)setCheckoutPref_WithId {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
@@ -101,6 +101,7 @@ internal extension OneTapFlowModel {
         viewModel.paymentMethods = search.paymentMethods
         viewModel.items = checkoutPreference.items
         viewModel.paymentMethodPlugins = paymentMethodPlugins
+        viewModel.additionalInfoSummary = checkoutPreference.pxAdditionalInfo?.pxSummary
         return viewModel
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
@@ -19,6 +19,7 @@ final class PXOneTapViewModel: PXReviewViewModel {
 
     var splitPaymentEnabled: Bool = false
     var splitPaymentSelectionByUser: Bool?
+    var additionalInfoSummary: PXAdditionalInfoSummary?
 }
 
 // MARK: ViewModels Publics.
@@ -156,15 +157,20 @@ extension PXOneTapViewModel {
 
             amountHelper.getPaymentData().setDiscount(discount, withCampaign: campaign, consumedDiscount: consumedDiscount)
 
+            var yourPurchaseSummaryTitle: String = "onetap_purchase_summary_title".localized_beta
+            if let customPurposeSummaryTitle = additionalInfoSummary?.purpose {
+                yourPurchaseSummaryTitle = customPurposeSummaryTitle
+            }
+
             if consumedDiscount {
-                customData.append(OneTapHeaderSummaryData("onetap_purchase_summary_title".localized_beta, yourPurchaseToShow, summaryColor, summaryAlpha, false, nil))
+                customData.append(OneTapHeaderSummaryData(yourPurchaseSummaryTitle, yourPurchaseToShow, summaryColor, summaryAlpha, false, nil))
                 let helperImage: UIImage? = isDefaultStatusBarStyle ? ResourceManager.shared.getImage("helper_ico_gray") : ResourceManager.shared.getImage("helper_ico_light")
                 customData.append(OneTapHeaderSummaryData("total_row_consumed_discount".localized_beta, "", summaryColor, discountDisclaimerAlpha, false, helperImage))
 
                 totalAmountToShow = Utils.getAmountFormated(amount: amountHelper.getAmountToPayWithoutPayerCost(selectedCard?.cardId), forCurrency: currency)
                 yourPurchaseToShow = Utils.getAmountFormated(amount: amountHelper.preferenceAmount, forCurrency: currency)
             } else if let discount = discount {
-                customData.append(OneTapHeaderSummaryData("onetap_purchase_summary_title".localized_beta, yourPurchaseToShow, summaryColor, summaryAlpha, false, nil))
+                customData.append(OneTapHeaderSummaryData(yourPurchaseSummaryTitle, yourPurchaseToShow, summaryColor, summaryAlpha, false, nil))
                 let discountToShow = Utils.getAmountFormated(amount: discount.couponAmount, forCurrency: currency)
                 let helperImage: UIImage? = isDefaultStatusBarStyle ? ResourceManager.shared.getImage("helper_ico") : ResourceManager.shared.getImage("helper_ico_light")
                 customData.append(OneTapHeaderSummaryData(discount.getDiscountDescription(), "- \(discountToShow)", discountColor, discountAlpha, false, helperImage))
@@ -180,26 +186,45 @@ extension PXOneTapViewModel {
 
         customData.append(OneTapHeaderSummaryData("onetap_purchase_summary_total".localized_beta, totalAmountToShow, totalColor, totalAlpha, true, nil))
 
-        // HeaderImage
+        // Populate header display data. From SP pref AdditionalInfo or instore retrocompatibility.
+        let (headerTitle, headerSubtitle, headerImage) = getSummaryHeader(item: items.first, additionalInfoSummaryData: additionalInfoSummary)
+
+        let headerVM = PXOneTapHeaderViewModel(icon: headerImage, title: headerTitle, subTitle: headerSubtitle, data: customData, splitConfiguration: splitConfiguration)
+        return headerVM
+    }
+
+    func getSummaryHeader(item: PXItem?, additionalInfoSummaryData: PXAdditionalInfoSummary?) -> (title: String, subtitle: String?, image: UIImage) {
         var headerImage: UIImage = UIImage()
         var headerTitle: String = ""
-        if let headerUrl = items.first?.getPictureURL() {
-            headerImage = PXUIImage(url: headerUrl)
+        var headerSubtitle: String?
+        if let defaultImage = ResourceManager.shared.getImage("MPSDK_review_iconoCarrito_white") {
+            headerImage = defaultImage
+        }
+
+        if let additionalSummaryData = additionalInfoSummaryData, additionalSummaryData.title.count > 0 {
+            // SP and new scenario based on Additional Info Summary
+            headerTitle = additionalSummaryData.title
+            headerSubtitle = additionalSummaryData.subtitle
+            if let headerUrl = additionalSummaryData.imageUrl {
+                headerImage = PXUIImage(url: headerUrl)
+            }
         } else {
-            if let defaultImage = ResourceManager.shared.getImage("MPSDK_review_iconoCarrito_white") {
-                headerImage = defaultImage
+            // Instore scenario. Retrocompatibility
+            // To deprecate. After instore migrate current preferences.
+
+            // Title desc from item
+            if let headerTitleStr = item?._description {
+                headerTitle = headerTitleStr
+            } else if let headerTitleStr = item?.title {
+                headerTitle = headerTitleStr
+            }
+            headerSubtitle = nil
+            // Image from item
+            if let headerUrl = item?.getPictureURL() {
+                headerImage = PXUIImage(url: headerUrl)
             }
         }
-
-        // TODO: Q2 2019 - SP Integration - Get title and subtitle from Preference.
-        if let headerTitleStr = items.first?._description {
-            headerTitle = headerTitleStr
-        } else if let headerTitleStr = items.first?.title {
-            headerTitle = headerTitleStr
-        }
-
-        let headerVM = PXOneTapHeaderViewModel(icon: headerImage, title: headerTitle, subTitle: nil, data: customData, splitConfiguration: splitConfiguration)
-        return headerVM
+        return (title: headerTitle, subtitle: headerSubtitle, image: headerImage)
     }
 
     func getCardSliderViewModel() -> [PXCardSliderViewModel] {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
@@ -201,9 +201,9 @@ extension PXOneTapViewModel {
             headerImage = defaultImage
         }
 
-        if let additionalSummaryData = additionalInfoSummaryData, additionalSummaryData.title.count > 0 {
+        if let additionalSummaryData = additionalInfoSummaryData, let additionalSummaryTitle = additionalSummaryData.title, !additionalSummaryTitle.isEmpty {
             // SP and new scenario based on Additional Info Summary
-            headerTitle = additionalSummaryData.title
+            headerTitle = additionalSummaryTitle
             headerSubtitle = additionalSummaryData.subtitle
             if let headerUrl = additionalSummaryData.imageUrl {
                 headerImage = PXUIImage(url: headerUrl)

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfo.swift
@@ -1,0 +1,46 @@
+//
+//  PXAdditionalInfo.swift
+//  MercadoPagoSDK
+//
+//  Created by Juan sebastian Sanzone on 4/8/19.
+//
+
+import Foundation
+
+final class PXAdditionalInfo: NSObject, Codable {
+    var pxSummary: PXAdditionalInfoSummary?
+
+    public init(pxSummary: PXAdditionalInfoSummary?) {
+        self.pxSummary = pxSummary
+    }
+
+    public enum PXAdditionalInfoKeys: String, CodingKey {
+        case pxSummary = "px_summary"
+    }
+
+    required public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: PXAdditionalInfoKeys.self)
+        let summary: PXAdditionalInfoSummary? = try container.decodeIfPresent(PXAdditionalInfoSummary.self, forKey: .pxSummary)
+        self.init(pxSummary: summary)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: PXAdditionalInfoKeys.self)
+        try container.encodeIfPresent(self.pxSummary, forKey: .pxSummary)
+    }
+
+    func toJSONString() throws -> String? {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(self)
+        return String(data: data, encoding: .utf8)
+    }
+
+    func toJSON() throws -> Data {
+        let encoder = JSONEncoder()
+        return try encoder.encode(self)
+    }
+
+    class func fromJSON(data: Data) throws -> PXAdditionalInfo {
+        return try JSONDecoder().decode(PXAdditionalInfo.self, from: data)
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfoSummary.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfoSummary.swift
@@ -8,37 +8,37 @@
 import Foundation
 
 final class PXAdditionalInfoSummary: NSObject, Codable {
-    let title: String
+    var title: String?
     var subtitle: String?
     var purpose: String?
     var imageUrl: String?
 
-    public init(title: String, subtitle: String?, purpose: String?, imageUrl: String?) {
+    init(title: String?, subtitle: String?, purpose: String?, imageUrl: String?) {
         self.title = title
         self.subtitle = subtitle
         self.purpose = purpose
         self.imageUrl = imageUrl
     }
 
-    public enum PXAdditionalInfoSummaryKeys: String, CodingKey {
+    enum PXAdditionalInfoSummaryKeys: String, CodingKey {
         case title
         case subtitle
         case purpose
         case imageUrl = "image_url"
     }
 
-    required public convenience init(from decoder: Decoder) throws {
+    required convenience init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: PXAdditionalInfoSummaryKeys.self)
-        let title: String = try container.decode(String.self, forKey: .title)
+        let title: String? = try container.decodeIfPresent(String.self, forKey: .title)
         let subtitle: String? = try container.decodeIfPresent(String.self, forKey: .subtitle)
         let purpose: String? = try container.decodeIfPresent(String.self, forKey: .purpose)
         let imageUrl: String? = try container.decodeIfPresent(String.self, forKey: .imageUrl)
         self.init(title: title, subtitle: subtitle, purpose: purpose, imageUrl: imageUrl)
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: PXAdditionalInfoSummaryKeys.self)
-        try container.encode(self.title, forKey: .title)
+        try container.encodeIfPresent(self.title, forKey: .title)
         try container.encodeIfPresent(self.subtitle, forKey: .subtitle)
         try container.encodeIfPresent(self.purpose, forKey: .purpose)
         try container.encodeIfPresent(self.imageUrl, forKey: .imageUrl)

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfoSummary.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfoSummary.swift
@@ -1,0 +1,61 @@
+//
+//  PXAdditionalInfoSummary.swift
+//  MercadoPagoSDK
+//
+//  Created by Juan sebastian Sanzone on 4/8/19.
+//
+
+import Foundation
+
+final class PXAdditionalInfoSummary: NSObject, Codable {
+    let title: String
+    var subtitle: String?
+    var purpose: String?
+    var imageUrl: String?
+
+    public init(title: String, subtitle: String?, purpose: String?, imageUrl: String?) {
+        self.title = title
+        self.subtitle = subtitle
+        self.purpose = purpose
+        self.imageUrl = imageUrl
+    }
+
+    public enum PXAdditionalInfoSummaryKeys: String, CodingKey {
+        case title
+        case subtitle
+        case purpose
+        case imageUrl = "image_url"
+    }
+
+    required public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: PXAdditionalInfoSummaryKeys.self)
+        let title: String = try container.decode(String.self, forKey: .title)
+        let subtitle: String? = try container.decodeIfPresent(String.self, forKey: .subtitle)
+        let purpose: String? = try container.decodeIfPresent(String.self, forKey: .purpose)
+        let imageUrl: String? = try container.decodeIfPresent(String.self, forKey: .imageUrl)
+        self.init(title: title, subtitle: subtitle, purpose: purpose, imageUrl: imageUrl)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: PXAdditionalInfoSummaryKeys.self)
+        try container.encode(self.title, forKey: .title)
+        try container.encodeIfPresent(self.subtitle, forKey: .subtitle)
+        try container.encodeIfPresent(self.purpose, forKey: .purpose)
+        try container.encodeIfPresent(self.imageUrl, forKey: .imageUrl)
+    }
+
+    func toJSONString() throws -> String? {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(self)
+        return String(data: data, encoding: .utf8)
+    }
+
+    func toJSON() throws -> Data {
+        let encoder = JSONEncoder()
+        return try encoder.encode(self)
+    }
+
+    class func fromJSON(data: Data) throws -> PXAdditionalInfoSummary {
+        return try JSONDecoder().decode(PXAdditionalInfoSummary.self, from: data)
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference+AdditionalInfo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference+AdditionalInfo.swift
@@ -10,11 +10,7 @@ import Foundation
 internal extension PXCheckoutPreference {
     internal func populateAdditionalInfoModel() {
         if let str = self.additionalInfo, let additionInfoData = str.data(using: .utf8) {
-            do {
-                self.pxAdditionalInfo = try JSONDecoder().decode(PXAdditionalInfo.self, from: additionInfoData)
-            } catch {
-                self.pxAdditionalInfo = nil
-            }
+            self.pxAdditionalInfo = try? JSONDecoder().decode(PXAdditionalInfo.self, from: additionInfoData)
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference+AdditionalInfo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference+AdditionalInfo.swift
@@ -1,0 +1,24 @@
+//
+//  PXCheckoutPreference+AdditionalInfo.swift
+//  MercadoPagoSDK
+//
+//  Created by Juan sebastian Sanzone on 4/8/19.
+//
+
+import Foundation
+
+internal extension PXCheckoutPreference {
+    internal func populateAdditionalInfoModel() {
+        if let str = self.additionalInfo, let additionInfoData = str.data(using: .utf8) {
+            do {
+                self.pxAdditionalInfo = try JSONDecoder().decode(PXAdditionalInfo.self, from: additionInfoData)
+            } catch {
+                self.pxAdditionalInfo = nil
+            }
+        }
+    }
+
+    internal func getAdditionalInfoModel() -> PXAdditionalInfo? {
+        return pxAdditionalInfo
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference.swift
@@ -56,7 +56,14 @@ import Foundation
      marketplace
      */
     open var marketplace: String? = "NONE"
+
+    /**
+     Additional info - json string.
+     */
+    open var additionalInfo: String?
+
     internal var binaryModeEnabled: Bool = false
+    internal var pxAdditionalInfo: PXAdditionalInfo?
 
     // MARK: Initialization
     /**
@@ -113,6 +120,7 @@ import Foundation
         case differentialPricing = "differential_pricing"
         case site
         case marketplace
+        case additionalInfo = "additional_info"
     }
 
     required public convenience init(from decoder: Decoder) throws {
@@ -128,6 +136,8 @@ import Foundation
         let differentialPricing: PXDifferentialPricing? = try container.decodeIfPresent(PXDifferentialPricing.self, forKey: .differentialPricing)
         let marketplace: String? = try container.decodeIfPresent(String.self, forKey: .marketplace)
         self.init(id: id, items: items, payer: payer, paymentPreference: paymentPreference, siteId: siteId, expirationDateTo: expirationDateTo, expirationDateFrom: expirationDateFrom, site: site, differentialPricing: differentialPricing, marketplace: marketplace)
+        self.additionalInfo = try container.decodeIfPresent(String.self, forKey: .additionalInfo)
+        populateAdditionalInfoModel()
     }
 
     /// :nodoc:
@@ -141,6 +151,7 @@ import Foundation
         try container.encodeIfPresent(self.site, forKey: .site)
         try container.encodeIfPresent(self.differentialPricing, forKey: .differentialPricing)
         try container.encodeIfPresent(self.marketplace, forKey: .marketplace)
+        try container.encodeIfPresent(self.additionalInfo, forKey: .additionalInfo)
     }
 
     /// :nodoc:

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference.swift
@@ -60,7 +60,11 @@ import Foundation
     /**
      Additional info - json string.
      */
-    open var additionalInfo: String?
+    open var additionalInfo: String? {
+        didSet {
+            self.populateAdditionalInfoModel()
+        }
+    }
 
     internal var binaryModeEnabled: Bool = false
     internal var pxAdditionalInfo: PXAdditionalInfo?


### PR DESCRIPTION
- Consume title, subtitle, icon and purpose (purchase title) from Additional Info cehckout Pref
- Support pref by id (backend) and pref abierta (SP) - String setter
- Suppport instore retrocompatibility. By item

_**Layout subtitle & title con los dos scenarios de posicionamiento:**_ (Se ve entrecortado por los frames del gif)
![image](https://media.giphy.com/media/UU1lUFSmxSMwQSDlhM/giphy.gif)

_**Ejemplo integración correcta**_
![image](https://user-images.githubusercontent.com/972199/55809596-957f2500-5abc-11e9-9877-642c019be803.png)


