### PR TITLE
Fix/ESC+Biometric+OneTap

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+Screens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+Screens.swift
@@ -40,8 +40,7 @@ extension OneTapFlow {
             // WARNING: Keep strong ref here (or any other block for this initializer) or it'll release the object after creating it
             self.executeNextStep()
         }
-        let viewModel = model.reviewConfirmViewModel()
-        
+        let viewModel = model.oneTapViewModel()
         let reviewVC = PXOneTapViewController(viewModel: viewModel, timeOutPayButton: model.getTimeoutForOneTapReviewController(), callbackPaymentData: callbackPaymentData, callbackConfirm: callbackConfirm, callbackUpdatePaymentOption: callbackUpdatePaymentOption, callbackExit: callbackExit, finishButtonAnimation: finishButtonAnimation)
 
         pxNavigationHandler.pushViewController(viewController: reviewVC, animated: true)

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow.swift
@@ -21,6 +21,8 @@ final class OneTapFlow: NSObject, PXFlow {
         resultHandler = oneTapResultHandler
         advancedConfig = advancedConfiguration
         model = OneTapFlowModel(paymentData: paymentData, checkoutPreference: checkoutPreference, search: search, paymentOptionSelected: paymentOptionSelected, chargeRules: chargeRules, mercadoPagoServicesAdapter: mercadoPagoServicesAdapter, advancedConfiguration: advancedConfiguration, paymentConfigurationService: paymentConfigurationService, disabledOption: disabledOption, escManager: escManager)
+        super.init()
+        model.oneTapFlow = self
     }
 
     deinit {
@@ -86,6 +88,10 @@ final class OneTapFlow: NSObject, PXFlow {
 
     func setPaymentMethodPlugins(_ plugins: [PXPaymentMethodPlugin]?) {
         model.paymentMethodPlugins = plugins
+    }
+
+    func shouldShowSecurityCodeScreen() -> Bool {
+        return model.nextStep() == .screenSecurityCode
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow.swift
@@ -90,7 +90,8 @@ final class OneTapFlow: NSObject, PXFlow {
         model.paymentMethodPlugins = plugins
     }
 
-    func shouldShowSecurityCodeScreen() -> Bool {
+    func needSecurityCodeValidation() -> Bool {
+        model.readyToPay = true
         return model.nextStep() == .screenSecurityCode
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
@@ -35,6 +35,9 @@ final internal class OneTapFlowModel: PXFlowModel {
     var paymentFlow: PXPaymentFlow?
     weak var paymentResultHandler: PXPaymentResultHandlerProtocol?
 
+    // One Tap Flow
+    weak var oneTapFlow: OneTapFlow?
+
     var chargeRules: [PXPaymentTypeChargeRule]?
 
     var invalidESC: Bool = false
@@ -111,8 +114,8 @@ internal extension OneTapFlowModel {
         return SecurityCodeViewModel(paymentMethod: paymentMethod, cardInfo: cardInformation, reason: reason)
     }
 
-    func reviewConfirmViewModel() -> PXOneTapViewModel {
-        let viewModel = PXOneTapViewModel(amountHelper: self.amountHelper, paymentOptionSelected: paymentOptionSelected, advancedConfig: advancedConfiguration, userLogged: false, disabledOption: disabledOption, escProtocol: self.escManager)
+    func oneTapViewModel() -> PXOneTapViewModel {
+        let viewModel = PXOneTapViewModel(amountHelper: amountHelper, paymentOptionSelected: paymentOptionSelected, advancedConfig: advancedConfiguration, userLogged: false, disabledOption: disabledOption, escProtocol: escManager, currentFlow: oneTapFlow)
         viewModel.expressData = search.oneTap
         viewModel.paymentMethods = search.availablePaymentMethods
         viewModel.items = checkoutPreference.items

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
@@ -261,7 +261,7 @@ extension PXOneTapViewController {
     }
 
     private func confirmPayment() {
-        if viewModel.shouldValidateWithBiometric(withCardId: selectedCard?.cardId) {
+        if viewModel.shouldValidateWithBiometric() {
             let biometricModule = PXConfiguratorManager.biometricProtocol
             biometricModule.validate(config: PXConfiguratorManager.biometricConfig, onSuccess: { [weak self] in
                 DispatchQueue.main.async {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
@@ -22,11 +22,19 @@ final class PXOneTapViewModel: PXReviewViewModel {
     var additionalInfoSummary: PXAdditionalInfoSummary?
     var disabledOption: PXDisabledOption?
 
-    public init(amountHelper: PXAmountHelper, paymentOptionSelected: PaymentMethodOption, advancedConfig: PXAdvancedConfiguration, userLogged: Bool, disabledOption: PXDisabledOption? = nil, escProtocol: MercadoPagoESC?) {
+    weak var currentFlow: OneTapFlow?
+
+    public init(amountHelper: PXAmountHelper, paymentOptionSelected: PaymentMethodOption, advancedConfig: PXAdvancedConfiguration, userLogged: Bool, disabledOption: PXDisabledOption? = nil, escProtocol: MercadoPagoESC?, currentFlow: OneTapFlow?) {
         self.disabledOption = disabledOption
+        self.currentFlow = currentFlow
         super.init(amountHelper: amountHelper, paymentOptionSelected: paymentOptionSelected, advancedConfig: advancedConfig, userLogged: userLogged, escProtocol: escProtocol)
     }
 
+    override func shouldValidateWithBiometric(withCardId: String? = nil) -> Bool {
+        guard let oneTapFlow = currentFlow else { return false }
+        oneTapFlow.model.readyToPay = true
+        return !oneTapFlow.shouldShowSecurityCodeScreen()
+    }
 }
 
 // MARK: ViewModels Publics.

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
@@ -22,6 +22,7 @@ final class PXOneTapViewModel: PXReviewViewModel {
     var additionalInfoSummary: PXAdditionalInfoSummary?
     var disabledOption: PXDisabledOption?
 
+    // Current flow.
     weak var currentFlow: OneTapFlow?
 
     public init(amountHelper: PXAmountHelper, paymentOptionSelected: PaymentMethodOption, advancedConfig: PXAdvancedConfiguration, userLogged: Bool, disabledOption: PXDisabledOption? = nil, escProtocol: MercadoPagoESC?, currentFlow: OneTapFlow?) {
@@ -32,8 +33,7 @@ final class PXOneTapViewModel: PXReviewViewModel {
 
     override func shouldValidateWithBiometric(withCardId: String? = nil) -> Bool {
         guard let oneTapFlow = currentFlow else { return false }
-        oneTapFlow.model.readyToPay = true
-        return !oneTapFlow.shouldShowSecurityCodeScreen()
+        return !oneTapFlow.needSecurityCodeValidation()
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
@@ -28,7 +28,6 @@ class PXReviewViewModel: NSObject {
         self.escProtocol = escProtocol
     }
 
-    @discardableResult
     func shouldValidateWithBiometric(withCardId: String? = nil) -> Bool {
         // Validation is mandatory for payment methods != (credit or debit card).
         if !isPaymentMethodDebitOrCredit() { return true }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
@@ -28,6 +28,7 @@ class PXReviewViewModel: NSObject {
         self.escProtocol = escProtocol
     }
 
+    @discardableResult
     func shouldValidateWithBiometric(withCardId: String? = nil) -> Bool {
         // Validation is mandatory for payment methods != (credit or debit card).
         if !isPaymentMethodDebitOrCredit() { return true }


### PR DESCRIPTION
Se cambia el paradigma de chequeo de si necesita llamar al modulo de Biometric o no para la validacion.
Ahora se sustenta 100% en la maquina de estados que es el reflejo de lo que realmente sucede a nivel flujo.

Basicamente, no se valida biometric si se va a mostrar una pantalla de codigo de seguridad.