### PR TITLE
Call to biometric only with saved esc

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
@@ -302,7 +302,7 @@ internal class MercadoPagoCheckoutViewModel: NSObject, NSCopying {
 
     func reviewConfirmViewModel() -> PXReviewViewModel {
         disableChangePaymentMethodIfNeed()
-        return PXReviewViewModel(amountHelper: self.amountHelper, paymentOptionSelected: self.paymentOptionSelected!, advancedConfig: advancedConfig, userLogged: !String.isNullOrEmpty(privateKey))
+        return PXReviewViewModel(amountHelper: self.amountHelper, paymentOptionSelected: self.paymentOptionSelected!, advancedConfig: advancedConfig, userLogged: !String.isNullOrEmpty(privateKey), escProtocol: self.escManager)
     }
 
     func resultViewModel() -> PXResultViewModel {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
@@ -114,7 +114,7 @@ internal extension OneTapFlowModel {
     }
 
     func reviewConfirmViewModel() -> PXOneTapViewModel {
-        let viewModel = PXOneTapViewModel(amountHelper: self.amountHelper, paymentOptionSelected: paymentOptionSelected, advancedConfig: advancedConfiguration, userLogged: false, disabledOption: disabledOption)
+        let viewModel = PXOneTapViewModel(amountHelper: self.amountHelper, paymentOptionSelected: paymentOptionSelected, advancedConfig: advancedConfiguration, userLogged: false, disabledOption: disabledOption, escProtocol: self.escManager)
         viewModel.expressData = search.expressCho
         viewModel.paymentMethods = search.paymentMethods
         viewModel.items = checkoutPreference.items

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
@@ -261,14 +261,18 @@ extension PXOneTapViewController {
     }
 
     private func confirmPayment() {
-        let biometricModule = PXConfiguratorManager.biometricProtocol
-        biometricModule.validate(config: PXConfiguratorManager.biometricConfig, onSuccess: { [weak self] in
-            DispatchQueue.main.async {
-                self?.doPayment()
+        if viewModel.shouldValidateWithBiometric(withCardId: selectedCard?.cardId) {
+            let biometricModule = PXConfiguratorManager.biometricProtocol
+            biometricModule.validate(config: PXConfiguratorManager.biometricConfig, onSuccess: { [weak self] in
+                DispatchQueue.main.async {
+                    self?.doPayment()
+                }
+            }) { [weak self] _ in
+                // User abort validation or validation fail.
+                self?.trackEvent(path: TrackingPaths.Events.getErrorPath())
             }
-        }) { [weak self] _ in
-            // User abort validation or validation fail.
-            self?.trackEvent(path: TrackingPaths.Events.getErrorPath())
+        } else {
+            doPayment()
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
@@ -22,9 +22,9 @@ final class PXOneTapViewModel: PXReviewViewModel {
     var additionalInfoSummary: PXAdditionalInfoSummary?
     var disabledOption: PXDisabledOption?
 
-    public init(amountHelper: PXAmountHelper, paymentOptionSelected: PaymentMethodOption, advancedConfig: PXAdvancedConfiguration, userLogged: Bool, disabledOption: PXDisabledOption? = nil) {
+    public init(amountHelper: PXAmountHelper, paymentOptionSelected: PaymentMethodOption, advancedConfig: PXAdvancedConfiguration, userLogged: Bool, disabledOption: PXDisabledOption? = nil, escProtocol: MercadoPagoESC?) {
         self.disabledOption = disabledOption
-        super.init(amountHelper: amountHelper, paymentOptionSelected: paymentOptionSelected, advancedConfig: advancedConfig, userLogged: userLogged)
+        super.init(amountHelper: amountHelper, paymentOptionSelected: paymentOptionSelected, advancedConfig: advancedConfig, userLogged: userLogged, escProtocol: escProtocol)
     }
 
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewController.swift
@@ -399,16 +399,19 @@ extension PXReviewViewController {
 
 // MARK: Actions.
 extension PXReviewViewController: PXTermsAndConditionViewDelegate {
-
     private func confirmPayment(_ targetButton: PXAnimatedButton) {
-        let biometricModule = PXConfiguratorManager.biometricProtocol
-        biometricModule.validate(config: PXConfiguratorManager.biometricConfig, onSuccess: { [weak self] in
-            DispatchQueue.main.async {
-                self?.doPayment(targetButton)
+        if viewModel.shouldValidateWithBiometric() {
+            let biometricModule = PXConfiguratorManager.biometricProtocol
+            biometricModule.validate(config: PXConfiguratorManager.biometricConfig, onSuccess: { [weak self] in
+                DispatchQueue.main.async {
+                    self?.doPayment(targetButton)
+                }
+            }) { [weak self] error in
+                // User abort validation or validation fail.
+                self?.trackEvent(path: TrackingPaths.Events.getErrorPath())
             }
-        }) { [weak self] error in
-            // User abort validation or validation fail.
-            self?.trackEvent(path: TrackingPaths.Events.getErrorPath())
+        } else {
+            self.doPayment(targetButton)
         }
     }
 


### PR DESCRIPTION
Llamamos al módulo de validacion de Biometric **SOLO** cuando tenemos el ESC guardado para esa tarjeta o el pago es AccountMoney o Digital Currency.

Esta lógica o una lógica simil (despues vemos de que manera) la llevamos al módulo de PX AddOn junto con @ericertlMELI 

**NO MERGEAR** todavia, ya que arquitectura va a sacar una build integrada para probar. cc / @fventre