### PR TITLE
HOT FIX - Header text alignment fix

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXHeader/PXHeaderRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXHeader/PXHeaderRenderer.swift
@@ -138,7 +138,7 @@ internal final class PXHeaderRenderer: NSObject {
 
     func buildMessageLabel(with text: NSAttributedString) -> UILabel {
         let messageLabel = UILabel()
-        messageLabel.textAlignment = .left
+        messageLabel.textAlignment = .center
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
         messageLabel.attributedText = text
         messageLabel.textColor = .white


### PR DESCRIPTION
##  Cambios introducidos : 
- Se hace un hot fix que arregla la alineación del texto del header en las congrats que no son verdes.
