### PR TITLE
Release 4.34.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v4.34.5
+# v4.34.5 
 🚀Private Release - 4.34.5 🚀
 MercadoPagoSDKV4 - Private Version
 - Reduce image sizes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-# v4.34.4 
+# v4.34.5
+🚀Private Release - 4.34.5 🚀
+MercadoPagoSDKV4 - Private Version
+- Reduce image sizes
+
+# v4.34.4
 🚀Private Release - 4.34.4 🚀
 MercadoPagoSDKV4 - Private Version
 - Fix discounts bug for pay-preference
 - Appium improvements
 
-# v4.34.3 
+# v4.34.3
 🚀Private Release - 4.34.3 🚀
 MercadoPagoSDKV4 - Private Version
 - Se agrego la sigla CNTFA para credits

--- a/MercadoPagoSDKV4.podspec
+++ b/MercadoPagoSDKV4.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDKV4"
-  s.version          = "4.34.4"
+  s.version          = "4.34.5"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
##  Cambios introducidos : 
- Se redujo el tamaño de las imagenes

Antes:
<img width="264" alt="Screen Shot 2020-06-29 at 10 00 18" src="https://user-images.githubusercontent.com/54864543/86011669-5e639f00-b9f3-11ea-92fa-0f8412df2c74.png">
Despues:
<img width="259" alt="Screen Shot 2020-06-29 at 10 24 45" src="https://user-images.githubusercontent.com/54864543/86011679-60c5f900-b9f3-11ea-9fb6-e3129aeab735.png">

