### PR TITLE
4- remove hardcoded processing mode

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/MercadoPagoServicesAdapter.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/MercadoPagoServicesAdapter.swift
@@ -14,7 +14,7 @@ internal class MercadoPagoServicesAdapter {
     let mercadoPagoServices: MercadoPagoServices!
 
     init(publicKey: String, privateKey: String?) {
-        mercadoPagoServices = MercadoPagoServices(merchantPublicKey: publicKey, payerAccessToken: privateKey ?? "", procesingMode: "aggregator")
+        mercadoPagoServices = MercadoPagoServices(merchantPublicKey: publicKey, payerAccessToken: privateKey ?? "")
         mercadoPagoServices.setLanguage(language: Localizator.sharedInstance.getLanguage())
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
@@ -12,17 +12,14 @@ internal class MercadoPagoServices: NSObject {
 
     open var merchantPublicKey: String
     open var payerAccessToken: String
-    open var procesingMode: String
-
     private var baseURL: String! = PXServicesURLConfigs.MP_API_BASE_URL
     private var gatewayBaseURL: String!
 
     private var language: String = NSLocale.preferredLanguages[0]
 
-    init(merchantPublicKey: String, payerAccessToken: String = "", procesingMode: String = "aggregator") {
+    init(merchantPublicKey: String, payerAccessToken: String = "") {
         self.merchantPublicKey = merchantPublicKey
         self.payerAccessToken = payerAccessToken
-        self.procesingMode = procesingMode
         super.init()
     }
 
@@ -41,7 +38,7 @@ internal class MercadoPagoServices: NSObject {
     }
 
     func getPaymentMethodSearch(amount: Double, excludedPaymentTypesIds: [String], excludedPaymentMethodsIds: [String], cardsWithEsc: [String]?, supportedPlugins: [String]?, defaultPaymentMethod: String?, payer: PXPayer, site: PXSite, differentialPricingId: String?, defaultInstallments: String?, expressEnabled: String, splitEnabled: String, discountParamsConfiguration: PXDiscountParamsConfiguration?, marketplace: String?, charges: [PXPaymentTypeChargeRule]?, callback : @escaping (PXPaymentMethodSearch) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {
-        let paymentMethodSearchService = PaymentMethodSearchService(baseURL: baseURL, merchantPublicKey: merchantPublicKey, payerAccessToken: payerAccessToken, processingMode: procesingMode)
+        let paymentMethodSearchService = PaymentMethodSearchService(baseURL: baseURL, merchantPublicKey: merchantPublicKey, payerAccessToken: payerAccessToken)
         paymentMethodSearchService.getPaymentMethods(amount, defaultPaymenMethodId: defaultPaymentMethod, excludedPaymentTypeIds: excludedPaymentTypesIds, excludedPaymentMethodIds: excludedPaymentMethodsIds, cardsWithEsc: cardsWithEsc, supportedPlugins: supportedPlugins, site: site, payer: payer, language: language, differentialPricingId: differentialPricingId, defaultInstallments: defaultInstallments, expressEnabled: expressEnabled, splitEnabled: splitEnabled, discountParamsConfiguration: discountParamsConfiguration, marketplace: marketplace, charges: charges, success: callback, failure: failure)
     }
 
@@ -158,12 +155,14 @@ internal class MercadoPagoServices: NSObject {
     }
 
     func getSummaryAmount(bin: String?, amount: Double, issuerId: String?, paymentMethodId: String, payment_type_id: String, differentialPricingId: String?, siteId: String?, marketplace: String?, discountParamsConfiguration: PXDiscountParamsConfiguration?, payer: PXPayer, defaultInstallments: Int?, charges: [PXPaymentTypeChargeRule]?, callback: @escaping (PXSummaryAmount) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {
-        let service: PaymentService = PaymentService(baseURL: baseURL, merchantPublicKey: merchantPublicKey, payerAccessToken: payerAccessToken, processingMode: procesingMode)
+        //FIXME: replace hardcoded void array with proper processing modes from preference
+        let service: PaymentService = PaymentService(baseURL: baseURL, merchantPublicKey: merchantPublicKey, payerAccessToken: payerAccessToken, processingModes: [])
         service.getSummaryAmount(bin: bin, amount: amount, issuerId: issuerId, payment_method_id: paymentMethodId, payment_type_id: payment_type_id, differential_pricing_id: differentialPricingId, siteId: siteId, marketplace: marketplace, discountParamsConfiguration: discountParamsConfiguration, payer: payer, defaultInstallments: defaultInstallments, charges: charges, success: callback, failure: failure)
     }
 
     func getIssuers(paymentMethodId: String, bin: String? = nil, callback: @escaping ([PXIssuer]) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {
-        let service: PaymentService = PaymentService(baseURL: baseURL, merchantPublicKey: merchantPublicKey, payerAccessToken: payerAccessToken, processingMode: procesingMode)
+        //FIXME: replace hardcoded void array with proper processing modes from preference
+        let service: PaymentService = PaymentService(baseURL: baseURL, merchantPublicKey: merchantPublicKey, payerAccessToken: payerAccessToken, processingModes: [])
         service.getIssuers(payment_method_id: paymentMethodId, bin: bin, success: {(data: Data) -> Void in
             do {
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXSummaryAmountBody.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXSummaryAmountBody.swift
@@ -20,10 +20,10 @@ class PXSummaryAmountBody: Codable {
     let labels: [String]?
     let defaultInstallments: Int?
     let differentialPricingId: String?
-    let processingMode: String?
+    let processingModes: [String]?
     let charges: [PXPaymentTypeChargeRule]?
 
-    init(siteId: String?, transactionAmount: String?, marketplace: String?, email: String?, productId: String?, paymentMethodId: String?, paymentType: String?, bin: String?, issuerId: String?, labels: [String]?, defaultInstallments: Int?, differentialPricingId: String?, processingMode: String?, charges: [PXPaymentTypeChargeRule]?) {
+    init(siteId: String?, transactionAmount: String?, marketplace: String?, email: String?, productId: String?, paymentMethodId: String?, paymentType: String?, bin: String?, issuerId: String?, labels: [String]?, defaultInstallments: Int?, differentialPricingId: String?, processingModes: [String]?, charges: [PXPaymentTypeChargeRule]?) {
         self.siteId = siteId
         self.transactionAmount = transactionAmount
         self.marketplace = marketplace
@@ -36,7 +36,7 @@ class PXSummaryAmountBody: Codable {
         self.labels = labels
         self.defaultInstallments = defaultInstallments
         self.differentialPricingId = differentialPricingId
-        self.processingMode = processingMode
+        self.processingModes = processingModes
         self.charges = charges
     }
 
@@ -53,7 +53,7 @@ class PXSummaryAmountBody: Codable {
         case labels
         case defaultInstallments = "default_installments"
         case differentialPricingId = "differential_pricing_id"
-        case processingMode = "processing_mode"
+        case processingModes = "processing_modes"
         case charges
     }
 
@@ -71,7 +71,7 @@ class PXSummaryAmountBody: Codable {
         try container.encodeIfPresent(self.labels, forKey: .labels)
         try container.encodeIfPresent(self.defaultInstallments, forKey: .defaultInstallments)
         try container.encodeIfPresent(self.differentialPricingId, forKey: .differentialPricingId)
-        try container.encodeIfPresent(self.processingMode, forKey: .processingMode)
+        try container.encodeIfPresent(self.processingModes, forKey: .processingModes)
         try container.encodeIfPresent(self.charges, forKey: .charges)
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentMethodSearchService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentMethodSearchService.swift
@@ -32,12 +32,10 @@ internal class PaymentMethodSearchService: MercadoPagoService {
 
     let merchantPublicKey: String
     let payerAccessToken: String?
-    let processingMode: String
 
-    init(baseURL: String, merchantPublicKey: String, payerAccessToken: String? = nil, processingMode: String) {
+    init(baseURL: String, merchantPublicKey: String, payerAccessToken: String? = nil) {
         self.merchantPublicKey = merchantPublicKey
         self.payerAccessToken = payerAccessToken
-        self.processingMode = processingMode
         super.init(baseURL: baseURL)
     }
 
@@ -71,7 +69,6 @@ internal class PaymentMethodSearchService: MercadoPagoService {
         params.paramsAppend(key: ApiParams.CUSTOMER_ID, value: customerId)
         params.paramsAppend(key: ApiParams.SITE_ID, value: site.id)
         params.paramsAppend(key: ApiParams.API_VERSION, value: PXServicesURLConfigs.API_VERSION)
-        params.paramsAppend(key: ApiParams.PROCESSING_MODE, value: processingMode)
         params.paramsAppend(key: ApiParams.DIFFERENTIAL_PRICING_ID, value: differentialPricingId)
 
         if let cardsWithEscParams = cardsWithEsc?.map({ $0 }).joined(separator: ",") {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentService.swift
@@ -12,12 +12,12 @@ internal class PaymentService: MercadoPagoService {
 
     let merchantPublicKey: String!
     let payerAccessToken: String?
-    let processingMode: String!
+    let processingModes: [String]
 
-    init (baseURL: String, merchantPublicKey: String, payerAccessToken: String? = nil, processingMode: String) {
+    init (baseURL: String, merchantPublicKey: String, payerAccessToken: String? = nil, processingModes: [String]) {
         self.merchantPublicKey = merchantPublicKey
         self.payerAccessToken = payerAccessToken
-        self.processingMode = processingMode
+        self.processingModes = processingModes
         super.init(baseURL: baseURL)
     }
     
@@ -25,7 +25,7 @@ internal class PaymentService: MercadoPagoService {
 
         let params: String = MercadoPagoServices.getParamsPublicKeyAndAcessToken(merchantPublicKey, payerAccessToken)
 
-        let body = PXSummaryAmountBody(siteId: siteId, transactionAmount: String(format: "%.2f", amount), marketplace: marketplace, email: payer.email, productId: discountParamsConfiguration?.productId, paymentMethodId: payment_method_id, paymentType: payment_type_id, bin: bin, issuerId: issuerId, labels: discountParamsConfiguration?.labels, defaultInstallments: defaultInstallments, differentialPricingId: differential_pricing_id, processingMode: processingMode, charges: charges)
+        let body = PXSummaryAmountBody(siteId: siteId, transactionAmount: String(format: "%.2f", amount), marketplace: marketplace, email: payer.email, productId: discountParamsConfiguration?.productId, paymentMethodId: payment_method_id, paymentType: payment_type_id, bin: bin, issuerId: issuerId, labels: discountParamsConfiguration?.labels, defaultInstallments: defaultInstallments, differentialPricingId: differential_pricing_id, processingModes: processingModes, charges: charges)
         let bodyJSON = try? body.toJSON()
 
         self.request( uri: uri, params: params, body: bodyJSON, method: HTTPMethod.post, cache: false, success: {(data: Data) -> Void in
@@ -56,7 +56,8 @@ internal class PaymentService: MercadoPagoService {
         var params: String = MercadoPagoServices.getParamsPublicKeyAndAcessToken(merchantPublicKey, payerAccessToken)
         params.paramsAppend(key: ApiParams.PAYMENT_METHOD_ID, value: payment_method_id)
         params.paramsAppend(key: ApiParams.BIN, value: bin)
-        params.paramsAppend(key: ApiParams.PROCESSING_MODE, value: processingMode)
+        //FIXME: add logic to transform processing modes array into query params
+//        params.paramsAppend(key: ApiParams.PROCESSING_MODE, value: processingModes)
 
         if bin != nil {
             self.request(uri: uri, params: params, body: nil, method: HTTPMethod.get, success: success, failure: { (error) in


### PR DESCRIPTION
In the previous implementation a hardcoded field called "processing_mode" of String type was sent in many calls with the value "aggregator" as a query params. This query param is no longer needed and may become confusing as the new "processing_modes" of Array type will be needed for the new implementation to work, therefore it needs to be removed.