### PR TITLE
Add new values to additional info model

### DIFF
--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -166,7 +166,7 @@
 
 -(void)setCheckoutPrefAdditionalInfo {
     // Example SP support for custom additional info.
-    self.pref.additionalInfo = @"{\"px_summary\":{\"title\":\"Recarga Claro\",\"image_url\":\"https://www.rondachile.cl/wordpress/wp-content/uploads/2018/03/Logo-Claro-1.jpg\",\"subtitle\":\"Celular 1159199234\",\"purpose\":\"Tu recarga\"}}";
+    self.pref.additionalInfo = @"{\"px_summary\":{\"title\":\"Recarga Claro\",\"image_url\":\"https://www.rondachile.cl/wordpress/wp-content/uploads/2018/03/Logo-Claro-1.jpg\",\"subtitle\":\"Celular 1159199234\",\"purpose\":\"Tu recarga\"}, \"px_configuration\": {\"flow_id\": \"/multiplayer\"}, \"px_custom_texts\": {\"pay_button\": \"Enviar\", \"pay_button_progress\": \"Enviando...\", \"total_description\": \"Total a enviar\"}}";
 }
 
 - (void)didFinishWithCheckout:(MercadoPagoCheckout * _Nonnull)checkout {

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/MercadoPagoCheckout.swift
@@ -57,20 +57,6 @@ open class MercadoPagoCheckout: NSObject {
             fatalError("CheckoutPreference or preferenceId must be mandatory.")
         }
 
-        // If AdditionalInfo has custom texts override the ones set by MercadoPagoCheckoutBuilder
-        if let customTexts = choPref.pxAdditionalInfo?.pxCustomTexts {
-            if let translation = customTexts.payButton {
-                Localizator.sharedInstance.addCustomTranslation(.pay_button, translation)
-            }
-            if let translation = customTexts.payButtonProgress {
-                Localizator.sharedInstance.addCustomTranslation(.pay_button_progress, translation)
-            }
-            if let translation = customTexts.totalDescription {
-                Localizator.sharedInstance.addCustomTranslation(.total_to_pay, translation)
-                Localizator.sharedInstance.addCustomTranslation(.total_to_pay_onetap, translation)
-            }
-        }
-
         viewModel = MercadoPagoCheckoutViewModel(checkoutPreference: choPref, publicKey: builder.publicKey, privateKey: builder.privateKey, advancedConfig: builder.advancedConfig, trackingConfig: builder.trackingConfig)
 
         // Set Theme.

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/MercadoPagoCheckout.swift
@@ -57,6 +57,20 @@ open class MercadoPagoCheckout: NSObject {
             fatalError("CheckoutPreference or preferenceId must be mandatory.")
         }
 
+        // If AdditionalInfo has custom texts override the ones set by MercadoPagoCheckoutBuilder
+        if let customTexts = choPref.pxAdditionalInfo?.pxCustomTexts {
+            if let translation = customTexts.payButton {
+                Localizator.sharedInstance.addCustomTranslation(.pay_button, translation)
+            }
+            if let translation = customTexts.payButtonProgress {
+                Localizator.sharedInstance.addCustomTranslation(.pay_button_progress, translation)
+            }
+            if let translation = customTexts.totalDescription {
+                Localizator.sharedInstance.addCustomTranslation(.total_to_pay, translation)
+                Localizator.sharedInstance.addCustomTranslation(.total_to_pay_onetap, translation)
+            }
+        }
+
         viewModel = MercadoPagoCheckoutViewModel(checkoutPreference: choPref, publicKey: builder.publicKey, privateKey: builder.privateKey, advancedConfig: builder.advancedConfig, trackingConfig: builder.trackingConfig)
 
         // Set Theme.

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
@@ -567,6 +567,22 @@ internal class MercadoPagoCheckoutViewModel: NSObject, NSCopying {
         return configurations
     }
 
+    internal func updateCustomTexts() {
+        // If AdditionalInfo has custom texts override the ones set by MercadoPagoCheckoutBuilder
+        if let customTexts = checkoutPreference.pxAdditionalInfo?.pxCustomTexts {
+            if let translation = customTexts.payButton {
+                Localizator.sharedInstance.addCustomTranslation(.pay_button, translation)
+            }
+            if let translation = customTexts.payButtonProgress {
+                Localizator.sharedInstance.addCustomTranslation(.pay_button_progress, translation)
+            }
+            if let translation = customTexts.totalDescription {
+                Localizator.sharedInstance.addCustomTranslation(.total_to_pay, translation)
+                Localizator.sharedInstance.addCustomTranslation(.total_to_pay_onetap, translation)
+            }
+        }
+    }
+
     public func updateCheckoutModel(paymentMethodSearch: PXInitDTO) {
         let configurations = getPaymentOptionConfigurations(paymentMethodSearch: paymentMethodSearch)
         self.paymentConfigurationService.setConfigurations(configurations)

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Localize/Localizator.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Localize/Localizator.swift
@@ -70,12 +70,11 @@ internal extension Localizator {
     }
 
     func addCustomTranslation(_ key: PXCustomTranslationKey, _ translation: String) {
-        if customTrans != nil {
-            customTrans?[key] = translation
-        } else {
+        if customTrans == nil {
             customTrans = [PXCustomTranslationKey: String]()
-            customTrans?[key] = translation
         }
+        printDebug("Added custom translation: \(translation) for key: \(key.description)")
+        customTrans?[key] = translation
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Localize/PXCustomTranslationKey.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Localize/PXCustomTranslationKey.swift
@@ -23,4 +23,14 @@ import Foundation
         case .pay_button_progress: return "Procesando tu pago"
         }
     }
+
+    internal var description: String {
+        switch self {
+        case .total_to_pay: return "total_to_pay"
+        case .total_to_pay_onetap: return "total_to_pay_onetap"
+        case .how_to_pay: return "how_to_pay"
+        case .pay_button: return "pay_button"
+        case .pay_button_progress: return "pay_button_progress"
+        }
+    }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/MercadopagoCheckoutViewModel+InitFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/MercadopagoCheckoutViewModel+InitFlow.swift
@@ -31,6 +31,7 @@ extension MercadoPagoCheckoutViewModel {
         initFlow = InitFlow(flowProperties: initFlowProperties, finishInitCallback: { [weak self] (checkoutPreference, initSearch)  in
             guard let self = self else { return }
             self.checkoutPreference = checkoutPreference
+            self.updateCustomTexts()
             self.updateCheckoutModel(paymentMethodSearch: initSearch)
             self.paymentData.updatePaymentDataWith(payer: checkoutPreference.getPayer())
             PXTrackingStore.sharedInstance.addData(forKey: PXTrackingStore.cardIdsESC, value: self.getCardsIdsWithESC())

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfo.swift
@@ -9,24 +9,34 @@ import Foundation
 
 final class PXAdditionalInfo: NSObject, Codable {
     var pxSummary: PXAdditionalInfoSummary?
+    var pxConfiguration: PXAdditionalInfoConfiguration?
+    var pxCustomTexts: PXAdditionalInfoCustomTexts?
 
-    public init(pxSummary: PXAdditionalInfoSummary?) {
+    public init(pxSummary: PXAdditionalInfoSummary?, pxConfiguration: PXAdditionalInfoConfiguration?, pxCustomTexts: PXAdditionalInfoCustomTexts?) {
         self.pxSummary = pxSummary
+        self.pxConfiguration = pxConfiguration
+        self.pxCustomTexts = pxCustomTexts
     }
 
     public enum PXAdditionalInfoKeys: String, CodingKey {
         case pxSummary = "px_summary"
+        case pxConfiguration = "px_configuration"
+        case pxCustomTexts = "px_custom_texts"
     }
 
     required public convenience init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: PXAdditionalInfoKeys.self)
-        let summary: PXAdditionalInfoSummary? = try container.decodeIfPresent(PXAdditionalInfoSummary.self, forKey: .pxSummary)
-        self.init(pxSummary: summary)
+        let pxSummary: PXAdditionalInfoSummary? = try container.decodeIfPresent(PXAdditionalInfoSummary.self, forKey: .pxSummary)
+        let pxConfiguration: PXAdditionalInfoConfiguration? = try container.decodeIfPresent(PXAdditionalInfoConfiguration.self, forKey: .pxConfiguration)
+        let pxCustomTexts: PXAdditionalInfoCustomTexts? = try container.decodeIfPresent(PXAdditionalInfoCustomTexts.self, forKey: .pxCustomTexts)
+        self.init(pxSummary: pxSummary, pxConfiguration: pxConfiguration, pxCustomTexts: pxCustomTexts)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: PXAdditionalInfoKeys.self)
         try container.encodeIfPresent(self.pxSummary, forKey: .pxSummary)
+        try container.encodeIfPresent(self.pxConfiguration, forKey: .pxConfiguration)
+        try container.encodeIfPresent(self.pxCustomTexts, forKey: .pxCustomTexts)
     }
 
     func toJSONString() throws -> String? {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfoConfiguration.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfoConfiguration.swift
@@ -1,0 +1,46 @@
+//
+//  PXAdditionalInfoConfiguration.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Eric Ertl on 24/07/2020.
+//
+
+import Foundation
+
+final class PXAdditionalInfoConfiguration: NSObject, Codable {
+    var flowId: String?
+
+    init(flowId: String?) {
+        self.flowId = flowId
+    }
+
+    enum PXAdditionalInfoConfigurationKeys: String, CodingKey {
+        case flowId = "flow_id"
+    }
+
+    required convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: PXAdditionalInfoConfigurationKeys.self)
+        let flowId: String? = try container.decodeIfPresent(String.self, forKey: .flowId)
+        self.init(flowId: flowId)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: PXAdditionalInfoConfigurationKeys.self)
+        try container.encodeIfPresent(flowId, forKey: .flowId)
+    }
+
+    func toJSONString() throws -> String? {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(self)
+        return String(data: data, encoding: .utf8)
+    }
+
+    func toJSON() throws -> Data {
+        let encoder = JSONEncoder()
+        return try encoder.encode(self)
+    }
+
+    class func fromJSON(data: Data) throws -> PXAdditionalInfoConfiguration {
+        return try JSONDecoder().decode(PXAdditionalInfoConfiguration.self, from: data)
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfoCustomTexts.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAdditionalInfoCustomTexts.swift
@@ -1,0 +1,56 @@
+//
+//  PXAdditionalInfoCustomTexts.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Eric Ertl on 24/07/2020.
+//
+
+import Foundation
+
+final class PXAdditionalInfoCustomTexts: NSObject, Codable {
+    var payButton: String?
+    var payButtonProgress: String?
+    var totalDescription: String?
+
+    init(payButton: String?, payButtonProgress: String?, totalDescription: String?) {
+        self.payButton = payButton
+        self.payButtonProgress = payButtonProgress
+        self.totalDescription = totalDescription
+    }
+
+    enum PXAdditionalInfoCustomTextsKeys: String, CodingKey {
+        case payButton = "pay_button"
+        case payButtonProgress = "pay_button_progress"
+        case totalDescription = "total_description"
+    }
+
+    required convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: PXAdditionalInfoCustomTextsKeys.self)
+        let payButton: String? = try container.decodeIfPresent(String.self, forKey: .payButton)
+        let payButtonProgress: String? = try container.decodeIfPresent(String.self, forKey: .payButtonProgress)
+        let totalDescription: String? = try container.decodeIfPresent(String.self, forKey: .totalDescription)
+        self.init(payButton: payButton, payButtonProgress: payButtonProgress, totalDescription: totalDescription)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: PXAdditionalInfoCustomTextsKeys.self)
+        try container.encodeIfPresent(payButton, forKey: .payButton)
+        try container.encodeIfPresent(payButtonProgress, forKey: .payButtonProgress)
+        try container.encodeIfPresent(totalDescription, forKey: .totalDescription)
+    }
+
+    func toJSONString() throws -> String? {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(self)
+        return String(data: data, encoding: .utf8)
+    }
+
+    func toJSON() throws -> Data {
+        let encoder = JSONEncoder()
+        return try encoder.encode(self)
+    }
+
+    class func fromJSON(data: Data) throws -> PXAdditionalInfoCustomTexts {
+        return try JSONDecoder().decode(PXAdditionalInfoCustomTexts.self, from: data)
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference+AdditionalInfo.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCheckoutPreference+AdditionalInfo.swift
@@ -9,8 +9,13 @@ import Foundation
 
 internal extension PXCheckoutPreference {
     func populateAdditionalInfoModel() {
-        if let str = self.additionalInfo, let additionInfoData = str.data(using: .utf8) {
-            self.pxAdditionalInfo = try? JSONDecoder().decode(PXAdditionalInfo.self, from: additionInfoData)
+        if let additionalInfo = additionalInfo,
+            let data = additionalInfo.data(using: .utf8) {
+            do {
+                pxAdditionalInfo = try PXAdditionalInfo.fromJSON(data: data)
+            } catch {
+                printDebug(error)
+            }
         }
     }
 


### PR DESCRIPTION
##  Cambios introducidos : 
- Se agrega **px_configuration** y **px_custom_texts** en el additional_info de la pref

```
{
  "px_summary": {},
  "px_configuration": {
    "flow_id": "/multiplayer"
  },
  "px_custom_texts": {
    "pay_button": "Enviar",
    "pay_button_progress": "Enviando...",
    "total_description": "Total a enviar"
  }
}
```

