### PR TITLE
5- Redirect preference fields to payment methods service

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Add_card/AddCardFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Add_card/AddCardFlow.swift
@@ -26,7 +26,8 @@ public class AddCardFlow: NSObject, PXFlow {
     private let escEnabled: Bool = true
     private let escManager: PXESCManager
 
-    private lazy var mercadoPagoServicesAdapter = MercadoPagoServicesAdapter(publicKey: "APP_USR-5bd14fdd-3807-446f-babd-095788d5ed4d", privateKey: self.accessToken)
+    //add card flow should have 'aggregator' processing mode by default
+    private lazy var mercadoPagoServicesAdapter = MercadoPagoServicesAdapter(publicKey: "APP_USR-5bd14fdd-3807-446f-babd-095788d5ed4d", privateKey: self.accessToken, processingModes:["aggregator"], branchId: nil)
 
     public convenience init(accessToken: String, locale: String, navigationController: UINavigationController, shouldSkipCongrats: Bool) {
         self.init(accessToken: accessToken, locale: locale, navigationController: navigationController)

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
@@ -131,7 +131,10 @@ internal class MercadoPagoCheckoutViewModel: NSObject, NSCopying {
         }
         self.trackingConfig = trackingConfig
 
-        mercadoPagoServicesAdapter = MercadoPagoServicesAdapter(publicKey: publicKey, privateKey: privateKey)
+        let processingModes = checkoutPreference.processingModes
+        let branchId = checkoutPreference.branchId
+
+        mercadoPagoServicesAdapter = MercadoPagoServicesAdapter(publicKey: publicKey, privateKey: privateKey, processingModes: processingModes, branchId: branchId)
 
         super.init()
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/MercadoPagoServicesAdapter.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/MercadoPagoServicesAdapter.swift
@@ -13,8 +13,8 @@ internal class MercadoPagoServicesAdapter {
 
     let mercadoPagoServices: MercadoPagoServices!
 
-    init(publicKey: String, privateKey: String?) {
-        mercadoPagoServices = MercadoPagoServices(merchantPublicKey: publicKey, payerAccessToken: privateKey ?? "")
+    init(publicKey: String, privateKey: String?, processingModes: [String], branchId: String?) {
+        mercadoPagoServices = MercadoPagoServices(merchantPublicKey: publicKey, payerAccessToken: privateKey ?? "", processingModes: processingModes, branchId: branchId)
         mercadoPagoServices.setLanguage(language: Localizator.sharedInstance.getLanguage())
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
@@ -12,14 +12,18 @@ internal class MercadoPagoServices: NSObject {
 
     open var merchantPublicKey: String
     open var payerAccessToken: String
+    open var processingModes: [String]
+    open var branchId: String?
     private var baseURL: String! = PXServicesURLConfigs.MP_API_BASE_URL
     private var gatewayBaseURL: String!
 
     private var language: String = NSLocale.preferredLanguages[0]
 
-    init(merchantPublicKey: String, payerAccessToken: String = "") {
+    init(merchantPublicKey: String, payerAccessToken: String = "", processingModes: [String], branchId: String?) {
         self.merchantPublicKey = merchantPublicKey
         self.payerAccessToken = payerAccessToken
+        self.processingModes = processingModes
+        self.branchId = branchId
         super.init()
     }
 
@@ -38,7 +42,7 @@ internal class MercadoPagoServices: NSObject {
     }
 
     func getPaymentMethodSearch(amount: Double, excludedPaymentTypesIds: [String], excludedPaymentMethodsIds: [String], cardsWithEsc: [String]?, supportedPlugins: [String]?, defaultPaymentMethod: String?, payer: PXPayer, site: PXSite, differentialPricingId: String?, defaultInstallments: String?, expressEnabled: String, splitEnabled: String, discountParamsConfiguration: PXDiscountParamsConfiguration?, marketplace: String?, charges: [PXPaymentTypeChargeRule]?, callback : @escaping (PXPaymentMethodSearch) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {
-        let paymentMethodSearchService = PaymentMethodSearchService(baseURL: baseURL, merchantPublicKey: merchantPublicKey, payerAccessToken: payerAccessToken)
+        let paymentMethodSearchService = PaymentMethodSearchService(baseURL: baseURL, merchantPublicKey: merchantPublicKey, payerAccessToken: payerAccessToken, processingModes: processingModes, branchId: branchId)
         paymentMethodSearchService.getPaymentMethods(amount, defaultPaymenMethodId: defaultPaymentMethod, excludedPaymentTypeIds: excludedPaymentTypesIds, excludedPaymentMethodIds: excludedPaymentMethodsIds, cardsWithEsc: cardsWithEsc, supportedPlugins: supportedPlugins, site: site, payer: payer, language: language, differentialPricingId: differentialPricingId, defaultInstallments: defaultInstallments, expressEnabled: expressEnabled, splitEnabled: splitEnabled, discountParamsConfiguration: discountParamsConfiguration, marketplace: marketplace, charges: charges, success: callback, failure: failure)
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
@@ -12,8 +12,8 @@ internal class MercadoPagoServices: NSObject {
 
     open var merchantPublicKey: String
     open var payerAccessToken: String
-    open var processingModes: [String]
-    open var branchId: String?
+    private var processingModes: [String]
+    private var branchId: String?
     private var baseURL: String! = PXServicesURLConfigs.MP_API_BASE_URL
     private var gatewayBaseURL: String!
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPaymentMethodSearchBody.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPaymentMethodSearchBody.swift
@@ -14,14 +14,18 @@ class PXPaymentMethodSearchBody: Codable {
     let productId: String?
     let labels: [String]?
     let charges: [PXPaymentTypeChargeRule]?
+    let processingModes: [String]
+    let branchId: String?
 
-    init(privateKey: String?, email: String?, marketplace: String?, productId: String?, labels: [String]?, charges: [PXPaymentTypeChargeRule]?) {
+    init(privateKey: String?, email: String?, marketplace: String?, productId: String?, labels: [String]?, charges: [PXPaymentTypeChargeRule]?, processingModes: [String], branchId: String?) {
         self.privateKey = privateKey
         self.email = email
         self.marketplace = marketplace
         self.productId = productId
         self.labels = labels
         self.charges = charges
+        self.processingModes = processingModes
+        self.branchId = branchId
     }
 
     public enum PXPaymentMethodSearchBodyKeys: String, CodingKey {
@@ -31,6 +35,8 @@ class PXPaymentMethodSearchBody: Codable {
         case productId = "product_id"
         case labels
         case charges
+        case processingModes = "processing_modes"
+        case branchId = "branch_id"
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -43,6 +49,8 @@ class PXPaymentMethodSearchBody: Codable {
         try container.encodeIfPresent(self.productId, forKey: .productId)
         try container.encodeIfPresent(self.labels, forKey: .labels)
         try container.encodeIfPresent(self.charges, forKey: .charges)
+        try container.encodeIfPresent(self.processingModes, forKey: .processingModes)
+        try container.encodeIfPresent(self.branchId, forKey: .branchId)
     }
 
     open func toJSONString() throws -> String? {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentMethodSearchService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentMethodSearchService.swift
@@ -32,10 +32,14 @@ internal class PaymentMethodSearchService: MercadoPagoService {
 
     let merchantPublicKey: String
     let payerAccessToken: String?
+    let processingModes: [String]
+    let branchId: String?
 
-    init(baseURL: String, merchantPublicKey: String, payerAccessToken: String? = nil) {
+    init(baseURL: String, merchantPublicKey: String, payerAccessToken: String? = nil, processingModes: [String], branchId: String?) {
         self.merchantPublicKey = merchantPublicKey
         self.payerAccessToken = payerAccessToken
+        self.processingModes = processingModes
+        self.branchId = branchId
         super.init(baseURL: baseURL)
     }
 
@@ -83,7 +87,7 @@ internal class PaymentMethodSearchService: MercadoPagoService {
 
         params.paramsAppend(key: "split_payment_enabled", value: splitEnabled)
 
-        let body = PXPaymentMethodSearchBody(privateKey: payer.accessToken, email: payer.email, marketplace: marketplace, productId: discountParamsConfiguration?.productId, labels: discountParamsConfiguration?.labels, charges: charges)
+        let body = PXPaymentMethodSearchBody(privateKey: payer.accessToken, email: payer.email, marketplace: marketplace, productId: discountParamsConfiguration?.productId, labels: discountParamsConfiguration?.labels, charges: charges, processingModes: processingModes, branchId: branchId)
         let bodyJSON = try? body.toJSON()
 
         let headers = ["Accept-Language": language]


### PR DESCRIPTION
Processing mode and branch id fields obtained in the preference service will be sent back as part of the body in the payment methods call.