### PR TITLE
Fix - Hex colors with alpha

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Extensions/UIColor+Additions.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Extensions/UIColor+Additions.swift
@@ -21,11 +21,19 @@ internal extension UIColor {
     }
 
     class func fromHex(_ hexValue: String) -> UIColor {
-        var hexInt: UInt32 = 0
-        let scanner: Scanner = Scanner(string: hexValue)
-        scanner.charactersToBeSkipped = CharacterSet(charactersIn: "#")
-        scanner.scanHexInt32(&hexInt)
-        return UIColorFromRGB(UInt(hexInt))
+        let hexAlphabet = "0123456789abcdefABCDEF"
+        let hex = hexValue.trimmingCharacters(in: CharacterSet(charactersIn: hexAlphabet).inverted)
+        var hexInt = UInt32()
+        Scanner(string: hex).scanHexInt32(&hexInt)
+
+        let alpha, red, green, blue: UInt32
+        switch hex.count {
+        case 3: (alpha, red, green, blue) = (255, (hexInt >> 8) * 17, (hexInt >> 4 & 0xF) * 17, (hexInt & 0xF) * 17) // RGB
+        case 6: (alpha, red, green, blue) = (255, hexInt >> 16, hexInt >> 8 & 0xFF, hexInt & 0xFF) // RRGGBB
+        case 8: (alpha, red, green, blue) = (hexInt >> 24, hexInt >> 16 & 0xFF, hexInt >> 8 & 0xFF, hexInt & 0xFF) // AARRGGBB
+        default: return UIColor.black
+        }
+        return UIColor(red: CGFloat(red)/255, green: CGFloat(green)/255, blue: CGFloat(blue)/255, alpha: CGFloat(alpha)/255)
     }
 
     convenience init(red: Int, green: Int, blue: Int) {
@@ -87,10 +95,6 @@ internal extension UIColor {
     }
     class func px_backgroundColor() -> UIColor {
         return UIColorFromRGB(0xEBEBF0)
-    }
-
-    class func px_white() -> UIColor {
-        return UIColorFromRGB(0xFFFFFF)
     }
 
     class func installments() -> UIColor {
@@ -160,10 +164,6 @@ internal extension UIColor {
         return UIColor(white: 102.0 / 255.0, alpha: 1.0)
     }
 
-    class var pxBlack: UIColor {
-        return UIColor(white: 51.0 / 255.0, alpha: 1.0)
-    }
-
     class var pxBlueMp: UIColor {
         return UIColor(red: 0.0, green: 156.0 / 255.0, blue: 238.0 / 255.0, alpha: 1.0)
     }
@@ -178,10 +178,6 @@ internal extension UIColor {
 
     class var pxOrangeMp: UIColor {
         return UIColor(red: 255.0 / 255.0, green: 166.0 / 255.0, blue: 68.0 / 255.0, alpha: 1.0)
-    }
-
-    class var pxWhite: UIColor {
-        return UIColor(white: 255.0 / 255.0, alpha: 1.0)
     }
 
     class var pxLightGray: UIColor {

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Utils.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Utils.swift
@@ -65,7 +65,7 @@ internal class Utils {
         return dateFormatter.string(from: date!)
     }
 
-    class func getAttributedAmount(_ formattedString: String, thousandSeparator: String, decimalSeparator: String, currencySymbol: String, color: UIColor = UIColor.px_white(), fontSize: CGFloat = 20, centsFontSize: CGFloat = 10, baselineOffset: Int = 7) -> NSAttributedString {
+    class func getAttributedAmount(_ formattedString: String, thousandSeparator: String, decimalSeparator: String, currencySymbol: String, color: UIColor = .white, fontSize: CGFloat = 20, centsFontSize: CGFloat = 10, baselineOffset: Int = 7) -> NSAttributedString {
         let cents = getCentsFormatted(formattedString, decimalSeparator: decimalSeparator)
         let amount = getAmountFormatted(String(describing: Int(formattedString)), thousandSeparator: thousandSeparator, decimalSeparator: decimalSeparator)
 
@@ -83,11 +83,11 @@ internal class Utils {
         return attributedSymbol
     }
 
-    class func getAttributedAmount(_ amount: Double, currency: PXCurrency, color: UIColor = UIColor.px_white(), fontSize: CGFloat = 20, centsFontSize: CGFloat = 10, baselineOffset: Int = 7, negativeAmount: Bool = false, lightFont: Bool = false) -> NSMutableAttributedString {
+    class func getAttributedAmount(_ amount: Double, currency: PXCurrency, color: UIColor = .white, fontSize: CGFloat = 20, centsFontSize: CGFloat = 10, baselineOffset: Int = 7, negativeAmount: Bool = false, lightFont: Bool = false) -> NSMutableAttributedString {
         return getAttributedAmount(amount, thousandSeparator: currency.getThousandsSeparatorOrDefault(), decimalSeparator: currency.getDecimalSeparatorOrDefault(), currencySymbol: currency.getCurrencySymbolOrDefault(), color: color, fontSize: fontSize, centsFontSize: centsFontSize, baselineOffset: baselineOffset, negativeAmount: negativeAmount, lightFont: lightFont)
     }
 
-    class func getAttributedAmount(_ amount: Double, thousandSeparator: String, decimalSeparator: String, currencySymbol: String, color: UIColor = UIColor.px_white(), fontSize: CGFloat = 20, centsFontSize: CGFloat = 10, baselineOffset: Int = 7, negativeAmount: Bool = false, smallSymbol: Bool = false, lightFont: Bool = false) -> NSMutableAttributedString {
+    class func getAttributedAmount(_ amount: Double, thousandSeparator: String, decimalSeparator: String, currencySymbol: String, color: UIColor = .white, fontSize: CGFloat = 20, centsFontSize: CGFloat = 10, baselineOffset: Int = 7, negativeAmount: Bool = false, smallSymbol: Bool = false, lightFont: Bool = false) -> NSMutableAttributedString {
         let cents = getCentsFormatted(String(amount), decimalSeparator: ".")
         let amount = getAmountFormatted(String(describing: Int(amount)), thousandSeparator: thousandSeparator, decimalSeparator: ".")
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXText.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXText.swift
@@ -7,11 +7,13 @@
 
 import Foundation
 
-public struct PXText: Codable {
+public class PXText: Codable {
     let message: String?
     let backgroundColor: String?
     let textColor: String?
     let weight: String?
+    var defaultTextColor: UIColor = .black
+    var defaultBackgroundColor: UIColor = .clear
 
     enum CodingKeys: String, CodingKey {
         case message
@@ -20,23 +22,42 @@ public struct PXText: Codable {
         case weight
     }
 
+    init(message: String?, backgroundColor: String?, textColor: String?, weight: String?) {
+        self.message = message
+        self.backgroundColor = backgroundColor
+        self.textColor = textColor
+        self.weight = weight
+    }
+
+    func setDefaultBackgroundColor(_ color: UIColor) {
+        self.defaultBackgroundColor = color
+    }
+
+    func setDefaultTextColor(_ color: UIColor) {
+        self.defaultTextColor = color
+    }
+
     internal func getAttributedString(fontSize: CGFloat = PXLayout.XS_FONT, textColor: UIColor? = nil, backgroundColor: UIColor? = nil) -> NSAttributedString? {
         guard let message = message else {return nil}
 
         var attributes: [NSAttributedString.Key: AnyObject] = [:]
 
-        // Add text color attribute
+        // Add text color attribute or default
         if let defaultTextColor = self.textColor {
             attributes[.foregroundColor] = UIColor.fromHex(defaultTextColor)
+        } else {
+            attributes[.foregroundColor] = defaultTextColor
         }
         // Override text color
         if let overrideTextColor = textColor {
             attributes[.foregroundColor] = overrideTextColor
         }
 
-        // Add background color attribute
+        // Add background color attribute or default
         if let defaultBackgroundColor = self.backgroundColor {
             attributes[.backgroundColor] = UIColor.fromHex(defaultBackgroundColor)
+        } else {
+            attributes[.backgroundColor] = defaultBackgroundColor
         }
         // Override background color
         if let overrideBackgroundColor = backgroundColor {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Base/PXComponentContainerViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Base/PXComponentContainerViewController.swift
@@ -38,7 +38,7 @@ class PXComponentContainerViewController: MercadoPagoUIViewController {
         topContentConstraint?.isActive = true
         PXLayout.centerHorizontally(view: contentView, to: scrollView).isActive = true
         PXLayout.matchWidth(ofView: contentView, toView: scrollView).isActive = true
-        contentView.backgroundColor = .pxWhite
+        contentView.backgroundColor = .white
         super.init(nibName: nil, bundle: nil)
 
         if adjustInsets {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Card/CardsAdminViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Card/CardsAdminViewController.swift
@@ -72,7 +72,7 @@ internal class CardsAdminViewController: MercadoPagoUIScrollViewController, UICo
         self.addCallbackCancel()
 
         self.addTopHeader()
-        self.collectionSearch.backgroundColor = UIColor.px_white()
+        self.collectionSearch.backgroundColor = .white
         self.setTitle()
         self.registerAllCells()
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsInfoRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsInfoRenderer.swift
@@ -11,7 +11,7 @@ import Foundation
 class PXInstructionsInfoRenderer: NSObject {
     let CONTENT_WIDTH_PERCENT: CGFloat = 84.0
     let TITLE_LABEL_FONT_SIZE: CGFloat = PXLayout.M_FONT
-    let TITLE_LABEL_FONT_COLOR: UIColor = .pxBlack
+    let TITLE_LABEL_FONT_COLOR: UIColor = .black
     let INFO_LABEL_FONT_SIZE: CGFloat = PXLayout.XS_FONT
     let INFO_LABEL_FONT_COLOR: UIColor = .pxBrownishGray
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsInteractionRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsInteractionRenderer.swift
@@ -12,7 +12,7 @@ class PXInstructionsInteractionRenderer: NSObject {
     let TITLE_LABEL_FONT_SIZE: CGFloat = PXLayout.XS_FONT
     let TITLE_LABEL_FONT_COLOR: UIColor = .pxBrownishGray
     let INTERACTION_LABEL_FONT_SIZE: CGFloat = PXLayout.M_FONT
-    let INTERACTION_LABEL_FONT_COLOR: UIColor = .pxBlack
+    let INTERACTION_LABEL_FONT_COLOR: UIColor = .black
 
     func render(_ instructionInteraction: PXInstructionsInteractionComponent) -> PXInstructionsInteractionView {
         let instructionInteractionView = PXInstructionsInteractionView()

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsInteractionsRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsInteractionsRenderer.swift
@@ -10,7 +10,7 @@ import Foundation
 class PXInstructionsInteractionsRenderer: NSObject {
     let CONTENT_WIDTH_PERCENT: CGFloat = 84.0
     let TITLE_LABEL_FONT_SIZE: CGFloat = PXLayout.M_FONT
-    let TITLE_LABEL_FONT_COLOR: UIColor = .pxBlack
+    let TITLE_LABEL_FONT_COLOR: UIColor = .black
 
     func render(_ instructionsInteractions: PXInstructionsInteractionsComponent) -> PXInstructionsInteractionsView {
         let instructionsInteractionsView = PXInstructionsInteractionsView()

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsReferenceRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsReferenceRenderer.swift
@@ -13,7 +13,7 @@ class PXInstructionsReferenceRenderer: NSObject {
     let TITLE_LABEL_FONT_SIZE: CGFloat = PXLayout.XXXS_FONT
     let TITLE_LABEL_FONT_COLOR: UIColor = .pxBrownishGray
     let REFERENCE_LABEL_FONT_SIZE: CGFloat = PXLayout.M_FONT
-    let REFERENCE_LABEL_FONT_COLOR: UIColor = .pxBlack
+    let REFERENCE_LABEL_FONT_COLOR: UIColor = .black
 
     func render(_ instructionReference: PXInstructionsReferenceComponent) -> PXInstructionsReferenceView {
         let instructionReferenceView = PXInstructionsReferenceView()

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsReferencesRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsReferencesRenderer.swift
@@ -11,7 +11,7 @@ import Foundation
 class PXInstructionsReferencesRenderer: NSObject {
     let CONTENT_WIDTH_PERCENT: CGFloat = 84.0
     let TITLE_LABEL_FONT_SIZE: CGFloat = PXLayout.M_FONT
-    let TITLE_LABEL_FONT_COLOR: UIColor = .pxBlack
+    let TITLE_LABEL_FONT_COLOR: UIColor = .black
 
     func render(_ instructionsReferences: PXInstructionsReferencesComponent) -> PXInstructionsReferencesView {
         let instructionsReferencesView = PXInstructionsReferencesView()

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsSecondaryInfoRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsSecondaryInfoRenderer.swift
@@ -15,7 +15,7 @@ class PXInstructionsSecondaryInfoRenderer: NSObject {
     func render(instructionsSecondaryInfo: PXInstructionsSecondaryInfoComponent) -> PXInstructionsSecondaryInfoView {
         let instructionsSecondaryInfoView = PXInstructionsSecondaryInfoView()
         instructionsSecondaryInfoView.translatesAutoresizingMaskIntoConstraints = false
-        instructionsSecondaryInfoView.backgroundColor = .pxWhite
+        instructionsSecondaryInfoView.backgroundColor = .white
 
         var lastLabel: UILabel?
         for string in instructionsSecondaryInfo.props.secondaryInfo {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsSubtitleRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsSubtitleRenderer.swift
@@ -15,7 +15,7 @@ class PXInstructionsSubtitleRenderer: NSObject {
     func render(_ instructionsSubtitle: PXInstructionsSubtitleComponent) -> PXInstructionsSubtitleView {
         let instructionsSubtitleView = PXInstructionsSubtitleView()
         instructionsSubtitleView.translatesAutoresizingMaskIntoConstraints = false
-        instructionsSubtitleView.backgroundColor = .pxWhite
+        instructionsSubtitleView.backgroundColor = .white
         let attributes = [NSAttributedString.Key.font: Utils.getFont(size: LABEL_FONT_SIZE)]
         let attributedString = NSAttributedString(string: instructionsSubtitle.props.subtitle, attributes: attributes)
         instructionsSubtitleView.subtitleLabel = buildSubtitleLabel(with: attributedString, in: instructionsSubtitleView)

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsTertiaryInfoRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Instructions/PXInstructionsTertiaryInfoRenderer.swift
@@ -11,7 +11,7 @@ import Foundation
 class PXInstructionsTertiaryInfoRenderer: NSObject {
     let CONTENT_WIDTH_PERCENT: CGFloat = 84.0
     let TITLE_LABEL_FONT_SIZE: CGFloat = PXLayout.M_FONT
-    let TITLE_LABEL_FONT_COLOR: UIColor = .pxBlack
+    let TITLE_LABEL_FONT_COLOR: UIColor = .black
     let INFO_LABEL_FONT_SIZE: CGFloat = PXLayout.XXXS_FONT
     let INFO_LABEL_FONT_COLOR: UIColor = .pxBrownishGray
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXError/PXErrorRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXError/PXErrorRenderer.swift
@@ -18,7 +18,7 @@ class PXErrorRenderer: NSObject {
 
     func render(component: PXErrorComponent) -> PXErrorView {
         let errorBodyView = PXErrorView()
-        errorBodyView.backgroundColor = .pxWhite
+        errorBodyView.backgroundColor = .white
         errorBodyView.translatesAutoresizingMaskIntoConstraints = false
 
         //Title Label

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXFooter/PXFooterRenderer.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXFooter/PXFooterRenderer.swift
@@ -22,7 +22,7 @@ final class PXFooterRenderer: NSObject {
         var topView: UIView = fooView
         var termsView: PXTermsAndConditionView?
         fooView.translatesAutoresizingMaskIntoConstraints = false
-        fooView.backgroundColor = .pxWhite
+        fooView.backgroundColor = .white
 
         if footer.props.termsInfo != nil {
             termsView = PXTermsAndConditionView(termsDto: footer.props.termsInfo, delegate: termsDelegate)

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXHeader/PXHeaderViewModelHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXHeader/PXHeaderViewModelHelper.swift
@@ -136,7 +136,7 @@ internal extension PXResultViewModel {
         if let range = amountRange {
             let lowerBoundTitle = String(instructionsInfo.instructions[0].title[..<range.lowerBound])
             let attributedTitle = NSMutableAttributedString(string: lowerBoundTitle, attributes: [NSAttributedString.Key.font: Utils.getFont(size: PXHeaderRenderer.TITLE_FONT_SIZE)])
-            let attributedAmount = Utils.getAttributedAmount(amountInfo.amount, thousandSeparator: thousandSeparator, decimalSeparator: decimalSeparator, currencySymbol: currencySymbol, color: UIColor.px_white(), fontSize: PXHeaderRenderer.TITLE_FONT_SIZE, centsFontSize: PXHeaderRenderer.TITLE_FONT_SIZE / 2, smallSymbol: true)
+            let attributedAmount = Utils.getAttributedAmount(amountInfo.amount, thousandSeparator: thousandSeparator, decimalSeparator: decimalSeparator, currencySymbol: currencySymbol, color: .white, fontSize: PXHeaderRenderer.TITLE_FONT_SIZE, centsFontSize: PXHeaderRenderer.TITLE_FONT_SIZE / 2, smallSymbol: true)
             attributedTitle.append(attributedAmount)
             let upperBoundTitle = String(instructionsInfo.instructions[0].title[range.upperBound...])
             let endingTitle = NSAttributedString(string: upperBoundTitle, attributes: [NSAttributedString.Key.font: Utils.getFont(size: PXHeaderRenderer.TITLE_FONT_SIZE)])

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResourceProvider.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResourceProvider.swift
@@ -43,7 +43,7 @@ internal class PXResourceProvider {
         let currencySymbol = currency.getCurrencySymbolOrDefault()
         let thousandSeparator = currency.getThousandsSeparatorOrDefault()
         let decimalSeparator = currency.getDecimalSeparatorOrDefault()
-        let attributtedString = Utils.getAttributedAmount(amount, thousandSeparator: thousandSeparator, decimalSeparator: decimalSeparator, currencySymbol: currencySymbol, color: UIColor.px_white(), fontSize: PXHeaderRenderer.TITLE_FONT_SIZE, centsFontSize: PXHeaderRenderer.TITLE_FONT_SIZE / 2, smallSymbol: true)
+        let attributtedString = Utils.getAttributedAmount(amount, thousandSeparator: thousandSeparator, decimalSeparator: decimalSeparator, currencySymbol: currencySymbol, color: .white, fontSize: PXHeaderRenderer.TITLE_FONT_SIZE, centsFontSize: PXHeaderRenderer.TITLE_FONT_SIZE / 2, smallSymbol: true)
         let amountString = attributtedString.string
         let composedText = initialText.replacingOccurrences(of: "{0}", with: amountString)
         return composedText

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultUtil.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultUtil.swift
@@ -119,7 +119,7 @@ extension PXNewResultUtil {
         let secondString: NSAttributedString? = getPMSecondString(paymentData: paymentData)
         let thirdString: NSAttributedString? = getPMThirdString(paymentData: paymentData)
 
-        let data = PXNewCustomViewData(firstString: firstString, secondString: secondString, thirdString: thirdString, icon: image, iconURL: nil, action: nil, color: .pxWhite)
+        let data = PXNewCustomViewData(firstString: firstString, secondString: secondString, thirdString: thirdString, icon: image, iconURL: nil, action: nil, color: .white)
         return data
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
@@ -60,7 +60,7 @@ class PXNewResultViewController: MercadoPagoUIViewController {
         view.removeAllSubviews()
         view.addSubview(scrollView)
         view.backgroundColor = viewModel.getHeaderColor()
-        scrollView.backgroundColor = .pxWhite
+        scrollView.backgroundColor = .white
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -81,7 +81,7 @@ class PXNewResultViewController: MercadoPagoUIViewController {
     func renderContentView() {
         //CONTENT VIEW
         let contentView = UIView()
-        contentView.backgroundColor = .pxWhite
+        contentView.backgroundColor = .white
         contentView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.addSubview(contentView)
 


### PR DESCRIPTION
##  Cambios introducidos : 
- Se agrega soporte para colores en formato hexadecimal de 8 dígitos (AARRGGBB)
- Se dejan de usar el pxWhite y el pxBlack
- Se agrega la opción de poder agregar colores default a los PXText
