### PR TITLE
{MPuntos wallet support} - Get discount name from back

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXDiscount+Business.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXDiscount+Business.swift
@@ -21,16 +21,7 @@ internal extension PXDiscount {
     }
 
     internal func getDiscountDescription() -> String {
-        let currency = SiteManager.shared.getCurrency()
-        if self.percentOff != 0 {
-            let percentageAttributedString = Utils.getAttributedPercentage(withAttributes: [:], amount: self.percentOff, addPercentageSymbol: true, negativeAmount: false)
-            let string: String = ("total_row_title_percent_off".localized_beta as NSString).replacingOccurrences(of: "%1$s", with: percentageAttributedString.string)
-            return string
-        } else {
-            let amountAttributedString = Utils.getAttributedAmount(withAttributes: [:], amount: self.amountOff, currency: currency, negativeAmount: true)
-            let string: String = ("total_row_title_amount_off".localized_beta as NSString).replacingOccurrences(of: "%1$s", with: amountAttributedString.string)
-            return string
-        }
+        return name ?? ""
     }
 
     internal func getDiscountAmount() -> Double? {

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXDiscount+Business.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXDiscount+Business.swift
@@ -21,7 +21,7 @@ internal extension PXDiscount {
     }
 
     internal func getDiscountDescription() -> String {
-        return name ?? ""
+        return name ?? "discount_coupon_detail_default_concept".localized_beta
     }
 
     internal func getDiscountAmount() -> Double? {
@@ -32,16 +32,9 @@ internal extension PXDiscount {
         return percentOff != 0
     }
 
-    internal func getDiscountReviewDescription() -> String {
-        let text  = "discount_coupon_detail_default_concept".localized_beta
-         if self.percentOff != 0 {
-            return text + " " + String(describing: self.percentOff) + " %"
-        }
-        return text
-    }
     var concept: String {
         get {
-            return getDiscountReviewDescription()
+            return getDiscountDescription()
         }
     }
 


### PR DESCRIPTION
Nos liberamos de logica de front para el amount percent off y fixed percent.
Lo tomamos desde backend ya formateado y resuelto, listo para mostrar.
Solo tenemos un default (safe check), en el caso que no venga el name. Donde ponemos "Descuento".
__
Esto se tiene que mergear una vez que el backend este live con este cambio.
El PR de backend todavia esta en draft.
Yo aviso cuando estaria listo para mergear este PR.

Backend related: https://github.com/mercadopago/px-ios/pull/1875
__