### PR TITLE
HOT FIX - Payment IDs in Congrats request

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow+Services.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow+Services.swift
@@ -62,14 +62,14 @@ internal extension PXPaymentFlow {
 
     func getPointsAndDiscounts() {
 
-        var paymentIds: [String]?
+        var paymentIds = [String]()
         if let paymentResultId = model.paymentResult?.paymentId {
-            paymentIds?.append(paymentResultId)
+            paymentIds.append(paymentResultId)
         } else if let businessResult = model.businessResult {
             if let receiptLists = businessResult.getReceiptIdList() {
                 paymentIds = receiptLists
             } else if let receiptId = businessResult.getReceiptId() {
-                paymentIds?.append(receiptId)
+                paymentIds.append(receiptId)
             }
         }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
@@ -269,7 +269,7 @@ internal class MercadoPagoServices: NSObject {
             params.paramsAppend(key: ApiParam.PAYER_ACCESS_TOKEN, value: payerAccessToken)
         }
 
-        if let paymentIds = paymentIds {
+        if let paymentIds = paymentIds, !paymentIds.isEmpty {
             var paymentIdsString = ""
             for (index, paymentId) in paymentIds.enumerated() {
                 if index != 0 {


### PR DESCRIPTION
##  Cambios introducidos : 
- Se arregla un bug por el cual no se enviaban los payment IDs en la mayoria de los casos al hacer el request a endpoint de congrats.
