### PR TITLE
Align with Android, waiting for payment will be green

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Managers/ResourceManager.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Managers/ResourceManager.swift
@@ -190,7 +190,7 @@ extension ResourceManager {
         if let statusDetail = statusDetail {
             //Payment Result Logic
             let paymentResult = PaymentResult(status: status, statusDetail: statusDetail, paymentData: PXPaymentData(), splitAccountMoney: nil, payerEmail: nil, paymentId: nil, statementDescription: nil)
-            if paymentResult.isApproved() {
+            if paymentResult.isApproved() || paymentResult.isWaitingForPayment() {
                 return ThemeManager.shared.successColor()
             }
             if paymentResult.isContingency() || paymentResult.isReviewManual() || paymentResult.isWarning() {


### PR DESCRIPTION
Waiting for payment debe ser **siempre** VERDE.
En Android esto funciona correctamente. Lo alineamos. Ya que hubo issues relacionados que levantaron los integradores.