### PR TITLE
7- Get issuer service adapted to new processing mode logic

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentService.swift
@@ -58,8 +58,9 @@ internal class PaymentService: MercadoPagoService {
         var params: String = MercadoPagoServices.getParamsPublicKeyAndAcessToken(merchantPublicKey, payerAccessToken)
         params.paramsAppend(key: ApiParams.PAYMENT_METHOD_ID, value: payment_method_id)
         params.paramsAppend(key: ApiParams.BIN, value: bin)
-        //FIXME: add logic to transform processing modes array into query params
-//        params.paramsAppend(key: ApiParams.PROCESSING_MODE, value: processingModes)
+        if processingModes.count == 1 {
+            params.paramsAppend(key: ApiParams.PROCESSING_MODE, value: processingModes.first)
+        }
 
         if bin != nil {
             self.request(uri: uri, params: params, body: nil, method: HTTPMethod.get, success: success, failure: { (error) in

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentService.swift
@@ -58,6 +58,8 @@ internal class PaymentService: MercadoPagoService {
         var params: String = MercadoPagoServices.getParamsPublicKeyAndAcessToken(merchantPublicKey, payerAccessToken)
         params.paramsAppend(key: ApiParams.PAYMENT_METHOD_ID, value: payment_method_id)
         params.paramsAppend(key: ApiParams.BIN, value: bin)
+
+        //FIXME: This is a temporary workaround to start testing instores cases but should never reach a productive environment. The whole "get issuers" service will soon be replaced with a new 'post' endpoint that can receive all 'processing modes' array properly.
         if processingModes.count == 1 {
             params.paramsAppend(key: ApiParams.PROCESSING_MODE, value: processingModes.first)
         }


### PR DESCRIPTION
get issuer service will only send a processing mode as a query params if there was only one option and thus could be autoselected, in any other case this query param goes as nil. 

all normal implementations will default to "[aggregator]" and keep sending aggregator as query param, the new case in which only 'gateway' is available will autoselect this mode. If both options are available, nothing will be sent as query param and the logic to determine which issuers should be returned will remain on the backend side.

This is a temporary solution.