### PR TITLE
PaymentCongrats: Initial structure

### DIFF
--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/Base.lproj/Main.storyboard
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SOP-J7-wnf">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SOP-J7-wnf">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,7 +12,7 @@
             <objects>
                 <navigationController id="SOP-J7-wnf" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ych-Lf-gaP">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.57919406890000003" green="0.1280144453" blue="0.57268613580000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
@@ -38,10 +36,10 @@
                             <tableViewSection id="lIv-5z-GjF">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="100" id="isW-Fg-w7L">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="100"/>
+                                        <rect key="frame" x="0.0" y="28" width="375" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="isW-Fg-w7L" id="8zM-HR-Uvt">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="99.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="100"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PlugNplay" translatesAutoresizingMaskIntoConstraints="NO" id="Byb-pF-4nL">
@@ -73,6 +71,46 @@
                                                 <constraint firstItem="NLR-IY-vgG" firstAttribute="top" secondItem="8zM-HR-Uvt" secondAttribute="topMargin" id="aUp-mE-Tgy"/>
                                                 <constraint firstItem="NLR-IY-vgG" firstAttribute="leading" secondItem="8zM-HR-Uvt" secondAttribute="leadingMargin" id="pUk-QR-p5T"/>
                                                 <constraint firstAttribute="bottomMargin" secondItem="NLR-IY-vgG" secondAttribute="bottom" id="wT2-OP-h3e"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="100" id="YGF-in-hiB">
+                                        <rect key="frame" x="0.0" y="128" width="375" height="100"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YGF-in-hiB" id="HDl-Tv-Vyy">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="100"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PlugNplay" translatesAutoresizingMaskIntoConstraints="NO" id="9l9-gT-gfD">
+                                                    <rect key="frame" x="26" y="24" width="66" height="52"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="66" id="s3k-dw-Z0Y"/>
+                                                        <constraint firstAttribute="height" constant="52" id="zGE-9L-3Da"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Congrats" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2sN-yM-voE">
+                                                    <rect key="frame" x="102" y="40" width="70" height="20"/>
+                                                    <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
+                                                    <color key="textColor" red="0.43529411759999997" green="0.4431372549" blue="0.47450980390000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UnX-Gg-RJM">
+                                                    <rect key="frame" x="16" y="11" width="343" height="78"/>
+                                                    <connections>
+                                                        <action selector="checkoutFlow:" destination="Rgx-dD-8Cm" eventType="touchUpInside" id="b2I-Sw-udR"/>
+                                                        <action selector="launchCongrats:" destination="Rgx-dD-8Cm" eventType="touchUpInside" id="IV2-Wf-SbU"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="UnX-Gg-RJM" firstAttribute="top" secondItem="HDl-Tv-Vyy" secondAttribute="topMargin" id="6VN-U9-1lz"/>
+                                                <constraint firstItem="2sN-yM-voE" firstAttribute="centerY" secondItem="HDl-Tv-Vyy" secondAttribute="centerY" id="ReM-JB-hJD"/>
+                                                <constraint firstItem="9l9-gT-gfD" firstAttribute="centerY" secondItem="HDl-Tv-Vyy" secondAttribute="centerY" id="Scl-Oi-kgP"/>
+                                                <constraint firstItem="9l9-gT-gfD" firstAttribute="leading" secondItem="HDl-Tv-Vyy" secondAttribute="leadingMargin" constant="10" id="VFe-rd-xVp"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="UnX-Gg-RJM" secondAttribute="trailing" id="Vbh-Qb-slb"/>
+                                                <constraint firstItem="UnX-Gg-RJM" firstAttribute="leading" secondItem="HDl-Tv-Vyy" secondAttribute="leadingMargin" id="Zy4-tS-pMI"/>
+                                                <constraint firstItem="2sN-yM-voE" firstAttribute="leading" secondItem="9l9-gT-gfD" secondAttribute="trailing" constant="10" id="sA2-bV-9xb"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="UnX-Gg-RJM" secondAttribute="bottom" id="vkh-sx-Aw6"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>

--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -29,7 +29,6 @@
                                          setCrossSellingData]
                                         setExpenseSplit: @"Expense"]
                                        startUsing: self.navigationController];
-    ;
 }
 
 - (IBAction)checkoutFlow:(id)sender {

--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -13,21 +13,22 @@
 @implementation MainExamplesViewController
 
 - (IBAction)launchCongrats:(id)sender {
-    PXPaymentCongrats *congratsData = [[[[[[[[[[[[PXPaymentCongrats alloc] init]
+    PXPaymentCongrats *congratsData = [[[[[[[[[[[[[PXPaymentCongrats alloc] init]
                                                 setStatus:PXBusinessResultStatusAPPROVED]
-                                               setHeaderTitle:@"¡Listo! Ya le pagaste a SuperMarket"] //Falta header image
-                                              shouldShowReceipt:TRUE receiptId:@"123"]
-                                             setMainActionWithLabel:@"Continuar" action:^{
+                                               setHeaderTitle: @"¡Listo! Ya le pagaste a SuperMarket"]
+                                              setHeaderImage: nil orURL: @"https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg"]
+                                              shouldShowReceipt: TRUE receiptId: @"123"]
+                                             setMainActionWithLabel: @"Continuar" action:^{
         NSLog(@"Continuar");
     }]
-                                            setSecondaryActionWithLabel:@"Tuve un problema" action:^{
+                                            setSecondaryActionWithLabel: @"Tuve un problema" action:^{
         NSLog(@"Tuve un problema");
     }]
-                                           addPointsDataWithPercentage:0.85 levelColor:@"#4063EA" levelNumber:4 title:@"Ud ganó 2.000 puntos" actionLabel:@"Ver mis beneficios" actionTarget:@"meli://loyalty/webview?url=https%3A%2F%2Fwww.mercadolivre.com.br%2Fmercado-pontos%2Fv2%2Fhub%23origin%3Dcongrats"]
-                                          addDiscounts]
-                                         addCrossSelling]
-                                        addExpenseSplit:@"Expense"]
-                                       startUsing:self.navigationController];
+                                           setPointsDataWithPercentage: 0.85 levelColor: @"#4063EA" levelNumber: 4 title: @"Ud ganó 2.000 puntos" actionLabel: @"Ver mis beneficios" actionTarget: @"meli://loyalty/webview?url=https%3A%2F%2Fwww.mercadolivre.com.br%2Fmercado-pontos%2Fv2%2Fhub%23origin%3Dcongrats"]
+                                          setDiscountsData]
+                                         setCrossSellingData]
+                                        setExpenseSplit: @"Expense"]
+                                       startUsing: self.navigationController];
     ;
 }
 

--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -12,6 +12,25 @@
   
 @implementation MainExamplesViewController
 
+- (IBAction)launchCongrats:(id)sender {
+    PXPaymentCongrats *congratsData = [[[[[[[[[[[[PXPaymentCongrats alloc] init]
+                                                setStatus:PXBusinessResultStatusAPPROVED]
+                                               setHeaderTitle:@"¡Listo! Ya le pagaste a SuperMarket"] //Falta header image
+                                              shouldShowReceipt:TRUE receiptId:@"123"]
+                                             setMainActionWithLabel:@"Continuar" action:^{
+        NSLog(@"Continuar");
+    }]
+                                            setSecondaryActionWithLabel:@"Tuve un problema" action:^{
+        NSLog(@"Tuve un problema");
+    }]
+                                           addPointsDataWithPercentage:0.85 levelColor:@"#4063EA" levelNumber:4 title:@"Ud ganó 2.000 puntos" actionLabel:@"Ver mis beneficios" actionTarget:@"meli://loyalty/webview?url=https%3A%2F%2Fwww.mercadolivre.com.br%2Fmercado-pontos%2Fv2%2Fhub%23origin%3Dcongrats"]
+                                          addDiscounts]
+                                         addCrossSelling]
+                                        addExpenseSplit:@"Expense"]
+                                       startUsing:self.navigationController];
+    ;
+}
+
 - (IBAction)checkoutFlow:(id)sender {
 
     //CHECKOUT PREFERENCE

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -25,22 +25,26 @@ class ViewController: UIViewController {
     }
     
     @IBAction func launchCongrats(_ sender: Any) {
+        guard let navController = navigationController else { return }
         _ = PXPaymentCongrats()
-            .setStatus(.APPROVED)
-            .setHeaderTitle("¡Listo! Ya le pagaste a SuperMarket")
-            .setHeaderImage(nil, orURL: "https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg")
+            .withStatus(.APPROVED)
+            .withHeaderTitle("¡Listo! Ya le pagaste a SuperMarket")
+            .withHeaderImage(nil, orURL: "https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg")
+            .withHeaderCloseAction {
+                navController.popViewController(animated: true)
+        }
             .shouldShowReceipt(true, receiptId: "123")
-            .setMainAction(label: "Continuar", action: {
-                print("Continuar")
+            .withMainAction(label: "Continuar", action: {
+                navController.popViewController(animated: true)
             })
-            .setSecondaryAction(label: "Tuve un problema", action: {
-                print("Tuve un problema")
+            .withSecondaryAction(label: "Tuve un problema", action: {
+                navController.popViewController(animated: true)
             })
-            .setPointsData(percentage: 0.85, levelColor: "#4063EA", levelNumber: 4, title: "Ud ganó 2.000 puntos", actionLabel: "Ver mis beneficios", actionTarget: "meli://loyalty/webview?url=https%3A%2F%2Fwww.mercadolivre.com.br%2Fmercado-pontos%2Fv2%2Fhub%23origin%3Dcongrats")
-            .setDiscountsData()
-            .setCrossSellingData()
-            .setExpenseSplit("Expense")
-            .start(using: self.navigationController!)
+            .withPointsData(percentage: 0.85, levelColor: "#4063EA", levelNumber: 4, title: "Ud ganó 2.000 puntos", actionLabel: "Ver mis beneficios", actionTarget: "meli://loyalty/webview?url=https%3A%2F%2Fwww.mercadolivre.com.br%2Fmercado-pontos%2Fv2%2Fhub%23origin%3Dcongrats")
+            .withDiscountsData()
+            .withCrossSellingData()
+            .withExpenseSplit("Expense", backgroundColor: "#000000", textColor: "#FFFFFF", weight: nil, actionLabel: "Action expense", actionTarget: nil, imageURL: "https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg")
+            .start(using: navController)
     }
     
     override func viewDidLoad() {

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -25,11 +25,10 @@ class ViewController: UIViewController {
     }
     
     @IBAction func launchCongrats(_ sender: Any) {
-        // TODO: Run congrats
         _ = PXPaymentCongrats()
             .setStatus(.APPROVED)
             .setHeaderTitle("¡Listo! Ya le pagaste a SuperMarket")
-            .headerImage(nil, orURL: "https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg")
+            .setHeaderImage(nil, orURL: "https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg")
             .shouldShowReceipt(true, receiptId: "123")
             .setMainAction(label: "Continuar", action: {
                 print("Continuar")
@@ -37,10 +36,10 @@ class ViewController: UIViewController {
             .setSecondaryAction(label: "Tuve un problema", action: {
                 print("Tuve un problema")
             })
-            .addPointsData(percentage: 0.85, levelColor: "#4063EA", levelNumber: 4, title: "Ud ganó 2.000 puntos", actionLabel: "Ver mis beneficios", actionTarget: "meli://loyalty/webview?url=https%3A%2F%2Fwww.mercadolivre.com.br%2Fmercado-pontos%2Fv2%2Fhub%23origin%3Dcongrats")
-            .addDiscounts()
-            .addCrossSelling()
-            .addExpenseSplit("Expense")
+            .setPointsData(percentage: 0.85, levelColor: "#4063EA", levelNumber: 4, title: "Ud ganó 2.000 puntos", actionLabel: "Ver mis beneficios", actionTarget: "meli://loyalty/webview?url=https%3A%2F%2Fwww.mercadolivre.com.br%2Fmercado-pontos%2Fv2%2Fhub%23origin%3Dcongrats")
+            .setDiscountsData()
+            .setCrossSellingData()
+            .setExpenseSplit("Expense")
             .start(using: self.navigationController!)
     }
     

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -9,11 +9,11 @@
 
 import UIKit
 
-#if PX_PRIVATE_POD
+//#if PX_PRIVATE_POD
     import MercadoPagoSDKV4
-#else
-    import MercadoPagoSDK
-#endif
+//#else
+//    import MercadoPagoSDK
+//#endif
 
 // Check full documentation: http://mercadopago.github.io/px-ios/v4/
 class ViewController: UIViewController {
@@ -22,6 +22,26 @@ class ViewController: UIViewController {
     @IBAction func initDefault(_ sender: Any) {
         // runMercadoPagoCheckout()
         runMercadoPagoCheckoutWithLifecycle()
+    }
+    
+    @IBAction func launchCongrats(_ sender: Any) {
+        // TODO: Run congrats
+        _ = PXPaymentCongrats()
+            .setStatus(.APPROVED)
+            .setHeaderTitle("¡Listo! Ya le pagaste a SuperMarket")
+            .headerImage(nil, orURL: "https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg")
+            .shouldShowReceipt(true, receiptId: "123")
+            .setMainAction(label: "Continuar", action: {
+                print("Continuar")
+            })
+            .setSecondaryAction(label: "Tuve un problema", action: {
+                print("Tuve un problema")
+            })
+            .addPointsData(percentage: 0.85, levelColor: "#4063EA", levelNumber: 4, title: "Ud ganó 2.000 puntos", actionLabel: "Ver mis beneficios", actionTarget: "meli://loyalty/webview?url=https%3A%2F%2Fwww.mercadolivre.com.br%2Fmercado-pontos%2Fv2%2Fhub%23origin%3Dcongrats")
+            .addDiscounts()
+            .addCrossSelling()
+            .addExpenseSplit("Expense")
+            .start(using: self.navigationController!)
     }
     
     override func viewDidLoad() {

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -9,11 +9,11 @@
 
 import UIKit
 
-//#if PX_PRIVATE_POD
+#if PX_PRIVATE_POD
     import MercadoPagoSDKV4
-//#else
-//    import MercadoPagoSDK
-//#endif
+#else
+    import MercadoPagoSDK
+#endif
 
 // Check full documentation: http://mercadopago.github.io/px-ios/v4/
 class ViewController: UIViewController {

--- a/ExampleSwift/ExampleSwift/Storyboards/Base.lproj/Main.storyboard
+++ b/ExampleSwift/ExampleSwift/Storyboards/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nVh-4Y-Mjr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nVh-4Y-Mjr">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -43,6 +43,19 @@
                                     <segue destination="zrt-Zz-h8w" kind="show" id="1D1-CH-h5u"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0VE-v2-udc">
+                                <rect key="frame" x="16" y="175" width="343" height="44"/>
+                                <color key="backgroundColor" name="andes-blue-ml-500"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="wZH-Sm-Ltq"/>
+                                </constraints>
+                                <state key="normal" title="Iniciar Congrats">
+                                    <color key="titleColor" name="andes-text-color-white"/>
+                                </state>
+                                <connections>
+                                    <action selector="launchCongrats:" destination="BYZ-38-t0r" eventType="touchUpInside" id="svl-3A-zDQ"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
@@ -51,6 +64,11 @@
                             <constraint firstItem="1Ik-LC-Wqd" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="Mrf-xv-I3Q"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="0Yu-7c-2ky" secondAttribute="trailing" constant="16" id="duv-UE-5n1"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="1Ik-LC-Wqd" secondAttribute="trailing" constant="16" id="j0g-1M-3Yj"/>
+                            <constraint firstItem="0VE-v2-udc" firstAttribute="width" secondItem="0Yu-7c-2ky" secondAttribute="width" id="nJf-qw-Wlr"/>
+                            <constraint firstItem="0VE-v2-udc" firstAttribute="trailing" secondItem="0Yu-7c-2ky" secondAttribute="trailing" id="s6b-NA-rld"/>
+                            <constraint firstItem="0VE-v2-udc" firstAttribute="height" secondItem="0Yu-7c-2ky" secondAttribute="height" id="sT8-c7-rYH"/>
+                            <constraint firstItem="0VE-v2-udc" firstAttribute="top" secondItem="0Yu-7c-2ky" secondAttribute="bottom" constant="8" id="yYU-k2-X6b"/>
+                            <constraint firstItem="0VE-v2-udc" firstAttribute="leading" secondItem="0Yu-7c-2ky" secondAttribute="leading" id="ypB-YP-QQg"/>
                             <constraint firstItem="0Yu-7c-2ky" firstAttribute="top" secondItem="1Ik-LC-Wqd" secondAttribute="bottom" constant="8" id="zJp-vq-WDM"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  PXPaymentCongrats.swift
 //  MercadoPagoSDK
 //
 //  Created by Franco Risma on 23/07/2020.
@@ -13,7 +13,6 @@ This also acts as an entry point for congrats withouth having to go through the 
 */
 @objcMembers
 public final class PXPaymentCongrats: NSObject {
-    
     // Header
     private var status: PXBusinessResultStatus = .REJECTED
     private var headerTitle: String = ""
@@ -60,78 +59,6 @@ public final class PXPaymentCongrats: NSObject {
     public override init() {
         super.init()
     }
-    
-    public func setStatus(_ status: PXBusinessResultStatus) -> PXPaymentCongrats {
-        self.status = status
-        return self
-    }
-    
-    public func setHeaderTitle(_ title: String) -> PXPaymentCongrats {
-        self.headerTitle = title
-        return self
-    }
-    
-    public func headerImage(_ image: UIImage?, orURL url: String?) -> PXPaymentCongrats {
-        self.headerImage = image
-        self.headerURL = url
-        return self
-    }
-
-    public func shouldShowReceipt(_ shouldShow: Bool, receiptId: String?) -> PXPaymentCongrats {
-        self.shouldShowReceipt = shouldShow
-        self.receiptId = receiptId
-        return self
-    }
-    
-    public func setMainAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
-        self.mainAction = PXAction(label: label, action: action)
-        return self
-    }
-    
-    public func setSecondaryAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
-        self.secondaryAction = PXAction(label: label, action: action)
-        return self
-    }
-
-    public func addPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
-        let action = PXRemoteAction(label: actionLabel, target: actionTarget)
-        self.pointsData = PXPoints(progress: PXPointsProgress(percentage: percentage, levelColor: levelColor, levelNumber: levelNumber), title: title, action: action)
-        return self
-    }
-
-    public func addDiscounts() -> PXPaymentCongrats {
-        self.discounts = PXDiscounts(title: "Descuentos por tu nivel", subtitle: "", discountsAction: PXRemoteAction(label: "Ver todos los descuentos", target: "mercadopago://discount_center_payers/list#from=/px/congrats"), downloadAction: PXDownloadAction(title: "Exclusivo con la app de Mercado Libre", action: PXRemoteAction(label: "Descargar", target: "https://852u.adj.st/discount_center_payers/list?adjust_t=ufj9wxn&adjust_deeplink=mercadopago%3A%2F%2Fdiscount_center_payers%2Flist&adjust_label=px-ml")), items: [PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/766266-MLA32568902676_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018483&user_level=1&mcc=1091102&distance=1072139&coupon_used=false&status=FULL&store_id=13040071&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F766266-MLA32568902676_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22Nutty%20Bavarian%22%7D%7D%5D#from=/px/congrats", campaingId: "1018483"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/826105-MLA32568902631_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018457&user_level=1&mcc=4771701&distance=543968&coupon_used=false&status=FULL&store_id=30316240&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F826105-MLA32568902631_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2015%22%2C%22subtitle%22%3A%22Drogasil%22%7D%7D%5D#from=/px/congrats", campaingId: "1018457"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/761600-MLA32568902662_102019-O.jpg", title: "Hasta", subtitle: "10 % OFF", target:  "mercadopago://discount_center_payers/detail?campaign_id=1018475&user_level=1&mcc=5611201&distance=654418&coupon_used=false&status=FULL&store_id=30108872&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F761600-MLA32568902662_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22McDonald%5Cu0027s%22%7D%7D%5D#from=/px/congrats", campaingId:"1018475") ], touchpoint: nil)
-        return self
-    }
-
-    public func addCrossSelling() -> PXPaymentCongrats {
-        self.crossSelling = [PXCrossSellingItem(title: "Gane 200 pesos por sus pagos diarios", icon: "https://mobile.mercadolibre.com/remote_resources/image/merchengine_mgm_icon_ml?density=xxhdpi&locale=es_AR", contentId: "cross_selling_mgm_ml", action: PXRemoteAction(label: "Invita a más amigos a usar la aplicación", target: "meli://invite/wallet"))]
-        return self
-    }
-    
-    #warning("Check if backgroundColor, textColor, weight should be customized from the outside")
-    public func addExpenseSplit(_ message: String) -> PXPaymentCongrats {
-        self.expenseSplit = PXExpenseSplit(title: PXText(message: message, backgroundColor: nil, textColor: nil, weight: nil), action: PXRemoteAction(label: "TBD", target: nil), imageUrl: "someImage")
-        return self
-    }
-
-    public func addViews(important: UIView?, top: UIView?, bottom: UIView?) -> PXPaymentCongrats {
-        self.importantView = important
-        self.topView = top
-        self.bottomView = bottom
-        return self
-    }
-    
-    public func addErrorMessage(_ message: String) {
-        self.errorMessage = message
-    }
-
-    public func start(using navController: UINavigationController) -> PXPaymentCongrats {
-        self.navigationController = navController
-        let vc = PXNewResultViewController(viewModel: self, callback:{_,_ in })
-        self.navigationController?.pushViewController(vc, animated: true)
-        return self
-    }
 
     // MARK: Private methods
     
@@ -145,6 +72,158 @@ public final class PXPaymentCongrats: NSObject {
         let props = PXErrorProps(title: title.toAttributedString(), message: labelInstruction.toAttributedString())
         
         return PXErrorComponent(props: props)
+    }
+}
+
+// MARK: Setters
+extension PXPaymentCongrats {
+    /**
+     Indicates status Success, Failure, for more info check `PXBusinessResultStatus`.
+     - parameter status: the result stats
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func setStatus(_ status: PXBusinessResultStatus) -> PXPaymentCongrats {
+        self.status = status
+        return self
+    }
+    
+    /**
+     Fills the header view with a message.
+     - parameter title: some message
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func setHeaderTitle(_ title: String) -> PXPaymentCongrats {
+        self.headerTitle = title
+        return self
+    }
+    
+    /**
+     Collector image shown in congrats' header. Can receive an `UIImage` or a `URL`.
+     - parameter image: an image in `UIImage` format
+     - parameter url: an `URL` for the image
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func headerImage(_ image: UIImage?, orURL url: String?) -> PXPaymentCongrats {
+        self.headerImage = image
+        self.headerURL = url
+        return self
+    }
+
+    /**
+     Defines if the receipt view should be shown, in affirmative case, the receiptId must be supplied.
+     - parameter shouldShow: some message
+     - parameter receiptId: some message
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func shouldShowReceipt(_ shouldShow: Bool, receiptId: String?) -> PXPaymentCongrats {
+        self.shouldShowReceipt = shouldShow
+        self.receiptId = receiptId
+        return self
+    }
+    
+    /**
+     Top button configuration.
+     - parameter label: button display text
+     - parameter action: a colsure to excecute
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func setMainAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
+        self.mainAction = PXAction(label: label, action: action)
+        return self
+    }
+    
+    /**
+     Bottom button configuration.
+     - parameter label: button display text
+     - parameter action: a colsure to excecute
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func setSecondaryAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
+        self.secondaryAction = PXAction(label: label, action: action)
+        return self
+    }
+
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func addPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
+        let action = PXRemoteAction(label: actionLabel, target: actionTarget)
+        self.pointsData = PXPoints(progress: PXPointsProgress(percentage: percentage, levelColor: levelColor, levelNumber: levelNumber), title: title, action: action)
+        return self
+    }
+
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func addDiscounts() -> PXPaymentCongrats {
+        self.discounts = PXDiscounts(title: "Descuentos por tu nivel", subtitle: "", discountsAction: PXRemoteAction(label: "Ver todos los descuentos", target: "mercadopago://discount_center_payers/list#from=/px/congrats"), downloadAction: PXDownloadAction(title: "Exclusivo con la app de Mercado Libre", action: PXRemoteAction(label: "Descargar", target: "https://852u.adj.st/discount_center_payers/list?adjust_t=ufj9wxn&adjust_deeplink=mercadopago%3A%2F%2Fdiscount_center_payers%2Flist&adjust_label=px-ml")), items: [PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/766266-MLA32568902676_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018483&user_level=1&mcc=1091102&distance=1072139&coupon_used=false&status=FULL&store_id=13040071&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F766266-MLA32568902676_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22Nutty%20Bavarian%22%7D%7D%5D#from=/px/congrats", campaingId: "1018483"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/826105-MLA32568902631_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018457&user_level=1&mcc=4771701&distance=543968&coupon_used=false&status=FULL&store_id=30316240&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F826105-MLA32568902631_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2015%22%2C%22subtitle%22%3A%22Drogasil%22%7D%7D%5D#from=/px/congrats", campaingId: "1018457"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/761600-MLA32568902662_102019-O.jpg", title: "Hasta", subtitle: "10 % OFF", target:  "mercadopago://discount_center_payers/detail?campaign_id=1018475&user_level=1&mcc=5611201&distance=654418&coupon_used=false&status=FULL&store_id=30108872&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F761600-MLA32568902662_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22McDonald%5Cu0027s%22%7D%7D%5D#from=/px/congrats", campaingId:"1018475") ], touchpoint: nil)
+        return self
+    }
+
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func addCrossSelling() -> PXPaymentCongrats {
+        self.crossSelling = [PXCrossSellingItem(title: "Gane 200 pesos por sus pagos diarios", icon: "https://mobile.mercadolibre.com/remote_resources/image/merchengine_mgm_icon_ml?density=xxhdpi&locale=es_AR", contentId: "cross_selling_mgm_ml", action: PXRemoteAction(label: "Invita a más amigos a usar la aplicación", target: "meli://invite/wallet"))]
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+    */
+    #warning("Check if backgroundColor, textColor, weight should be customized from the outside")
+    @discardableResult
+    public func addExpenseSplit(_ message: String) -> PXPaymentCongrats {
+        self.expenseSplit = PXExpenseSplit(title: PXText(message: message, backgroundColor: nil, textColor: nil, weight: nil), action: PXRemoteAction(label: "TBD", target: nil), imageUrl: "someImage")
+        return self
+    }
+
+    /**
+     Custom views to be displayed.
+     - Parameters:
+        - important: some `UIView`
+        - top: some `UIView`
+        - bottom: some `UIView`
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func addViews(important: UIView?, top: UIView?, bottom: UIView?) -> PXPaymentCongrats {
+        self.importantView = important
+        self.topView = top
+        self.bottomView = bottom
+        return self
+    }
+    
+    /**
+     For a failure congrats, this is the message displayed.
+     - parameter message: some error message
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func addErrorMessage(_ message: String) {
+        self.errorMessage = message
+    }
+
+    /**
+     Shows the congrats' view.
+     - parameter navController: a `UINavigationController`
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func start(using navController: UINavigationController) -> PXPaymentCongrats {
+        self.navigationController = navController
+        let vc = PXNewResultViewController(viewModel: self, callback:{_,_ in })
+        self.navigationController?.pushViewController(vc, animated: true)
+        return self
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
@@ -74,7 +74,7 @@ public final class PXPaymentCongrats: NSObject {
     private(set) var trackingPath: String = "" //TODO
     private(set) var trackingValues: [String : Any] = [:] //TODO
     // This field is ment to be used only by Checkout
-    private(set) var flowBehaviourResult: PXResultKey!
+    private(set) var flowBehaviourResult: PXResultKey?
     
     // Error
     private(set) var errorBodyView: UIView?
@@ -295,11 +295,48 @@ extension PXPaymentCongrats {
         return self
     }
     
+    
+    /**
+     - ToDo: Fill this
+     */
+    @discardableResult
+    public func paymentHasBeenRejectedWithRemedy(_ hasRemedies: Bool) -> PXPaymentCongrats {
+        self.hasPaymentBeenRejectedWithRemedy = hasRemedies
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+     */
+    @discardableResult
+    public func withRemedyButtonAction(_ action: @escaping (String?) -> ()) -> PXPaymentCongrats {
+        self.remedyButtonAction = action
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+     */
+    @discardableResult
+    public func withCreditsExpectationView(_ view: UIView) -> PXPaymentCongrats {
+        self.creditsExpectationView = view
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+     */
+    @discardableResult
+    internal func withFlowBehaviorResult(_ result: PXResultKey) -> PXPaymentCongrats {
+        self.flowBehaviourResult = result
+        return self
+    }
+    
     /**
      An error view to be displayed when a failure congrats is shown
      - parameter shouldShow: a `Bool` indicating if
      - returns: tihs builder `PXPaymentCongrats`
-    */
+     */
     @discardableResult
     public func withErrorBodyView(_ view: UIView) -> PXPaymentCongrats {
         self.errorBodyView = view

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
@@ -127,7 +127,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func headerImage(_ image: UIImage?, orURL url: String?) -> PXPaymentCongrats {
+    public func setHeaderImage(_ image: UIImage?, orURL url: String?) -> PXPaymentCongrats {
         self.headerImage = image
         self.headerURL = url
         return self
@@ -174,7 +174,7 @@ extension PXPaymentCongrats {
      - ToDo: Fill this
     */
     @discardableResult
-    public func addPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
+    public func setPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
         let action = PXRemoteAction(label: actionLabel, target: actionTarget)
         self.pointsData = PXPoints(progress: PXPointsProgress(percentage: percentage, levelColor: levelColor, levelNumber: levelNumber), title: title, action: action)
         return self
@@ -184,7 +184,7 @@ extension PXPaymentCongrats {
      - ToDo: Fill this
     */
     @discardableResult
-    public func addDiscounts() -> PXPaymentCongrats {
+    public func setDiscountsData() -> PXPaymentCongrats {
         self.discounts = PXDiscounts(title: "Descuentos por tu nivel", subtitle: "", discountsAction: PXRemoteAction(label: "Ver todos los descuentos", target: "mercadopago://discount_center_payers/list#from=/px/congrats"), downloadAction: PXDownloadAction(title: "Exclusivo con la app de Mercado Libre", action: PXRemoteAction(label: "Descargar", target: "https://852u.adj.st/discount_center_payers/list?adjust_t=ufj9wxn&adjust_deeplink=mercadopago%3A%2F%2Fdiscount_center_payers%2Flist&adjust_label=px-ml")), items: [PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/766266-MLA32568902676_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018483&user_level=1&mcc=1091102&distance=1072139&coupon_used=false&status=FULL&store_id=13040071&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F766266-MLA32568902676_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22Nutty%20Bavarian%22%7D%7D%5D#from=/px/congrats", campaingId: "1018483"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/826105-MLA32568902631_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018457&user_level=1&mcc=4771701&distance=543968&coupon_used=false&status=FULL&store_id=30316240&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F826105-MLA32568902631_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2015%22%2C%22subtitle%22%3A%22Drogasil%22%7D%7D%5D#from=/px/congrats", campaingId: "1018457"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/761600-MLA32568902662_102019-O.jpg", title: "Hasta", subtitle: "10 % OFF", target:  "mercadopago://discount_center_payers/detail?campaign_id=1018475&user_level=1&mcc=5611201&distance=654418&coupon_used=false&status=FULL&store_id=30108872&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F761600-MLA32568902662_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22McDonald%5Cu0027s%22%7D%7D%5D#from=/px/congrats", campaingId:"1018475") ], touchpoint: nil)
         return self
     }
@@ -193,7 +193,7 @@ extension PXPaymentCongrats {
      - ToDo: Fill this
     */
     @discardableResult
-    public func addCrossSelling() -> PXPaymentCongrats {
+    public func setCrossSellingData() -> PXPaymentCongrats {
         self.crossSelling = [PXCrossSellingItem(title: "Gane 200 pesos por sus pagos diarios", icon: "https://mobile.mercadolibre.com/remote_resources/image/merchengine_mgm_icon_ml?density=xxhdpi&locale=es_AR", contentId: "cross_selling_mgm_ml", action: PXRemoteAction(label: "Invita a más amigos a usar la aplicación", target: "meli://invite/wallet"))]
         return self
     }
@@ -203,7 +203,7 @@ extension PXPaymentCongrats {
     */
     #warning("Check if backgroundColor, textColor, weight should be customized from the outside")
     @discardableResult
-    public func addExpenseSplit(_ message: String) -> PXPaymentCongrats {
+    public func setExpenseSplit(_ message: String) -> PXPaymentCongrats {
         self.expenseSplit = PXExpenseSplit(title: PXText(message: message, backgroundColor: nil, textColor: nil, weight: nil), action: PXRemoteAction(label: "TBD", target: nil), imageUrl: "someImage")
         return self
     }
@@ -226,7 +226,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func addViews(important: UIView?, top: UIView?, bottom: UIView?) -> PXPaymentCongrats {
+    public func setCustomViews(important: UIView?, top: UIView?, bottom: UIView?) -> PXPaymentCongrats {
         self.importantView = important
         self.topView = top
         self.bottomView = bottom
@@ -239,7 +239,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func addErrorMessage(_ message: String) -> PXPaymentCongrats {
+    public func setErrorMessage(_ message: String) -> PXPaymentCongrats {
         self.errorMessage = message
         return self
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
@@ -1,0 +1,386 @@
+//
+//  File.swift
+//  MercadoPagoSDK
+//
+//  Created by Franco Risma on 23/07/2020.
+//
+
+import Foundation
+
+/**
+This class holds all the information a congrats' view needs to consume (specified at `PXNewResultViewModelInterface`).
+This also acts as an entry point for congrats withouth having to go through the entire checkout flow.
+*/
+@objcMembers
+public final class PXPaymentCongrats: NSObject {
+    
+    // Header
+    private var status: PXBusinessResultStatus = .REJECTED
+    private var headerTitle: String = ""
+    private var headerImage: UIImage?
+    private var headerURL: String?
+    
+    // Receipt
+    private var shouldShowReceipt: Bool = false
+    private var receiptId: String?
+    
+    // Action Buttons
+    private var mainAction: PXAction?
+    private var secondaryAction: PXAction?
+    #warning("TBD")
+    private var closeCallback: (PaymentResult.CongratsState, String?) -> () = { state, text in
+        print("congrats state \(state) and text \(text)")
+    }
+    
+    /* --- Ponints & Discounts --- */
+    // Points
+    private var pointsData: PXPoints?
+    
+    // Discounts
+    private var discounts: PXDiscounts?
+    
+    // CrossSelling
+    private var crossSelling: [PXCrossSellingItem]?
+    
+    // Expense split
+    private var expenseSplit: PXExpenseSplit?
+    /* --- Ponints & Discounts --- */
+    
+    // CustomViews
+    private var topView: UIView?
+    private var importantView: UIView?
+    private var bottomView: UIView?
+    
+    private var errorMessage: String?
+    
+    private var navigationController: UINavigationController?
+    
+    // MARK: API
+    
+    public override init() {
+        super.init()
+    }
+    
+    public func setStatus(_ status: PXBusinessResultStatus) -> PXPaymentCongrats {
+        self.status = status
+        return self
+    }
+    
+    public func setHeaderTitle(_ title: String) -> PXPaymentCongrats {
+        self.headerTitle = title
+        return self
+    }
+    
+    public func headerImage(_ image: UIImage?, orURL url: String?) -> PXPaymentCongrats {
+        self.headerImage = image
+        self.headerURL = url
+        return self
+    }
+
+    public func shouldShowReceipt(_ shouldShow: Bool, receiptId: String?) -> PXPaymentCongrats {
+        self.shouldShowReceipt = shouldShow
+        self.receiptId = receiptId
+        return self
+    }
+    
+    public func setMainAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
+        self.mainAction = PXAction(label: label, action: action)
+        return self
+    }
+    
+    public func setSecondaryAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
+        self.secondaryAction = PXAction(label: label, action: action)
+        return self
+    }
+
+    public func addPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
+        let action = PXRemoteAction(label: actionLabel, target: actionTarget)
+        self.pointsData = PXPoints(progress: PXPointsProgress(percentage: percentage, levelColor: levelColor, levelNumber: levelNumber), title: title, action: action)
+        return self
+    }
+
+    public func addDiscounts() -> PXPaymentCongrats {
+        self.discounts = PXDiscounts(title: "Descuentos por tu nivel", subtitle: "", discountsAction: PXRemoteAction(label: "Ver todos los descuentos", target: "mercadopago://discount_center_payers/list#from=/px/congrats"), downloadAction: PXDownloadAction(title: "Exclusivo con la app de Mercado Libre", action: PXRemoteAction(label: "Descargar", target: "https://852u.adj.st/discount_center_payers/list?adjust_t=ufj9wxn&adjust_deeplink=mercadopago%3A%2F%2Fdiscount_center_payers%2Flist&adjust_label=px-ml")), items: [PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/766266-MLA32568902676_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018483&user_level=1&mcc=1091102&distance=1072139&coupon_used=false&status=FULL&store_id=13040071&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F766266-MLA32568902676_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22Nutty%20Bavarian%22%7D%7D%5D#from=/px/congrats", campaingId: "1018483"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/826105-MLA32568902631_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018457&user_level=1&mcc=4771701&distance=543968&coupon_used=false&status=FULL&store_id=30316240&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F826105-MLA32568902631_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2015%22%2C%22subtitle%22%3A%22Drogasil%22%7D%7D%5D#from=/px/congrats", campaingId: "1018457"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/761600-MLA32568902662_102019-O.jpg", title: "Hasta", subtitle: "10 % OFF", target:  "mercadopago://discount_center_payers/detail?campaign_id=1018475&user_level=1&mcc=5611201&distance=654418&coupon_used=false&status=FULL&store_id=30108872&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F761600-MLA32568902662_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22McDonald%5Cu0027s%22%7D%7D%5D#from=/px/congrats", campaingId:"1018475") ], touchpoint: nil)
+        return self
+    }
+
+    public func addCrossSelling() -> PXPaymentCongrats {
+        self.crossSelling = [PXCrossSellingItem(title: "Gane 200 pesos por sus pagos diarios", icon: "https://mobile.mercadolibre.com/remote_resources/image/merchengine_mgm_icon_ml?density=xxhdpi&locale=es_AR", contentId: "cross_selling_mgm_ml", action: PXRemoteAction(label: "Invita a más amigos a usar la aplicación", target: "meli://invite/wallet"))]
+        return self
+    }
+    
+    #warning("Check if backgroundColor, textColor, weight should be customized from the outside")
+    public func addExpenseSplit(_ message: String) -> PXPaymentCongrats {
+        self.expenseSplit = PXExpenseSplit(title: PXText(message: message, backgroundColor: nil, textColor: nil, weight: nil), action: PXRemoteAction(label: "TBD", target: nil), imageUrl: "someImage")
+        return self
+    }
+
+    public func addViews(important: UIView?, top: UIView?, bottom: UIView?) -> PXPaymentCongrats {
+        self.importantView = important
+        self.topView = top
+        self.bottomView = bottom
+        return self
+    }
+    
+    public func addErrorMessage(_ message: String) {
+        self.errorMessage = message
+    }
+
+    public func start(using navController: UINavigationController) -> PXPaymentCongrats {
+        self.navigationController = navController
+        let vc = PXNewResultViewController(viewModel: self, callback:{_,_ in })
+        self.navigationController?.pushViewController(vc, animated: true)
+        return self
+    }
+
+    // MARK: Private methods
+    
+    // Esto no debería hacerse
+    private func getErrorComponent() -> PXErrorComponent? {
+        guard let labelInstruction = errorMessage else {
+            return nil
+        }
+        
+        let title = PXResourceProvider.getTitleForErrorBody()
+        let props = PXErrorProps(title: title.toAttributedString(), message: labelInstruction.toAttributedString())
+        
+        return PXErrorComponent(props: props)
+    }
+}
+
+extension PXPaymentCongrats: PXNewResultViewModelInterface {
+    func getHeaderColor() -> UIColor {
+        return ResourceManager.shared.getResultColorWith(status: self.status.getDescription())
+    }
+    
+    func getHeaderTitle() -> String {
+        return headerTitle
+    }
+    
+    func getHeaderIcon() -> UIImage? {
+        return headerImage
+    }
+    
+    func getHeaderURLIcon() -> String? {
+        return headerURL
+    }
+    
+    func getHeaderBadgeImage() -> UIImage? {
+        return ResourceManager.shared.getBadgeImageWith(status: status.getDescription())
+    }
+    
+    func getHeaderCloseAction() -> (() -> Void)? {
+        let action = { [weak self] in
+            if let callback = self?.closeCallback {
+                callback(PaymentResult.CongratsState.EXIT, nil)
+            }
+        }
+        return action
+    }
+    
+    func mustShowReceipt() -> Bool {
+        return shouldShowReceipt
+    }
+    
+    func getReceiptId() -> String? {
+        return receiptId
+    }
+    
+    func getPoints() -> PXPoints? {
+        return pointsData
+    }
+    
+    func getPointsTapAction() -> ((String) -> Void)? {
+        let action: (String) -> Void = { (deepLink) in
+            //open deep link
+            PXDeepLinkManager.open(deepLink)
+            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapScorePath())
+        }
+        return action
+    }
+    
+    func getDiscounts() -> PXDiscounts? {
+        return discounts
+    }
+    
+    func getDiscountsTapAction() -> ((Int, String?, String?) -> Void)? {
+        let action: (Int, String?, String?) -> Void = { (index, deepLink, trackId) in
+            //open deep link
+            PXDeepLinkManager.open(deepLink)
+            PXCongratsTracking.trackTapDiscountItemEvent(index, trackId)
+        }
+        return action
+    }
+    
+    func didTapDiscount(index: Int, deepLink: String?, trackId: String?) {
+        PXDeepLinkManager.open(deepLink)
+        PXCongratsTracking.trackTapDiscountItemEvent(index, trackId)
+    }
+    
+    func getExpenseSplit() -> PXExpenseSplit? {
+        return self.expenseSplit
+    }
+    
+    func getExpenseSplitTapAction() -> (() -> Void)? {
+        let action: () -> Void = { [weak self] in
+            PXDeepLinkManager.open(self?.expenseSplit?.action.target)
+            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapDeeplinkPath(), properties: PXCongratsTracking.getDeeplinkProperties(type: "money_split", deeplink: self?.expenseSplit?.action.target ?? ""))
+        }
+        return action
+    }
+    
+    func getCrossSellingItems() -> [PXCrossSellingItem]? {
+        return crossSelling
+    }
+    
+    func getCrossSellingTapAction() -> ((String) -> Void)? {
+        let action: (String) -> Void = { (deepLink) in
+            //open deep link
+            PXDeepLinkManager.open(deepLink)
+            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapCrossSellingPath())
+        }
+        return action
+    }
+    
+    func getViewReceiptAction() -> PXRemoteAction? {
+        // TODO
+        //        return pointsAndDiscounts?.viewReceiptAction
+        return nil
+    }
+    
+    func getTopTextBox() -> PXText? {
+        // TODO
+        //        return pointsAndDiscounts?.topTextBox
+        return nil
+    }
+    
+    func getCustomOrder() -> Bool? {
+        // TODO
+        //        return pointsAndDiscounts?.customOrder
+        return nil
+    }
+    
+    func hasInstructions() -> Bool {
+        return false
+    }
+    
+    func getInstructionsView() -> UIView? {
+        return nil
+    }
+    
+    // Para que muestre el payment method, tenemos que devolver ademas paymentData
+    func shouldShowPaymentMethod() -> Bool {
+        #warning("logica especifica para comparar PXBusinessResultStatus con PXPaymentStatus")
+        let isApproved = status.getDescription().lowercased() == PXPaymentStatus.APPROVED.rawValue.lowercased()
+        return !hasInstructions() && isApproved
+    }
+    
+    func getPaymentData() -> PXPaymentData? {
+        // TODO
+        //        return paymentData
+        return nil
+    }
+    
+    func getAmountHelper() -> PXAmountHelper? {
+        // TODO
+        //        return amountHelper
+        return nil
+    }
+    
+    func getSplitPaymentData() -> PXPaymentData? {
+        // TODO
+        //        return amountHelper.splitAccountMoney
+        return nil
+    }
+    
+    func getSplitAmountHelper() -> PXAmountHelper? {
+        // TODO
+        //        return amountHelper
+        return nil
+    }
+    
+    func shouldShowErrorBody() -> Bool {
+        return getErrorComponent() != nil
+    }
+    
+    func getErrorBodyView() -> UIView? {
+        if let errorComponent = getErrorComponent() {
+            return errorComponent.render()
+        }
+        return nil
+    }
+    
+    func getRemedyView(animatedButtonDelegate: PXAnimatedButtonDelegate?, remedyViewProtocol: PXRemedyViewProtocol?) -> UIView? {
+        return nil
+    }
+    
+    func getRemedyButtonAction() -> ((String?) -> Void)? {
+        // TODO
+        return nil
+    }
+    
+    func isPaymentResultRejectedWithRemedy() -> Bool {
+        return false
+    }
+    
+    func getFooterMainAction() -> PXAction? {
+        return mainAction
+    }
+    
+    func getFooterSecondaryAction() -> PXAction? {
+        //        let linkAction = secondaryAction != nil ? businessResult.getSecondaryAction() : PXCloseLinkAction()
+        //        return linkAction
+        // TODO
+        return secondaryAction
+    }
+    
+    func getImportantView() -> UIView? {
+        return importantView
+    }
+    
+    func getCreditsExpectationView() -> UIView? {
+        // TODO
+        //        if let resultInfo = amountHelper.getPaymentData().getPaymentMethod()?.creditsDisplayInfo?.resultInfo,
+        //            let title = resultInfo.title,
+        //            let subtitle = resultInfo.subtitle,
+        //            businessResult.isApproved() {
+        //            return PXCreditsExpectationView(title: title, subtitle: subtitle)
+        //        }
+        return nil
+    }
+    
+    func getTopCustomView() -> UIView? {
+        return topView
+    }
+    
+    func getBottomCustomView() -> UIView? {
+        return bottomView
+    }
+    
+    func setCallback(callback: @escaping (PaymentResult.CongratsState, String?) -> Void) {
+        // TODO
+    }
+    
+    func getTrackingProperties() -> [String : Any] {
+        // TODO
+        return ["Franco": "Franco"]
+    }
+    
+    func getTrackingPath() -> String {
+        // TODO
+        return "trackingPath"
+    }
+    
+    func getFlowBehaviourResult() -> PXResultKey {
+        switch status {
+            case .APPROVED:
+                return .SUCCESS
+            case .REJECTED:
+                return .FAILURE
+            case .PENDING:
+                return .PENDING
+            case .IN_PROGRESS:
+                return .PENDING
+        }
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
@@ -29,9 +29,9 @@ public final class PXPaymentCongrats: NSObject {
     private(set) var shouldShowReceipt: Bool = false
     private(set) var receiptId: String?
     
-    /* --- Ponints & Discounts --- */
+    /* --- Points & Discounts --- */
     // Points
-    private(set) var pointsData: PXPoints?
+    private(set) var points: PXPoints?
     
     // Discounts
     private(set) var discounts: PXDiscounts?
@@ -43,7 +43,6 @@ public final class PXPaymentCongrats: NSObject {
     private(set) var crossSelling: [PXCrossSellingItem]?
     
     // View Receipt action
-    #warning("Investigate what is this used for")
     private(set) var viewReceiptAction: PXRemoteAction?
     
     private(set) var topTextBox: PXText?
@@ -177,7 +176,7 @@ extension PXPaymentCongrats {
     @discardableResult
     public func withPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
         let action = PXRemoteAction(label: actionLabel, target: actionTarget)
-        self.pointsData = PXPoints(progress: PXPointsProgress(percentage: percentage, levelColor: levelColor, levelNumber: levelNumber), title: title, action: action)
+        self.points = PXPoints(progress: PXPointsProgress(percentage: percentage, levelColor: levelColor, levelNumber: levelNumber), title: title, action: action)
         return self
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
@@ -13,22 +13,21 @@ This also acts as an entry point for congrats withouth having to go through the 
 */
 @objcMembers
 public final class PXPaymentCongrats: NSObject {
+    
     // Header
     private var status: PXBusinessResultStatus = .REJECTED
+    // This field is ment to be used only by Checkout
+    private var headerColor: UIColor?
     private var headerTitle: String = ""
     private var headerImage: UIImage?
     private var headerURL: String?
+    // This field is ment to be used only by Checkout
     private var headerBadgeImage: UIImage?
+    private var headerCloseAction: (() -> ())?
     
     // Receipt
     private var shouldShowReceipt: Bool = false
     private var receiptId: String?
-    
-    // Action Buttons
-    private var mainAction: PXAction?
-    private var secondaryAction: PXAction?
-    #warning("TBD - This action is triggered when tap on the X button at the top left")
-    private var closeAction: (() -> ())?
     
     /* --- Ponints & Discounts --- */
     // Points
@@ -37,11 +36,11 @@ public final class PXPaymentCongrats: NSObject {
     // Discounts
     private var discounts: PXDiscounts?
     
-    // CrossSelling
-    private var crossSelling: [PXCrossSellingItem]?
-    
     // Expense split
     private var expenseSplit: PXExpenseSplit?
+    
+    // CrossSelling
+    private var crossSelling: [PXCrossSellingItem]?
     
     // View Receipt action
     #warning("Investigate what is this used for")
@@ -52,26 +51,33 @@ public final class PXPaymentCongrats: NSObject {
     private var hasCustomOrder: Bool?
     /* --- Ponints & Discounts --- */
     
+    // Instructions
+    private var shouldShowInstructions: Bool = false
+    private var instructionsView: UIView?
+    
+    // Footer Buttons
+    private var mainAction: PXAction?
+    private var secondaryAction: PXAction?
+    
     // CustomViews
     private var topView: UIView?
     private var importantView: UIView?
     private var bottomView: UIView?
     
-    private var errorMessage: String?
-    
     // Remedies
     private var hasPaymentBeenRejectedWithRemedy: Bool = false
     private var remedyButtonAction: ((String?) -> ())?
-    
-    // Instructions
-    private var shouldShowInstructions: Bool = false
-    private var instructionsView: UIView?
     
     private var creditsExpectationView: UIView?
     
     // Tracking
     private var trackingPath: String = "" //TODO
     private var trackingValues: [String : Any] = [:] //TODO
+    // This field is ment to be used only by Checkout
+    private var flowBehaviourResult: PXResultKey!
+    
+    // Error
+    private var errorBodyView: UIView?
     
     private var navigationController: UINavigationController?
     
@@ -79,20 +85,6 @@ public final class PXPaymentCongrats: NSObject {
     
     public override init() {
         super.init()
-    }
-
-    // MARK: Private methods
-    
-    // Esto no debería hacerse
-    private func getErrorComponent() -> PXErrorComponent? {
-        guard let labelInstruction = errorMessage else {
-            return nil
-        }
-        
-        let title = PXResourceProvider.getTitleForErrorBody()
-        let props = PXErrorProps(title: title.toAttributedString(), message: labelInstruction.toAttributedString())
-        
-        return PXErrorComponent(props: props)
     }
 }
 
@@ -106,6 +98,17 @@ extension PXPaymentCongrats {
     @discardableResult
     public func setStatus(_ status: PXBusinessResultStatus) -> PXPaymentCongrats {
         self.status = status
+        return self
+    }
+    
+    /**
+     Any color for showing in the congrats' header. This should be used ONLY internally
+     - parameter color: a color
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    internal func setHeaderColor(_ color: UIColor) -> PXPaymentCongrats {
+        self.headerColor = color
         return self
     }
     
@@ -132,6 +135,28 @@ extension PXPaymentCongrats {
         self.headerURL = url
         return self
     }
+    
+    /**
+     Collector badge image shown in congrats' header. This should be used ONLY internally
+     - parameter image: an image in `UIImage` format
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    internal func setHeaderBadgeImage(_ image: UIImage) -> PXPaymentCongrats {
+        self.headerBadgeImage = image
+        return self
+    }
+    
+    /**
+     Top left close button configuration.
+     - parameter action: a colsure to excecute
+     - returns: tihs builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func setHeaderCloseAction(_ action: @escaping () -> ()) -> PXPaymentCongrats {
+        self.headerCloseAction = action
+        return self
+    }
 
     /**
      Defines if the receipt view should be shown, in affirmative case, the receiptId must be supplied.
@@ -146,6 +171,90 @@ extension PXPaymentCongrats {
         return self
     }
     
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func setPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
+        let action = PXRemoteAction(label: actionLabel, target: actionTarget)
+        self.pointsData = PXPoints(progress: PXPointsProgress(percentage: percentage, levelColor: levelColor, levelNumber: levelNumber), title: title, action: action)
+        return self
+    }
+
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func setDiscountsData() -> PXPaymentCongrats {
+        self.discounts = PXDiscounts(title: "Descuentos por tu nivel", subtitle: "", discountsAction: PXRemoteAction(label: "Ver todos los descuentos", target: "mercadopago://discount_center_payers/list#from=/px/congrats"), downloadAction: PXDownloadAction(title: "Exclusivo con la app de Mercado Libre", action: PXRemoteAction(label: "Descargar", target: "https://852u.adj.st/discount_center_payers/list?adjust_t=ufj9wxn&adjust_deeplink=mercadopago%3A%2F%2Fdiscount_center_payers%2Flist&adjust_label=px-ml")), items: [PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/766266-MLA32568902676_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018483&user_level=1&mcc=1091102&distance=1072139&coupon_used=false&status=FULL&store_id=13040071&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F766266-MLA32568902676_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22Nutty%20Bavarian%22%7D%7D%5D#from=/px/congrats", campaingId: "1018483"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/826105-MLA32568902631_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018457&user_level=1&mcc=4771701&distance=543968&coupon_used=false&status=FULL&store_id=30316240&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F826105-MLA32568902631_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2015%22%2C%22subtitle%22%3A%22Drogasil%22%7D%7D%5D#from=/px/congrats", campaingId: "1018457"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/761600-MLA32568902662_102019-O.jpg", title: "Hasta", subtitle: "10 % OFF", target:  "mercadopago://discount_center_payers/detail?campaign_id=1018475&user_level=1&mcc=5611201&distance=654418&coupon_used=false&status=FULL&store_id=30108872&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F761600-MLA32568902662_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22McDonald%5Cu0027s%22%7D%7D%5D#from=/px/congrats", campaingId:"1018475") ], touchpoint: nil)
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+    */
+    #warning("Check if backgroundColor, textColor, weight should be customized from the outside")
+    @discardableResult
+    public func setExpenseSplit(_ message: String?, backgroundColor: String?, textColor: String?, weight: String?, actionLabel: String, actionTarget: String?, imageURL: String) -> PXPaymentCongrats {
+        self.expenseSplit = PXExpenseSplit(title: PXText(message: message, backgroundColor: nil, textColor: nil, weight: weight), action: PXRemoteAction(label: actionLabel, target: actionTarget), imageUrl: imageURL)
+        return self
+    }
+
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func setCrossSellingData() -> PXPaymentCongrats {
+        self.crossSelling = [PXCrossSellingItem(title: "Gane 200 pesos por sus pagos diarios", icon: "https://mobile.mercadolibre.com/remote_resources/image/merchengine_mgm_icon_ml?density=xxhdpi&locale=es_AR", contentId: "cross_selling_mgm_ml", action: PXRemoteAction(label: "Invita a más amigos a usar la aplicación", target: "meli://invite/wallet"))]
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func setViewReceiptAction(label: String, target: String) -> PXPaymentCongrats {
+        self.viewReceiptAction = PXRemoteAction(label: label, target: target)
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func setTopTextBox(message: String?, backgroundColor: String?, textColor: String?, weight: String?) -> PXPaymentCongrats {
+        self.topTextBox = PXText(message: message, backgroundColor: backgroundColor, textColor: textColor, weight: weight)
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func shouldHaveCustomOrder(_ customOrder: Bool) -> PXPaymentCongrats {
+        self.hasCustomOrder = customOrder
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func shouldShowInstructionView(_ shouldShow: Bool) -> PXPaymentCongrats {
+        self.shouldShowInstructions = shouldShow
+        return self
+    }
+    
+    /**
+     - ToDo: Fill this
+    */
+    @discardableResult
+    public func setInstructionView(_ view: UIView) -> PXPaymentCongrats {
+        self.instructionsView = view
+        return self
+    }
+    
+        
     /**
      Top button configuration.
      - parameter label: button display text
@@ -171,53 +280,6 @@ extension PXPaymentCongrats {
     }
 
     /**
-     - ToDo: Fill this
-    */
-    @discardableResult
-    public func setPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
-        let action = PXRemoteAction(label: actionLabel, target: actionTarget)
-        self.pointsData = PXPoints(progress: PXPointsProgress(percentage: percentage, levelColor: levelColor, levelNumber: levelNumber), title: title, action: action)
-        return self
-    }
-
-    /**
-     - ToDo: Fill this
-    */
-    @discardableResult
-    public func setDiscountsData() -> PXPaymentCongrats {
-        self.discounts = PXDiscounts(title: "Descuentos por tu nivel", subtitle: "", discountsAction: PXRemoteAction(label: "Ver todos los descuentos", target: "mercadopago://discount_center_payers/list#from=/px/congrats"), downloadAction: PXDownloadAction(title: "Exclusivo con la app de Mercado Libre", action: PXRemoteAction(label: "Descargar", target: "https://852u.adj.st/discount_center_payers/list?adjust_t=ufj9wxn&adjust_deeplink=mercadopago%3A%2F%2Fdiscount_center_payers%2Flist&adjust_label=px-ml")), items: [PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/766266-MLA32568902676_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018483&user_level=1&mcc=1091102&distance=1072139&coupon_used=false&status=FULL&store_id=13040071&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F766266-MLA32568902676_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22Nutty%20Bavarian%22%7D%7D%5D#from=/px/congrats", campaingId: "1018483"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/826105-MLA32568902631_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018457&user_level=1&mcc=4771701&distance=543968&coupon_used=false&status=FULL&store_id=30316240&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F826105-MLA32568902631_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2015%22%2C%22subtitle%22%3A%22Drogasil%22%7D%7D%5D#from=/px/congrats", campaingId: "1018457"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/761600-MLA32568902662_102019-O.jpg", title: "Hasta", subtitle: "10 % OFF", target:  "mercadopago://discount_center_payers/detail?campaign_id=1018475&user_level=1&mcc=5611201&distance=654418&coupon_used=false&status=FULL&store_id=30108872&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F761600-MLA32568902662_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22McDonald%5Cu0027s%22%7D%7D%5D#from=/px/congrats", campaingId:"1018475") ], touchpoint: nil)
-        return self
-    }
-
-    /**
-     - ToDo: Fill this
-    */
-    @discardableResult
-    public func setCrossSellingData() -> PXPaymentCongrats {
-        self.crossSelling = [PXCrossSellingItem(title: "Gane 200 pesos por sus pagos diarios", icon: "https://mobile.mercadolibre.com/remote_resources/image/merchengine_mgm_icon_ml?density=xxhdpi&locale=es_AR", contentId: "cross_selling_mgm_ml", action: PXRemoteAction(label: "Invita a más amigos a usar la aplicación", target: "meli://invite/wallet"))]
-        return self
-    }
-    
-    /**
-     - ToDo: Fill this
-    */
-    #warning("Check if backgroundColor, textColor, weight should be customized from the outside")
-    @discardableResult
-    public func setExpenseSplit(_ message: String) -> PXPaymentCongrats {
-        self.expenseSplit = PXExpenseSplit(title: PXText(message: message, backgroundColor: nil, textColor: nil, weight: nil), action: PXRemoteAction(label: "TBD", target: nil), imageUrl: "someImage")
-        return self
-    }
-    
-    /**
-     - ToDo: Fill this
-    */
-    @discardableResult
-    public func setViewReceiptAction(label: String, target: String) -> PXPaymentCongrats {
-        self.viewReceiptAction = PXRemoteAction(label: label, target: target)
-        return self
-    }
-
-    /**
      Custom views to be displayed.
      - Parameters:
         - important: some `UIView`
@@ -234,16 +296,16 @@ extension PXPaymentCongrats {
     }
     
     /**
-     For a failure congrats, this is the message displayed.
-     - parameter message: some error message
+     An error view to be displayed when a failure congrats is shown
+     - parameter shouldShow: a `Bool` indicating if
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func setErrorMessage(_ message: String) -> PXPaymentCongrats {
-        self.errorMessage = message
+    public func setErrorBodyView(_ view: UIView) -> PXPaymentCongrats {
+        self.errorBodyView = view
         return self
     }
-
+    
     /**
      Shows the congrats' view.
      - parameter navController: a `UINavigationController`
@@ -263,8 +325,13 @@ extension PXPaymentCongrats {
  as a ViewModel for `PXNewResultViewController`
  */
 extension PXPaymentCongrats: PXNewResultViewModelInterface {
+    // HEADER
+    #warning("PXResultViewModel also sends a status description to calculate the congrats color, a solution could be to expose only to the checkout a headerColor, and let PXBusinessResult and PXResultViewModel to set it. While external integrators should not care about header color because it should be calculated by relying in status. Validate this solution")
     func getHeaderColor() -> UIColor {
-        return ResourceManager.shared.getResultColorWith(status: self.status.getDescription())
+        guard let color = headerColor else {
+            return ResourceManager.shared.getResultColorWith(status: self.status.getDescription())
+        }
+        return color
     }
     
     func getHeaderTitle() -> String {
@@ -280,14 +347,17 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
     }
     
     func getHeaderBadgeImage() -> UIImage? {
-        return headerBadgeImage
+        guard let image = headerBadgeImage else {
+            return ResourceManager.shared.getBadgeImageWith(status: self.status.getDescription())
+        }
+        return image
     }
     
-    #warning("Chequear implementacion por no es la misma entre PXResultViewModel y PXBusinessResultViewModel")
     func getHeaderCloseAction() -> (() -> Void)? {
-        return closeAction
+        return headerCloseAction
     }
     
+    //RECEIPT
     func mustShowReceipt() -> Bool {
         return shouldShowReceipt
     }
@@ -296,10 +366,13 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return receiptId
     }
     
+    //POINTS AND DISCOUNTS
+    ///POINTS
     func getPoints() -> PXPoints? {
         return pointsData
     }
     
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
     func getPointsTapAction() -> ((String) -> Void)? {
         let action: (String) -> Void = { (deepLink) in
             //open deep link
@@ -309,10 +382,12 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return action
     }
     
+    ///DISCOUNTS
     func getDiscounts() -> PXDiscounts? {
         return discounts
     }
     
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
     func getDiscountsTapAction() -> ((Int, String?, String?) -> Void)? {
         let action: (Int, String?, String?) -> Void = { (index, deepLink, trackId) in
             //open deep link
@@ -322,15 +397,18 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return action
     }
     
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
     func didTapDiscount(index: Int, deepLink: String?, trackId: String?) {
         PXDeepLinkManager.open(deepLink)
         PXCongratsTracking.trackTapDiscountItemEvent(index, trackId)
     }
     
+    ///EXPENSE SPLIT VIEW
     func getExpenseSplit() -> PXExpenseSplit? {
         return self.expenseSplit
     }
     
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
     func getExpenseSplitTapAction() -> (() -> Void)? {
         let action: () -> Void = { [weak self] in
             PXDeepLinkManager.open(self?.expenseSplit?.action.target)
@@ -343,6 +421,8 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return crossSelling
     }
     
+    ///CROSS SELLING
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
     func getCrossSellingTapAction() -> ((String) -> Void)? {
         let action: (String) -> Void = { (deepLink) in
             //open deep link
@@ -352,18 +432,22 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return action
     }
     
+    ////VIEW RECEIPT ACTION
     func getViewReceiptAction() -> PXRemoteAction? {
         return viewReceiptAction
     }
     
+    ////TOP TEXT BOX
     func getTopTextBox() -> PXText? {
         return topTextBox
     }
     
+    ////CUSTOM ORDER
     func getCustomOrder() -> Bool? {
         return hasCustomOrder
     }
     
+    //INSTRUCTIONS
     func hasInstructions() -> Bool {
         return shouldShowInstructions
     }
@@ -372,9 +456,10 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return instructionsView
     }
     
-    // Para que muestre el payment method, tenemos que devolver ademas paymentData
+    // PAYMENT METHOD
+    // TODO Para que muestre el payment method, tenemos que devolver ademas paymentData
+    #warning("logica especifica para comparar PXBusinessResultStatus con PXPaymentStatus")
     func shouldShowPaymentMethod() -> Bool {
-        #warning("logica especifica para comparar PXBusinessResultStatus con PXPaymentStatus")
         // TODO checkear comparación de este status (BusinessStatus) pero puede ser que venga por PXResultViewModel que tiene otra logica
         let isApproved = status.getDescription().lowercased() == PXPaymentStatus.APPROVED.rawValue.lowercased()
         return !hasInstructions() && isApproved
@@ -394,6 +479,7 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return nil
     }
     
+    // SPLIT PAYMENT METHOD
     #warning("Desacoplar payment data del VC de Congrats")
     func getSplitPaymentData() -> PXPaymentData? {
         // TODO
@@ -408,17 +494,16 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return nil
     }
     
+    // REJECTED BODY
     func shouldShowErrorBody() -> Bool {
-        return getErrorComponent() != nil
+        return errorBodyView != nil
     }
     
     func getErrorBodyView() -> UIView? {
-        if let errorComponent = getErrorComponent() {
-            return errorComponent.render()
-        }
-        return nil
+        return errorBodyView
     }
     
+    // REMEDY
     #warning("Chequear como resolver esto donde se le pasa parametros a esta funcion para que ejecute una accion en particular. Tener en cuenta que PXBusinessResult y PXResult tienen implementaciones distintas")
     func getRemedyView(animatedButtonDelegate: PXAnimatedButtonDelegate?, remedyViewProtocol: PXRemedyViewProtocol?) -> UIView? {
         // TODO
@@ -433,6 +518,7 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return self.hasPaymentBeenRejectedWithRemedy
     }
     
+    // FOOTER
     func getFooterMainAction() -> PXAction? {
         return mainAction
     }
@@ -441,6 +527,7 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return secondaryAction
     }
     
+    // CUSTOM VIEWS
     func getImportantView() -> UIView? {
         return importantView
     }
@@ -457,20 +544,24 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
         return bottomView
     }
     
+    //CALLBACKS & TRACKING
+    // TODO
     func setCallback(callback: @escaping (PaymentResult.CongratsState, String?) -> Void) {
-        // TODO
     }
     
+    // TODO double check how this is used
     func getTrackingProperties() -> [String : Any] {
         return trackingValues
     }
     
+    // TODO double check how this is used
     func getTrackingPath() -> String {
         return trackingPath
     }
     
     func getFlowBehaviourResult() -> PXResultKey {
-        switch status {
+        guard let result = flowBehaviourResult else {
+            switch status {
             case .APPROVED:
                 return .SUCCESS
             case .REJECTED:
@@ -479,6 +570,8 @@ extension PXPaymentCongrats: PXNewResultViewModelInterface {
                 return .PENDING
             case .IN_PROGRESS:
                 return .PENDING
+            }
         }
+        return result
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
@@ -350,7 +350,7 @@ extension PXPaymentCongrats {
     @discardableResult
     public func start(using navController: UINavigationController) -> PXPaymentCongrats {
         self.navigationController = navController
-        let viewModel = PXPaymentCongratsViewModel(paymentData: self)
+        let viewModel = PXPaymentCongratsViewModel(paymentCongrats: self)
         viewModel.launch()
         return self
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
@@ -15,71 +15,71 @@ This also acts as an entry point for congrats withouth having to go through the 
 public final class PXPaymentCongrats: NSObject {
     
     // Header
-    private var status: PXBusinessResultStatus = .REJECTED
+    private(set) var status: PXBusinessResultStatus = .REJECTED
     // This field is ment to be used only by Checkout
-    private var headerColor: UIColor?
-    private var headerTitle: String = ""
-    private var headerImage: UIImage?
-    private var headerURL: String?
+    private(set) var headerColor: UIColor?
+    private(set) var headerTitle: String = ""
+    private(set) var headerImage: UIImage?
+    private(set) var headerURL: String?
     // This field is ment to be used only by Checkout
-    private var headerBadgeImage: UIImage?
-    private var headerCloseAction: (() -> ())?
+    private(set) var headerBadgeImage: UIImage?
+    private(set) var headerCloseAction: (() -> ())?
     
     // Receipt
-    private var shouldShowReceipt: Bool = false
-    private var receiptId: String?
+    private(set) var shouldShowReceipt: Bool = false
+    private(set) var receiptId: String?
     
     /* --- Ponints & Discounts --- */
     // Points
-    private var pointsData: PXPoints?
+    private(set) var pointsData: PXPoints?
     
     // Discounts
-    private var discounts: PXDiscounts?
+    private(set) var discounts: PXDiscounts?
     
     // Expense split
-    private var expenseSplit: PXExpenseSplit?
+    private(set) var expenseSplit: PXExpenseSplit?
     
     // CrossSelling
-    private var crossSelling: [PXCrossSellingItem]?
+    private(set) var crossSelling: [PXCrossSellingItem]?
     
     // View Receipt action
     #warning("Investigate what is this used for")
-    private var viewReceiptAction: PXRemoteAction?
+    private(set) var viewReceiptAction: PXRemoteAction?
     
-    private var topTextBox: PXText?
+    private(set) var topTextBox: PXText?
     
-    private var hasCustomOrder: Bool?
+    private(set) var hasCustomOrder: Bool?
     /* --- Ponints & Discounts --- */
     
     // Instructions
-    private var shouldShowInstructions: Bool = false
-    private var instructionsView: UIView?
+    private(set) var shouldShowInstructions: Bool = false
+    private(set) var instructionsView: UIView?
     
     // Footer Buttons
-    private var mainAction: PXAction?
-    private var secondaryAction: PXAction?
+    private(set) var mainAction: PXAction?
+    private(set) var secondaryAction: PXAction?
     
     // CustomViews
-    private var topView: UIView?
-    private var importantView: UIView?
-    private var bottomView: UIView?
+    private(set) var topView: UIView?
+    private(set) var importantView: UIView?
+    private(set) var bottomView: UIView?
     
     // Remedies
-    private var hasPaymentBeenRejectedWithRemedy: Bool = false
-    private var remedyButtonAction: ((String?) -> ())?
+    private(set) var hasPaymentBeenRejectedWithRemedy: Bool = false
+    private(set) var remedyButtonAction: ((String?) -> ())?
     
-    private var creditsExpectationView: UIView?
+    private(set) var creditsExpectationView: UIView?
     
     // Tracking
-    private var trackingPath: String = "" //TODO
-    private var trackingValues: [String : Any] = [:] //TODO
+    private(set) var trackingPath: String = "" //TODO
+    private(set) var trackingValues: [String : Any] = [:] //TODO
     // This field is ment to be used only by Checkout
-    private var flowBehaviourResult: PXResultKey!
+    private(set) var flowBehaviourResult: PXResultKey!
     
     // Error
-    private var errorBodyView: UIView?
+    private(set) var errorBodyView: UIView?
     
-    private var navigationController: UINavigationController?
+    private(set) var navigationController: UINavigationController?
     
     // MARK: API
     
@@ -96,7 +96,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func setStatus(_ status: PXBusinessResultStatus) -> PXPaymentCongrats {
+    public func withStatus(_ status: PXBusinessResultStatus) -> PXPaymentCongrats {
         self.status = status
         return self
     }
@@ -107,7 +107,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    internal func setHeaderColor(_ color: UIColor) -> PXPaymentCongrats {
+    internal func withHeaderColor(_ color: UIColor) -> PXPaymentCongrats {
         self.headerColor = color
         return self
     }
@@ -118,7 +118,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func setHeaderTitle(_ title: String) -> PXPaymentCongrats {
+    public func withHeaderTitle(_ title: String) -> PXPaymentCongrats {
         self.headerTitle = title
         return self
     }
@@ -130,7 +130,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func setHeaderImage(_ image: UIImage?, orURL url: String?) -> PXPaymentCongrats {
+    public func withHeaderImage(_ image: UIImage?, orURL url: String?) -> PXPaymentCongrats {
         self.headerImage = image
         self.headerURL = url
         return self
@@ -142,7 +142,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    internal func setHeaderBadgeImage(_ image: UIImage) -> PXPaymentCongrats {
+    internal func withHeaderBadgeImage(_ image: UIImage) -> PXPaymentCongrats {
         self.headerBadgeImage = image
         return self
     }
@@ -153,7 +153,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func setHeaderCloseAction(_ action: @escaping () -> ()) -> PXPaymentCongrats {
+    public func withHeaderCloseAction(_ action: @escaping () -> ()) -> PXPaymentCongrats {
         self.headerCloseAction = action
         return self
     }
@@ -175,7 +175,7 @@ extension PXPaymentCongrats {
      - ToDo: Fill this
     */
     @discardableResult
-    public func setPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
+    public func withPointsData(percentage: Double, levelColor: String, levelNumber: Int, title: String, actionLabel: String, actionTarget: String) -> PXPaymentCongrats {
         let action = PXRemoteAction(label: actionLabel, target: actionTarget)
         self.pointsData = PXPoints(progress: PXPointsProgress(percentage: percentage, levelColor: levelColor, levelNumber: levelNumber), title: title, action: action)
         return self
@@ -185,7 +185,7 @@ extension PXPaymentCongrats {
      - ToDo: Fill this
     */
     @discardableResult
-    public func setDiscountsData() -> PXPaymentCongrats {
+    public func withDiscountsData() -> PXPaymentCongrats {
         self.discounts = PXDiscounts(title: "Descuentos por tu nivel", subtitle: "", discountsAction: PXRemoteAction(label: "Ver todos los descuentos", target: "mercadopago://discount_center_payers/list#from=/px/congrats"), downloadAction: PXDownloadAction(title: "Exclusivo con la app de Mercado Libre", action: PXRemoteAction(label: "Descargar", target: "https://852u.adj.st/discount_center_payers/list?adjust_t=ufj9wxn&adjust_deeplink=mercadopago%3A%2F%2Fdiscount_center_payers%2Flist&adjust_label=px-ml")), items: [PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/766266-MLA32568902676_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018483&user_level=1&mcc=1091102&distance=1072139&coupon_used=false&status=FULL&store_id=13040071&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F766266-MLA32568902676_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22Nutty%20Bavarian%22%7D%7D%5D#from=/px/congrats", campaingId: "1018483"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/826105-MLA32568902631_102019-O.jpg", title: "Hasta", subtitle: "20 % OFF", target: "mercadopago://discount_center_payers/detail?campaign_id=1018457&user_level=1&mcc=4771701&distance=543968&coupon_used=false&status=FULL&store_id=30316240&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F826105-MLA32568902631_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2015%22%2C%22subtitle%22%3A%22Drogasil%22%7D%7D%5D#from=/px/congrats", campaingId: "1018457"),PXDiscountsItem(icon: "https://mla-s1-p.mlstatic.com/761600-MLA32568902662_102019-O.jpg", title: "Hasta", subtitle: "10 % OFF", target:  "mercadopago://discount_center_payers/detail?campaign_id=1018475&user_level=1&mcc=5611201&distance=654418&coupon_used=false&status=FULL&store_id=30108872&sections=%5B%7B%22id%22%3A%22header%22%2C%22type%22%3A%22header%22%2C%22content%22%3A%7B%22logo%22%3A%22https%3A%2F%2Fmla-s1-p.mlstatic.com%2F761600-MLA32568902662_102019-O.jpg%22%2C%22title%22%3A%22At%C3%A9%20R%24%2010%22%2C%22subtitle%22%3A%22McDonald%5Cu0027s%22%7D%7D%5D#from=/px/congrats", campaingId:"1018475") ], touchpoint: nil)
         return self
     }
@@ -195,7 +195,7 @@ extension PXPaymentCongrats {
     */
     #warning("Check if backgroundColor, textColor, weight should be customized from the outside")
     @discardableResult
-    public func setExpenseSplit(_ message: String?, backgroundColor: String?, textColor: String?, weight: String?, actionLabel: String, actionTarget: String?, imageURL: String) -> PXPaymentCongrats {
+    public func withExpenseSplit(_ message: String?, backgroundColor: String?, textColor: String?, weight: String?, actionLabel: String, actionTarget: String?, imageURL: String) -> PXPaymentCongrats {
         self.expenseSplit = PXExpenseSplit(title: PXText(message: message, backgroundColor: nil, textColor: nil, weight: weight), action: PXRemoteAction(label: actionLabel, target: actionTarget), imageUrl: imageURL)
         return self
     }
@@ -204,7 +204,7 @@ extension PXPaymentCongrats {
      - ToDo: Fill this
     */
     @discardableResult
-    public func setCrossSellingData() -> PXPaymentCongrats {
+    public func withCrossSellingData() -> PXPaymentCongrats {
         self.crossSelling = [PXCrossSellingItem(title: "Gane 200 pesos por sus pagos diarios", icon: "https://mobile.mercadolibre.com/remote_resources/image/merchengine_mgm_icon_ml?density=xxhdpi&locale=es_AR", contentId: "cross_selling_mgm_ml", action: PXRemoteAction(label: "Invita a más amigos a usar la aplicación", target: "meli://invite/wallet"))]
         return self
     }
@@ -213,7 +213,7 @@ extension PXPaymentCongrats {
      - ToDo: Fill this
     */
     @discardableResult
-    public func setViewReceiptAction(label: String, target: String) -> PXPaymentCongrats {
+    public func withViewReceiptAction(label: String, target: String) -> PXPaymentCongrats {
         self.viewReceiptAction = PXRemoteAction(label: label, target: target)
         return self
     }
@@ -222,7 +222,7 @@ extension PXPaymentCongrats {
      - ToDo: Fill this
     */
     @discardableResult
-    public func setTopTextBox(message: String?, backgroundColor: String?, textColor: String?, weight: String?) -> PXPaymentCongrats {
+    public func withTopTextBox(message: String?, backgroundColor: String?, textColor: String?, weight: String?) -> PXPaymentCongrats {
         self.topTextBox = PXText(message: message, backgroundColor: backgroundColor, textColor: textColor, weight: weight)
         return self
     }
@@ -249,7 +249,7 @@ extension PXPaymentCongrats {
      - ToDo: Fill this
     */
     @discardableResult
-    public func setInstructionView(_ view: UIView) -> PXPaymentCongrats {
+    public func withInstructionView(_ view: UIView) -> PXPaymentCongrats {
         self.instructionsView = view
         return self
     }
@@ -262,7 +262,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func setMainAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
+    public func withMainAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
         self.mainAction = PXAction(label: label, action: action)
         return self
     }
@@ -274,7 +274,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func setSecondaryAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
+    public func withSecondaryAction(label: String, action: @escaping () -> ()) -> PXPaymentCongrats {
         self.secondaryAction = PXAction(label: label, action: action)
         return self
     }
@@ -288,7 +288,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func setCustomViews(important: UIView?, top: UIView?, bottom: UIView?) -> PXPaymentCongrats {
+    public func withCustomViews(important: UIView?, top: UIView?, bottom: UIView?) -> PXPaymentCongrats {
         self.importantView = important
         self.topView = top
         self.bottomView = bottom
@@ -301,7 +301,7 @@ extension PXPaymentCongrats {
      - returns: tihs builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func setErrorBodyView(_ view: UIView) -> PXPaymentCongrats {
+    public func withErrorBodyView(_ view: UIView) -> PXPaymentCongrats {
         self.errorBodyView = view
         return self
     }
@@ -314,264 +314,8 @@ extension PXPaymentCongrats {
     @discardableResult
     public func start(using navController: UINavigationController) -> PXPaymentCongrats {
         self.navigationController = navController
-        let vc = PXNewResultViewController(viewModel: self, callback:{_,_ in })
-        self.navigationController?.pushViewController(vc, animated: true)
+        let viewModel = PXPaymentCongratsViewModel(paymentData: self)
+        viewModel.launch()
         return self
-    }
-}
-
-/**
- By conforming to `PXNewResultViewModelInterface` this class can be used
- as a ViewModel for `PXNewResultViewController`
- */
-extension PXPaymentCongrats: PXNewResultViewModelInterface {
-    // HEADER
-    #warning("PXResultViewModel also sends a status description to calculate the congrats color, a solution could be to expose only to the checkout a headerColor, and let PXBusinessResult and PXResultViewModel to set it. While external integrators should not care about header color because it should be calculated by relying in status. Validate this solution")
-    func getHeaderColor() -> UIColor {
-        guard let color = headerColor else {
-            return ResourceManager.shared.getResultColorWith(status: self.status.getDescription())
-        }
-        return color
-    }
-    
-    func getHeaderTitle() -> String {
-        return headerTitle
-    }
-    
-    func getHeaderIcon() -> UIImage? {
-        return headerImage
-    }
-    
-    func getHeaderURLIcon() -> String? {
-        return headerURL
-    }
-    
-    func getHeaderBadgeImage() -> UIImage? {
-        guard let image = headerBadgeImage else {
-            return ResourceManager.shared.getBadgeImageWith(status: self.status.getDescription())
-        }
-        return image
-    }
-    
-    func getHeaderCloseAction() -> (() -> Void)? {
-        return headerCloseAction
-    }
-    
-    //RECEIPT
-    func mustShowReceipt() -> Bool {
-        return shouldShowReceipt
-    }
-    
-    func getReceiptId() -> String? {
-        return receiptId
-    }
-    
-    //POINTS AND DISCOUNTS
-    ///POINTS
-    func getPoints() -> PXPoints? {
-        return pointsData
-    }
-    
-    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
-    func getPointsTapAction() -> ((String) -> Void)? {
-        let action: (String) -> Void = { (deepLink) in
-            //open deep link
-            PXDeepLinkManager.open(deepLink)
-            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapScorePath())
-        }
-        return action
-    }
-    
-    ///DISCOUNTS
-    func getDiscounts() -> PXDiscounts? {
-        return discounts
-    }
-    
-    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
-    func getDiscountsTapAction() -> ((Int, String?, String?) -> Void)? {
-        let action: (Int, String?, String?) -> Void = { (index, deepLink, trackId) in
-            //open deep link
-            PXDeepLinkManager.open(deepLink)
-            PXCongratsTracking.trackTapDiscountItemEvent(index, trackId)
-        }
-        return action
-    }
-    
-    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
-    func didTapDiscount(index: Int, deepLink: String?, trackId: String?) {
-        PXDeepLinkManager.open(deepLink)
-        PXCongratsTracking.trackTapDiscountItemEvent(index, trackId)
-    }
-    
-    ///EXPENSE SPLIT VIEW
-    func getExpenseSplit() -> PXExpenseSplit? {
-        return self.expenseSplit
-    }
-    
-    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
-    func getExpenseSplitTapAction() -> (() -> Void)? {
-        let action: () -> Void = { [weak self] in
-            PXDeepLinkManager.open(self?.expenseSplit?.action.target)
-            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapDeeplinkPath(), properties: PXCongratsTracking.getDeeplinkProperties(type: "money_split", deeplink: self?.expenseSplit?.action.target ?? ""))
-        }
-        return action
-    }
-    
-    func getCrossSellingItems() -> [PXCrossSellingItem]? {
-        return crossSelling
-    }
-    
-    ///CROSS SELLING
-    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
-    func getCrossSellingTapAction() -> ((String) -> Void)? {
-        let action: (String) -> Void = { (deepLink) in
-            //open deep link
-            PXDeepLinkManager.open(deepLink)
-            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapCrossSellingPath())
-        }
-        return action
-    }
-    
-    ////VIEW RECEIPT ACTION
-    func getViewReceiptAction() -> PXRemoteAction? {
-        return viewReceiptAction
-    }
-    
-    ////TOP TEXT BOX
-    func getTopTextBox() -> PXText? {
-        return topTextBox
-    }
-    
-    ////CUSTOM ORDER
-    func getCustomOrder() -> Bool? {
-        return hasCustomOrder
-    }
-    
-    //INSTRUCTIONS
-    func hasInstructions() -> Bool {
-        return shouldShowInstructions
-    }
-    
-    func getInstructionsView() -> UIView? {
-        return instructionsView
-    }
-    
-    // PAYMENT METHOD
-    // TODO Para que muestre el payment method, tenemos que devolver ademas paymentData
-    #warning("logica especifica para comparar PXBusinessResultStatus con PXPaymentStatus")
-    func shouldShowPaymentMethod() -> Bool {
-        // TODO checkear comparación de este status (BusinessStatus) pero puede ser que venga por PXResultViewModel que tiene otra logica
-        let isApproved = status.getDescription().lowercased() == PXPaymentStatus.APPROVED.rawValue.lowercased()
-        return !hasInstructions() && isApproved
-    }
-    
-    #warning("Desacoplar payment data del VC de Congrats")
-    func getPaymentData() -> PXPaymentData? {
-        // TODO
-        //        return paymentData
-        return nil
-    }
-    
-    #warning("Desacoplar ammount helper del VC de Congrats")
-    func getAmountHelper() -> PXAmountHelper? {
-        // TODO
-        //        return amountHelper
-        return nil
-    }
-    
-    // SPLIT PAYMENT METHOD
-    #warning("Desacoplar payment data del VC de Congrats")
-    func getSplitPaymentData() -> PXPaymentData? {
-        // TODO
-        //        return amountHelper.splitAccountMoney
-        return nil
-    }
-    
-    #warning("Desacoplar ammount helper del VC de Congrats")
-    func getSplitAmountHelper() -> PXAmountHelper? {
-        // TODO
-        //        return amountHelper
-        return nil
-    }
-    
-    // REJECTED BODY
-    func shouldShowErrorBody() -> Bool {
-        return errorBodyView != nil
-    }
-    
-    func getErrorBodyView() -> UIView? {
-        return errorBodyView
-    }
-    
-    // REMEDY
-    #warning("Chequear como resolver esto donde se le pasa parametros a esta funcion para que ejecute una accion en particular. Tener en cuenta que PXBusinessResult y PXResult tienen implementaciones distintas")
-    func getRemedyView(animatedButtonDelegate: PXAnimatedButtonDelegate?, remedyViewProtocol: PXRemedyViewProtocol?) -> UIView? {
-        // TODO
-        return nil
-    }
-    
-    func getRemedyButtonAction() -> ((String?) -> Void)? {
-        return remedyButtonAction
-    }
-    
-    func isPaymentResultRejectedWithRemedy() -> Bool {
-        return self.hasPaymentBeenRejectedWithRemedy
-    }
-    
-    // FOOTER
-    func getFooterMainAction() -> PXAction? {
-        return mainAction
-    }
-    
-    func getFooterSecondaryAction() -> PXAction? {
-        return secondaryAction
-    }
-    
-    // CUSTOM VIEWS
-    func getImportantView() -> UIView? {
-        return importantView
-    }
-    
-    func getCreditsExpectationView() -> UIView? {
-        return creditsExpectationView
-    }
-    
-    func getTopCustomView() -> UIView? {
-        return topView
-    }
-    
-    func getBottomCustomView() -> UIView? {
-        return bottomView
-    }
-    
-    //CALLBACKS & TRACKING
-    // TODO
-    func setCallback(callback: @escaping (PaymentResult.CongratsState, String?) -> Void) {
-    }
-    
-    // TODO double check how this is used
-    func getTrackingProperties() -> [String : Any] {
-        return trackingValues
-    }
-    
-    // TODO double check how this is used
-    func getTrackingPath() -> String {
-        return trackingPath
-    }
-    
-    func getFlowBehaviourResult() -> PXResultKey {
-        guard let result = flowBehaviourResult else {
-            switch status {
-            case .APPROVED:
-                return .SUCCESS
-            case .REJECTED:
-                return .FAILURE
-            case .PENDING:
-                return .PENDING
-            case .IN_PROGRESS:
-                return .PENDING
-            }
-        }
-        return result
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
@@ -1,0 +1,274 @@
+//
+//  PXPaymentCongratsViewModel.swift
+//  Pods
+//
+//  Created by Franco Risma on 28/07/2020.
+//
+
+import Foundation
+
+class PXPaymentCongratsViewModel {
+    
+    private let paymentData: PXPaymentCongrats
+    
+    init(paymentData: PXPaymentCongrats) {
+        self.paymentData = paymentData
+    }
+    
+    func launch() {
+        let vc = PXNewResultViewController(viewModel: self, callback:{_,_ in })
+        paymentData.navigationController?.pushViewController(vc, animated: true)
+    }
+}
+
+extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
+    // HEADER
+    #warning("PXResultViewModel also sends a status description to calculate the congrats color, a solution could be to expose only to the checkout a headerColor, and let PXBusinessResult and PXResultViewModel to set it. While external integrators should not care about header color because it should be calculated by relying in status. Validate this solution")
+    func getHeaderColor() -> UIColor {
+        guard let color = paymentData.headerColor else {
+            return ResourceManager.shared.getResultColorWith(status: paymentData.status.getDescription())
+        }
+        return color
+    }
+    
+    func getHeaderTitle() -> String {
+        return paymentData.headerTitle
+    }
+    
+    func getHeaderIcon() -> UIImage? {
+        return paymentData.headerImage
+    }
+    
+    func getHeaderURLIcon() -> String? {
+        return paymentData.headerURL
+    }
+    
+    func getHeaderBadgeImage() -> UIImage? {
+        guard let image = paymentData.headerBadgeImage else {
+            return ResourceManager.shared.getBadgeImageWith(status: paymentData.status.getDescription())
+        }
+        return image
+    }
+    
+    func getHeaderCloseAction() -> (() -> Void)? {
+        return paymentData.headerCloseAction
+    }
+    
+    //RECEIPT
+    func mustShowReceipt() -> Bool {
+        return paymentData.shouldShowReceipt
+    }
+    
+    func getReceiptId() -> String? {
+        return paymentData.receiptId
+    }
+    
+    //POINTS AND DISCOUNTS
+    ///POINTS
+    func getPoints() -> PXPoints? {
+        return paymentData.pointsData
+    }
+    
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
+    func getPointsTapAction() -> ((String) -> Void)? {
+        let action: (String) -> Void = { (deepLink) in
+            //open deep link
+            PXDeepLinkManager.open(deepLink)
+            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapScorePath())
+        }
+        return action
+    }
+    
+    ///DISCOUNTS
+    func getDiscounts() -> PXDiscounts? {
+        return paymentData.discounts
+    }
+    
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
+    func getDiscountsTapAction() -> ((Int, String?, String?) -> Void)? {
+        let action: (Int, String?, String?) -> Void = { (index, deepLink, trackId) in
+            //open deep link
+            PXDeepLinkManager.open(deepLink)
+            PXCongratsTracking.trackTapDiscountItemEvent(index, trackId)
+        }
+        return action
+    }
+    
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
+    func didTapDiscount(index: Int, deepLink: String?, trackId: String?) {
+        PXDeepLinkManager.open(deepLink)
+        PXCongratsTracking.trackTapDiscountItemEvent(index, trackId)
+    }
+    
+    ///EXPENSE SPLIT VIEW
+    func getExpenseSplit() -> PXExpenseSplit? {
+        return paymentData.expenseSplit
+    }
+    
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
+    func getExpenseSplitTapAction() -> (() -> Void)? {
+        let action: () -> Void = { [weak self] in
+            PXDeepLinkManager.open(self?.paymentData.expenseSplit?.action.target)
+            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapDeeplinkPath(), properties: PXCongratsTracking.getDeeplinkProperties(type: "money_split", deeplink: self?.paymentData.expenseSplit?.action.target ?? ""))
+        }
+        return action
+    }
+    
+    func getCrossSellingItems() -> [PXCrossSellingItem]? {
+        return paymentData.crossSelling
+    }
+    
+    ///CROSS SELLING
+    // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
+    func getCrossSellingTapAction() -> ((String) -> Void)? {
+        let action: (String) -> Void = { (deepLink) in
+            //open deep link
+            PXDeepLinkManager.open(deepLink)
+            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapCrossSellingPath())
+        }
+        return action
+    }
+    
+    ////VIEW RECEIPT ACTION
+    func getViewReceiptAction() -> PXRemoteAction? {
+        return paymentData.viewReceiptAction
+    }
+    
+    ////TOP TEXT BOX
+    func getTopTextBox() -> PXText? {
+        return paymentData.topTextBox
+    }
+    
+    ////CUSTOM ORDER
+    func getCustomOrder() -> Bool? {
+        return paymentData.hasCustomOrder
+    }
+    
+    //INSTRUCTIONS
+    func hasInstructions() -> Bool {
+        return paymentData.shouldShowInstructions
+    }
+    
+    func getInstructionsView() -> UIView? {
+        return paymentData.instructionsView
+    }
+    
+    // PAYMENT METHOD
+    // TODO Para que muestre el payment method, tenemos que devolver ademas paymentData
+    #warning("logica especifica para comparar PXBusinessResultStatus con PXPaymentStatus")
+    func shouldShowPaymentMethod() -> Bool {
+        // TODO checkear comparación de este status (BusinessStatus) pero puede ser que venga por PXResultViewModel que tiene otra logica
+        let isApproved = paymentData.status.getDescription().lowercased() == PXPaymentStatus.APPROVED.rawValue.lowercased()
+        return !hasInstructions() && isApproved
+    }
+    
+    #warning("Desacoplar payment data del VC de Congrats")
+    func getPaymentData() -> PXPaymentData? {
+        // TODO
+        //        return paymentData
+        return nil
+    }
+    
+    #warning("Desacoplar ammount helper del VC de Congrats")
+    func getAmountHelper() -> PXAmountHelper? {
+        // TODO
+        //        return amountHelper
+        return nil
+    }
+    
+    // SPLIT PAYMENT METHOD
+    #warning("Desacoplar payment data del VC de Congrats")
+    func getSplitPaymentData() -> PXPaymentData? {
+        // TODO
+        //        return amountHelper.splitAccountMoney
+        return nil
+    }
+    
+    #warning("Desacoplar ammount helper del VC de Congrats")
+    func getSplitAmountHelper() -> PXAmountHelper? {
+        // TODO
+        //        return amountHelper
+        return nil
+    }
+    
+    // REJECTED BODY
+    func shouldShowErrorBody() -> Bool {
+        return paymentData.errorBodyView != nil
+    }
+    
+    func getErrorBodyView() -> UIView? {
+        return paymentData.errorBodyView
+    }
+    
+    // REMEDY
+    #warning("Chequear como resolver esto donde se le pasa parametros a esta funcion para que ejecute una accion en particular. Tener en cuenta que PXBusinessResult y PXResult tienen implementaciones distintas")
+    func getRemedyView(animatedButtonDelegate: PXAnimatedButtonDelegate?, remedyViewProtocol: PXRemedyViewProtocol?) -> UIView? {
+        // TODO
+        return nil
+    }
+    
+    func getRemedyButtonAction() -> ((String?) -> Void)? {
+        return paymentData.remedyButtonAction
+    }
+    
+    func isPaymentResultRejectedWithRemedy() -> Bool {
+        return paymentData.hasPaymentBeenRejectedWithRemedy
+    }
+    
+    // FOOTER
+    func getFooterMainAction() -> PXAction? {
+        return paymentData.mainAction
+    }
+    
+    func getFooterSecondaryAction() -> PXAction? {
+        return paymentData.secondaryAction
+    }
+    
+    // CUSTOM VIEWS
+    func getImportantView() -> UIView? {
+        return paymentData.importantView
+    }
+    
+    func getCreditsExpectationView() -> UIView? {
+        return paymentData.creditsExpectationView
+    }
+    
+    func getTopCustomView() -> UIView? {
+        return paymentData.topView
+    }
+    
+    func getBottomCustomView() -> UIView? {
+        return paymentData.bottomView
+    }
+    
+    //CALLBACKS & TRACKING
+    // TODO
+    func setCallback(callback: @escaping (PaymentResult.CongratsState, String?) -> Void) {
+    }
+    
+    // TODO double check how this is used
+    func getTrackingProperties() -> [String : Any] {
+        return paymentData.trackingValues
+    }
+    
+    // TODO double check how this is used
+    func getTrackingPath() -> String {
+        return paymentData.trackingPath
+    }
+    
+    func getFlowBehaviourResult() -> PXResultKey {
+        guard let result = paymentData.flowBehaviourResult else {
+            switch paymentData.status {
+            case .APPROVED:
+                return .SUCCESS
+            case .REJECTED:
+                return .FAILURE
+            case .PENDING:
+                return .PENDING
+            case .IN_PROGRESS:
+                return .PENDING
+            }
+        }
+        return result
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
@@ -9,15 +9,15 @@ import Foundation
 
 class PXPaymentCongratsViewModel {
     
-    private let paymentData: PXPaymentCongrats
+    private let paymentCongrats: PXPaymentCongrats
     
-    init(paymentData: PXPaymentCongrats) {
-        self.paymentData = paymentData
+    init(paymentCongrats: PXPaymentCongrats) {
+        self.paymentCongrats = paymentCongrats
     }
     
     func launch() {
         let vc = PXNewResultViewController(viewModel: self, callback:{_,_ in })
-        paymentData.navigationController?.pushViewController(vc, animated: true)
+        paymentCongrats.navigationController?.pushViewController(vc, animated: true)
     }
 }
 
@@ -25,48 +25,48 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
     // HEADER
     #warning("PXResultViewModel also sends a status description to calculate the congrats color, a solution could be to expose only to the checkout a headerColor, and let PXBusinessResult and PXResultViewModel to set it. While external integrators should not care about header color because it should be calculated by relying in status. Validate this solution")
     func getHeaderColor() -> UIColor {
-        guard let color = paymentData.headerColor else {
-            return ResourceManager.shared.getResultColorWith(status: paymentData.status.getDescription())
+        guard let color = paymentCongrats.headerColor else {
+            return ResourceManager.shared.getResultColorWith(status: paymentCongrats.status.getDescription())
         }
         return color
     }
     
     func getHeaderTitle() -> String {
-        return paymentData.headerTitle
+        return paymentCongrats.headerTitle
     }
     
     func getHeaderIcon() -> UIImage? {
-        return paymentData.headerImage
+        return paymentCongrats.headerImage
     }
     
     func getHeaderURLIcon() -> String? {
-        return paymentData.headerURL
+        return paymentCongrats.headerURL
     }
     
     func getHeaderBadgeImage() -> UIImage? {
-        guard let image = paymentData.headerBadgeImage else {
-            return ResourceManager.shared.getBadgeImageWith(status: paymentData.status.getDescription())
+        guard let image = paymentCongrats.headerBadgeImage else {
+            return ResourceManager.shared.getBadgeImageWith(status: paymentCongrats.status.getDescription())
         }
         return image
     }
     
     func getHeaderCloseAction() -> (() -> Void)? {
-        return paymentData.headerCloseAction
+        return paymentCongrats.headerCloseAction
     }
     
     //RECEIPT
     func mustShowReceipt() -> Bool {
-        return paymentData.shouldShowReceipt
+        return paymentCongrats.shouldShowReceipt
     }
     
     func getReceiptId() -> String? {
-        return paymentData.receiptId
+        return paymentCongrats.receiptId
     }
     
     //POINTS AND DISCOUNTS
     ///POINTS
     func getPoints() -> PXPoints? {
-        return paymentData.pointsData
+        return paymentCongrats.points
     }
     
     // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
@@ -81,7 +81,7 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
     
     ///DISCOUNTS
     func getDiscounts() -> PXDiscounts? {
-        return paymentData.discounts
+        return paymentCongrats.discounts
     }
     
     // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
@@ -102,20 +102,20 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
     
     ///EXPENSE SPLIT VIEW
     func getExpenseSplit() -> PXExpenseSplit? {
-        return paymentData.expenseSplit
+        return paymentCongrats.expenseSplit
     }
     
     // This implementation is the same accross PXBusinessResultViewModel and PXResultViewModel, so it's ok to do it here
     func getExpenseSplitTapAction() -> (() -> Void)? {
         let action: () -> Void = { [weak self] in
-            PXDeepLinkManager.open(self?.paymentData.expenseSplit?.action.target)
-            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapDeeplinkPath(), properties: PXCongratsTracking.getDeeplinkProperties(type: "money_split", deeplink: self?.paymentData.expenseSplit?.action.target ?? ""))
+            PXDeepLinkManager.open(self?.paymentCongrats.expenseSplit?.action.target)
+            MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.Congrats.getSuccessTapDeeplinkPath(), properties: PXCongratsTracking.getDeeplinkProperties(type: "money_split", deeplink: self?.paymentCongrats.expenseSplit?.action.target ?? ""))
         }
         return action
     }
     
     func getCrossSellingItems() -> [PXCrossSellingItem]? {
-        return paymentData.crossSelling
+        return paymentCongrats.crossSelling
     }
     
     ///CROSS SELLING
@@ -131,26 +131,26 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
     
     ////VIEW RECEIPT ACTION
     func getViewReceiptAction() -> PXRemoteAction? {
-        return paymentData.viewReceiptAction
+        return paymentCongrats.viewReceiptAction
     }
     
     ////TOP TEXT BOX
     func getTopTextBox() -> PXText? {
-        return paymentData.topTextBox
+        return paymentCongrats.topTextBox
     }
     
     ////CUSTOM ORDER
     func getCustomOrder() -> Bool? {
-        return paymentData.hasCustomOrder
+        return paymentCongrats.hasCustomOrder
     }
     
     //INSTRUCTIONS
     func hasInstructions() -> Bool {
-        return paymentData.shouldShowInstructions
+        return paymentCongrats.shouldShowInstructions
     }
     
     func getInstructionsView() -> UIView? {
-        return paymentData.instructionsView
+        return paymentCongrats.instructionsView
     }
     
     // PAYMENT METHOD
@@ -158,7 +158,7 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
     #warning("logica especifica para comparar PXBusinessResultStatus con PXPaymentStatus")
     func shouldShowPaymentMethod() -> Bool {
         // TODO checkear comparación de este status (BusinessStatus) pero puede ser que venga por PXResultViewModel que tiene otra logica
-        let isApproved = paymentData.status.getDescription().lowercased() == PXPaymentStatus.APPROVED.rawValue.lowercased()
+        let isApproved = paymentCongrats.status.getDescription().lowercased() == PXPaymentStatus.APPROVED.rawValue.lowercased()
         return !hasInstructions() && isApproved
     }
     
@@ -193,11 +193,11 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
     
     // REJECTED BODY
     func shouldShowErrorBody() -> Bool {
-        return paymentData.errorBodyView != nil
+        return paymentCongrats.errorBodyView != nil
     }
     
     func getErrorBodyView() -> UIView? {
-        return paymentData.errorBodyView
+        return paymentCongrats.errorBodyView
     }
     
     // REMEDY
@@ -208,37 +208,37 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
     }
     
     func getRemedyButtonAction() -> ((String?) -> Void)? {
-        return paymentData.remedyButtonAction
+        return paymentCongrats.remedyButtonAction
     }
     
     func isPaymentResultRejectedWithRemedy() -> Bool {
-        return paymentData.hasPaymentBeenRejectedWithRemedy
+        return paymentCongrats.hasPaymentBeenRejectedWithRemedy
     }
     
     // FOOTER
     func getFooterMainAction() -> PXAction? {
-        return paymentData.mainAction
+        return paymentCongrats.mainAction
     }
     
     func getFooterSecondaryAction() -> PXAction? {
-        return paymentData.secondaryAction
+        return paymentCongrats.secondaryAction
     }
     
     // CUSTOM VIEWS
     func getImportantView() -> UIView? {
-        return paymentData.importantView
+        return paymentCongrats.importantView
     }
     
     func getCreditsExpectationView() -> UIView? {
-        return paymentData.creditsExpectationView
+        return paymentCongrats.creditsExpectationView
     }
     
     func getTopCustomView() -> UIView? {
-        return paymentData.topView
+        return paymentCongrats.topView
     }
     
     func getBottomCustomView() -> UIView? {
-        return paymentData.bottomView
+        return paymentCongrats.bottomView
     }
     
     //CALLBACKS & TRACKING
@@ -248,17 +248,17 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
     
     // TODO double check how this is used
     func getTrackingProperties() -> [String : Any] {
-        return paymentData.trackingValues
+        return paymentCongrats.trackingValues
     }
     
     // TODO double check how this is used
     func getTrackingPath() -> String {
-        return paymentData.trackingPath
+        return paymentCongrats.trackingPath
     }
     
     func getFlowBehaviourResult() -> PXResultKey {
-        guard let result = paymentData.flowBehaviourResult else {
-            switch paymentData.status {
+        guard let result = paymentCongrats.flowBehaviourResult else {
+            switch paymentCongrats.status {
             case .APPROVED:
                 return .SUCCESS
             case .REJECTED:


### PR DESCRIPTION
##  Cambios introducidos : 
- Se crea la clase `PXPaymentCongrats` que servirá como punto de entrada para los integradores que deseen instanciar *Congrats* sin tener que pasar por el flujo de checkout.

- Se comienza a dar forma a la estructura de `PXPaymentCongrats`, se crean varios setters `public` y otros `internal` para el uso exclusivo del checkout. Hay muchas definiciones pendientes y comentarios que tienen que ver con terminar de entender para que se usa cada campo.

- `PXPaymentCongratsViewModel` conforma con el protocolo `PXNewResultViewModelInterface` para poder ser utilizado como fuente de datos del `PXNewResultViewController`. Su init recibe `PXPaymentCongrats` que es el DTO que finalmente posee todos los campos.

- En la testApp de Swift y Objc se agregan botones que permiten lanzar esta nueva Congrats haciendo uso de `PXPaymentCongrats`

| TestApp Swift | TestApp Objc |
|--------------|--------------|
| ![image](https://user-images.githubusercontent.com/43185702/88421034-2f580780-cdbe-11ea-9b45-1238be4b5c9c.png) | ![image](https://user-images.githubusercontent.com/43185702/88421063-3c74f680-cdbe-11ea-8311-4c57137d6aff.png) |

