### PR TITLE
9- correct proccesing mode use for each service

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Add_card/AddCardFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Add_card/AddCardFlow.swift
@@ -27,7 +27,7 @@ public class AddCardFlow: NSObject, PXFlow {
     private let escManager: PXESCManager
 
     //add card flow should have 'aggregator' processing mode by default
-    private lazy var mercadoPagoServicesAdapter = MercadoPagoServicesAdapter(publicKey: "APP_USR-5bd14fdd-3807-446f-babd-095788d5ed4d", privateKey: self.accessToken, processingModes:["aggregator"], branchId: nil)
+    private lazy var mercadoPagoServicesAdapter = MercadoPagoServicesAdapter(publicKey: "APP_USR-5bd14fdd-3807-446f-babd-095788d5ed4d", privateKey: self.accessToken, branchId: nil)
 
     public convenience init(accessToken: String, locale: String, navigationController: UINavigationController, shouldSkipCongrats: Bool) {
         self.init(accessToken: accessToken, locale: locale, navigationController: navigationController)

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+ConfigurationServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+ConfigurationServices.swift
@@ -22,6 +22,9 @@ extension MercadoPagoCheckout {
         if let differentialPricing = self.viewModel.checkoutPreference.differentialPricing?.id {
             diffPricingString = String(describing: differentialPricing)
         }
+
+        //summary ammount service should be performed using the processing modes designated by the payment method
+        self.viewModel.mercadoPagoServicesAdapter.update(processingModes: paymentMethod.processingModes)
         self.viewModel.mercadoPagoServicesAdapter.getSummaryAmount(bin: bin, amount: self.viewModel.amountHelper.preferenceAmount, issuer: self.viewModel.paymentData.getIssuer(), paymentMethodId: paymentMethod.id, payment_type_id: paymentMethod.paymentTypeId, differentialPricingId: diffPricingString, siteId: self.viewModel.checkoutPreference.siteId, marketplace: self.viewModel.checkoutPreference.marketplace, discountParamsConfiguration: self.viewModel.getAdvancedConfiguration().discountParamsConfiguration, payer: self.viewModel.checkoutPreference.payer, defaultInstallments: self.viewModel.checkoutPreference.getDefaultInstallments(), charges: self.viewModel.amountHelper.chargeRules, callback: { [weak self] (summaryAmount) in
 
             guard let strongSelf = self else {

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckoutServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckoutServices.swift
@@ -16,6 +16,9 @@ extension MercadoPagoCheckout {
             return
         }
         let bin = self.viewModel.cardToken?.getBin()
+        
+        //issuers service should be performed using the processing modes designated by the payment method
+        self.viewModel.mercadoPagoServicesAdapter.update(processingModes: paymentMethod.processingModes)
         self.viewModel.mercadoPagoServicesAdapter.getIssuers(paymentMethodId: paymentMethod.id, bin: bin, callback: { [weak self] (issuers) in
 
             self?.viewModel.issuers = issuers

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
@@ -131,10 +131,8 @@ internal class MercadoPagoCheckoutViewModel: NSObject, NSCopying {
         }
         self.trackingConfig = trackingConfig
 
-        let processingModes = checkoutPreference.processingModes
         let branchId = checkoutPreference.branchId
-
-        mercadoPagoServicesAdapter = MercadoPagoServicesAdapter(publicKey: publicKey, privateKey: privateKey, processingModes: processingModes, branchId: branchId)
+        mercadoPagoServicesAdapter = MercadoPagoServicesAdapter(publicKey: publicKey, privateKey: privateKey, branchId: branchId)
 
         super.init()
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/MercadoPagoServicesAdapter.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/MercadoPagoServicesAdapter.swift
@@ -13,9 +13,13 @@ internal class MercadoPagoServicesAdapter {
 
     let mercadoPagoServices: MercadoPagoServices!
 
-    init(publicKey: String, privateKey: String?, processingModes: [String], branchId: String?) {
-        mercadoPagoServices = MercadoPagoServices(merchantPublicKey: publicKey, payerAccessToken: privateKey ?? "", processingModes: processingModes, branchId: branchId)
+    init(publicKey: String, privateKey: String?, branchId: String?) {
+        mercadoPagoServices = MercadoPagoServices(merchantPublicKey: publicKey, payerAccessToken: privateKey ?? "", branchId: branchId)
         mercadoPagoServices.setLanguage(language: Localizator.sharedInstance.getLanguage())
+    }
+
+    func update(processingModes: [String]?) {
+        mercadoPagoServices.update(processingModes: processingModes ?? ["aggregator"])
     }
 
     func getTimeOut() -> TimeInterval {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/InitFlow+Services.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/InitFlow+Services.swift
@@ -87,8 +87,11 @@ extension InitFlow {
         let discountParamsConfiguration = model.properties.advancedConfig.discountParamsConfiguration
         let marketplace = model.amountHelper.preference.marketplace
         let splitEnabled: Bool = model.properties.paymentPlugin?.supportSplitPaymentMethodPayment(checkoutStore: PXCheckoutStore.sharedInstance) ?? false
+        let serviceAdapter = model.getService()
 
-        model.getService().getPaymentMethodSearch(amount: model.amountHelper.amountToPay, exclusions: exclusions, oneTapInfo: oneTapInfo, payer: model.properties.paymentData.payer ?? PXPayer(email: ""), site: SiteManager.shared.getSiteId(), extraParams: (defaultPaymentMethod: model.getDefaultPaymentMethodId(), differentialPricingId: differentialPricingString, defaultInstallments: defaultInstallments, expressEnabled: model.properties.advancedConfig.expressEnabled, hasPaymentProcessor: hasPaymentProcessor, splitEnabled: splitEnabled), discountParamsConfiguration: discountParamsConfiguration, marketplace: marketplace, charges: self.model.amountHelper.chargeRules, callback: { [weak self] (paymentMethodSearch) in
+        //payment method search service should be performed using the processing modes designated by the preference object
+        serviceAdapter.update(processingModes: model.properties.checkoutPreference.processingModes)
+        serviceAdapter.getPaymentMethodSearch(amount: model.amountHelper.amountToPay, exclusions: exclusions, oneTapInfo: oneTapInfo, payer: model.properties.paymentData.payer ?? PXPayer(email: ""), site: SiteManager.shared.getSiteId(), extraParams: (defaultPaymentMethod: model.getDefaultPaymentMethodId(), differentialPricingId: differentialPricingString, defaultInstallments: defaultInstallments, expressEnabled: model.properties.advancedConfig.expressEnabled, hasPaymentProcessor: hasPaymentProcessor, splitEnabled: splitEnabled), discountParamsConfiguration: discountParamsConfiguration, marketplace: marketplace, charges: self.model.amountHelper.chargeRules, callback: { [weak self] (paymentMethodSearch) in
 
             guard let strongSelf = self else {
                 return

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
@@ -12,19 +12,22 @@ internal class MercadoPagoServices: NSObject {
 
     open var merchantPublicKey: String
     open var payerAccessToken: String
-    open var processingModes: [String]
+    open var processingModes: [String] = ["aggregator"]
     open var branchId: String?
     private var baseURL: String! = PXServicesURLConfigs.MP_API_BASE_URL
     private var gatewayBaseURL: String!
 
     private var language: String = NSLocale.preferredLanguages[0]
 
-    init(merchantPublicKey: String, payerAccessToken: String = "", processingModes: [String], branchId: String?) {
+    init(merchantPublicKey: String, payerAccessToken: String = "", branchId: String?) {
         self.merchantPublicKey = merchantPublicKey
         self.payerAccessToken = payerAccessToken
-        self.processingModes = processingModes
         self.branchId = branchId
         super.init()
+    }
+
+    func update(processingModes: [String]) {
+        self.processingModes = processingModes
     }
 
     func getCheckoutPreference(checkoutPreferenceId: String, callback : @escaping (PXCheckoutPreference) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {


### PR DESCRIPTION
-Issuers and summary services should use the "processing modes" that are bound to the payment method that has been selected at that time.
-Payment methods service should use the "processing modes" that are allowed by the preference set at initialization

This PR ensures that the right source of "proccesing modes" is used on every each of the aforementioned situations