### PR TITLE
card id fix

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/MoneyIn/MercadoPagoCheckoutViewModel+MoneyIn.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/MoneyIn/MercadoPagoCheckoutViewModel+MoneyIn.swift
@@ -17,6 +17,16 @@ extension MercadoPagoCheckoutViewModel {
 
         amountHelper.preference.clearCardId()
 
+
+        if let options = self.paymentMethodOptions {
+            let optionsFound = options.filter { (paymentMethodOption: PaymentMethodOption) -> Bool in
+                return paymentMethodOption.getId() == cardId
+            }
+            if let paymentOption = optionsFound.first {
+                return paymentOption
+            }
+        }
+
         if self.search != nil {
             guard let customerPaymentMethods = customPaymentOptions else {
                 return nil
@@ -28,14 +38,6 @@ extension MercadoPagoCheckoutViewModel {
             }
         }
 
-        if let options = self.paymentMethodOptions {
-            let optionsFound = options.filter { (paymentMethodOption: PaymentMethodOption) -> Bool in
-                return paymentMethodOption.getId() == cardId
-            }
-            if let paymentOption = optionsFound.first {
-                return paymentOption
-            }
-        }
         return nil
     }
 }


### PR DESCRIPTION
Swapping the conditions order avoids a subcase in which the card id was not applied properly. If the user has no customer options but card_id has been set to "debit_card", the debit card option should be autoselected.