### PR TITLE
Fix crash trying to select a card in OneTap

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/MercadoPagoCheckout+Tracking.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/MercadoPagoCheckout+Tracking.swift
@@ -70,7 +70,7 @@ extension MercadoPagoCheckout {
         properties["extra_info"] = extraDic
         MPXTracker.sharedInstance.trackEvent(path: TrackingPaths.Events.getErrorPath(), properties: properties)
     }
-    
+
     private func getCheckoutPrefForTracking(checkoutPreference: PXCheckoutPreference) -> [String: Any] {
         var checkoutPrefDic: [String: Any] = [:]
 
@@ -87,7 +87,7 @@ extension MercadoPagoCheckout {
         checkoutPrefDic["payment_methods"] = getPaymentPreferenceForTracking(paymentPreference: checkoutPreference.paymentPreference)
         return checkoutPrefDic
     }
-    
+
     func getPaymentPreferenceForTracking(paymentPreference: PXPaymentPreference) -> [String: Any] {
         var paymentPrefDic: [String: Any] = [:]
         paymentPrefDic["installments"] = paymentPreference.maxAcceptedInstallments

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
@@ -345,7 +345,7 @@ extension PXOneTapInstallmentInfoView {
         if shouldShowPulseView(experiment) {
             setupChevronBackgroundView()
             if let chevronBackgroundView = chevronBackgroundView {
-                arrowImage.image = MLBusinessAppDataService().getAppIdentifier() == .mp ? ResourceManager.shared.getImage("chevronMP") : ResourceManager.shared.getImage("chevronML")
+                arrowImage.image = MLBusinessAppDataService().isMp() ? ResourceManager.shared.getImage("chevronMP") : ResourceManager.shared.getImage("chevronML")
                 arrowImage.translatesAutoresizingMaskIntoConstraints = false
                 addSubview(arrowImage)
                 NSLayoutConstraint.activate([

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
@@ -578,8 +578,7 @@ extension PXOneTapViewController: PXCardSliderProtocol {
 
     func selectCardInSliderAtIndex(_ index: Int) {
         let cardSliderViewModel = viewModel.getCardSliderViewModel()
-        if slider.canScrollTo(index: index),
-            (0 ... cardSliderViewModel.count - 1).contains(index) {
+        if (0 ... cardSliderViewModel.count - 1).contains(index) {
             do {
                 try slider.goToItemAt(index: index, animated: false)
             } catch {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
@@ -578,8 +578,17 @@ extension PXOneTapViewController: PXCardSliderProtocol {
 
     func selectCardInSliderAtIndex(_ index: Int) {
         let cardSliderViewModel = viewModel.getCardSliderViewModel()
-        if cardSliderViewModel.count - 1 >= index && index >= 0 {
-            slider.goToItemAt(index: index, animated: false)
+        if slider.canScrollTo(index: index),
+            (0 ... cardSliderViewModel.count - 1).contains(index) {
+            do {
+                try slider.goToItemAt(index: index, animated: false)
+            } catch {
+                // We shouldn't reach this line. Track friction
+                let properties = viewModel.getSelectCardEventProperties(index: index, count: cardSliderViewModel.count)
+                trackEvent(path: TrackingPaths.Events.getErrorPath(), properties: properties)
+                selectFirstCardInSlider()
+                return
+            }
             let card = cardSliderViewModel[index]
             newCardDidSelected(targetModel: card)
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel+Tracking.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel+Tracking.swift
@@ -113,6 +113,20 @@ extension PXOneTapViewModel {
         properties["extra_info"] = extraDic
         return properties
     }
+    
+    func getSelectCardEventProperties(index: Int, count: Int) -> [String: Any] {
+        var properties: [String: Any] = [:]
+        properties["path"] = TrackingPaths.Screens.OneTap.getOneTapPath()
+        properties["style"] = Tracking.Style.noScreen
+        properties["id"] = Tracking.Error.Id.genericError
+        properties["message"] = "No se pudo seleccionar la tarjeta ingresada"
+        properties["attributable_to"] = Tracking.Error.Atrributable.mercadopago
+        var extraDic: [String: Any] = [:]
+        extraDic["index"] =  index
+        extraDic["count"] =  count
+        properties["extra_info"] = extraDic
+        return properties
+    }
 
     func getTargetBehaviourProperties(_ behaviour: PXBehaviour) -> [String: Any] {
         var properties: [String: Any] = [:]

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXPulseView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXPulseView.swift
@@ -14,7 +14,7 @@ final class PXPulseView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .clear
         layer.cornerRadius = 16
-        layer.borderColor = MLBusinessAppDataService().getAppIdentifier() == .mp ? UIColor(red: 0, green: 158, blue: 227).withAlphaComponent(0.3).cgColor : UIColor(red: 52, green: 131, blue: 250).withAlphaComponent(0.3).cgColor
+        layer.borderColor = MLBusinessAppDataService().isMp() ? UIColor(red: 0, green: 158, blue: 227).withAlphaComponent(0.3).cgColor : UIColor(red: 52, green: 131, blue: 250).withAlphaComponent(0.3).cgColor
         layer.borderWidth = 8.5
         setupAnimations()
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/BusinessResult/PXBusinessResultViewModel+Tracking.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/BusinessResult/PXBusinessResultViewModel+Tracking.swift
@@ -110,7 +110,7 @@ extension PXBusinessResultViewModel: PXCongratsTrackingDataProtocol {
     }
 
     func hasExpenseSplitView() -> Bool {
-        return getExpenseSplit() != nil && MLBusinessAppDataService().getAppIdentifier() == .mp ? true : false
+        return getExpenseSplit() != nil && MLBusinessAppDataService().isMp() ? true : false
     }
 
     func getScoreLevel() -> Int? {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/PXCardSlider.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/PXCardSlider.swift
@@ -169,6 +169,31 @@ extension PXCardSlider {
     func getSelectedIndex() -> Int {
         return selectedIndex
     }
+    
+    func newCardDidSelected(_ index: Int) {
+        if model.indices.contains(pageControl.currentPage) {
+            let modelData = model[pageControl.currentPage]
+            delegate?.newCardDidSelected(targetModel: modelData)
+        }
+    }
+    
+    enum PXCardSliderError: Error {
+        case outOfBounds
+    }
+    
+    func canScrollTo(index: Int) -> Bool {
+        return (0 ... (pagerView.dataSource?.numberOfItems(in: pagerView) ?? 1 - 1)).contains(index)
+    }
+
+    func goToItemAt(index: Int, animated: Bool) throws {
+        guard canScrollTo(index: index) else {
+            throw PXCardSliderError.outOfBounds
+        }
+        pagerView.scrollToItem(at: index, animated: animated)
+        pageControl.currentPage = index
+        selectedIndex = index
+        UIAccessibility.post(notification: .pageScrolled, argument: "\(index + 1)" + "de".localized + "\(pageControl.numberOfPages)")
+    }
 }
 
 // MARK: Privates
@@ -209,35 +234,6 @@ extension PXCardSlider {
         PXLayout.pinBottom(view: pageControl, to: pagerView, withMargin: -pagerYMargin).isActive = true
         PXLayout.setHeight(owner: pageControl, height: pagerHeight).isActive = true
         pageControl.layoutIfNeeded()
-    }
-
-    func newCardDidSelected(_ index: Int) {
-        if model.indices.contains(pageControl.currentPage) {
-            let modelData = model[pageControl.currentPage]
-            delegate?.newCardDidSelected(targetModel: modelData)
-        }
-    }
-    
-    func indexOfCard() -> Int {
-        return 0
-    }
-    
-    enum PXCardSliderError: Error {
-        case outOfBounds
-    }
-    
-    func canScrollTo(index: Int) -> Bool {
-        return (0 ... (pagerView.dataSource?.numberOfItems(in: pagerView) ?? 1 - 1)).contains(index)
-    }
-
-    func goToItemAt(index: Int, animated: Bool) throws {
-        guard canScrollTo(index: index) else {
-            throw PXCardSliderError.outOfBounds
-        }
-        pagerView.scrollToItem(at: index, animated: animated)
-        pageControl.currentPage = index
-        selectedIndex = index
-        UIAccessibility.post(notification: .pageScrolled, argument: "\(index + 1)" + "de".localized + "\(pageControl.numberOfPages)")
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/PXCardSlider.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXCardSlider/PXCardSlider.swift
@@ -217,14 +217,23 @@ extension PXCardSlider {
             delegate?.newCardDidSelected(targetModel: modelData)
         }
     }
-}
-
-extension PXCardSlider: PXTermsAndConditionViewDelegate {
-    func shouldOpenTermsCondition(_ title: String, url: URL) {
-        termsAndCondDelegate?.shouldOpenTermsCondition(title, url: url)
+    
+    func indexOfCard() -> Int {
+        return 0
+    }
+    
+    enum PXCardSliderError: Error {
+        case outOfBounds
+    }
+    
+    func canScrollTo(index: Int) -> Bool {
+        return (0 ... (pagerView.dataSource?.numberOfItems(in: pagerView) ?? 1 - 1)).contains(index)
     }
 
-    func goToItemAt(index: Int, animated: Bool) {
+    func goToItemAt(index: Int, animated: Bool) throws {
+        guard canScrollTo(index: index) else {
+            throw PXCardSliderError.outOfBounds
+        }
         pagerView.scrollToItem(at: index, animated: animated)
         pageControl.currentPage = index
         selectedIndex = index
@@ -232,14 +241,20 @@ extension PXCardSlider: PXTermsAndConditionViewDelegate {
     }
 }
 
+extension PXCardSlider: PXTermsAndConditionViewDelegate {
+    func shouldOpenTermsCondition(_ title: String, url: URL) {
+        termsAndCondDelegate?.shouldOpenTermsCondition(title, url: url)
+    }
+}
+
 // MARK: ChangeCardAccessibilityProtocol
 extension PXCardSlider: ChangeCardAccessibilityProtocol {
     func scrollTo(direction: UIAccessibilityScrollDirection) {
         if direction == UIAccessibilityScrollDirection.left, pageControl.currentPage < pageControl.numberOfPages - 1 {
-            goToItemAt(index: pageControl.currentPage + 1, animated: true)
+            try? goToItemAt(index: pageControl.currentPage + 1, animated: true)
         }
         else if direction == UIAccessibilityScrollDirection.right, pageControl.currentPage > 0 {
-            goToItemAt(index: pageControl.currentPage - 1, animated: true)
+            try? goToItemAt(index: pageControl.currentPage - 1, animated: true)
         }
         newCardDidSelected(pageControl.currentPage)
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
@@ -527,7 +527,7 @@ extension PXNewResultViewController {
     ////EXPENSE SPLIT VIEW
     private func buildExpenseSplitView() -> UIView? {
         guard let expenseSplit = viewModel.getExpenseSplit(),
-            MLBusinessAppDataService().getAppIdentifier() == .mp
+            MLBusinessAppDataService().isMp()
         else { return nil }
 
         let data = PXNewResultUtil.getDataForExpenseSplitView(expenseSplit: expenseSplit)

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXResultViewModel.swift
@@ -77,7 +77,7 @@ extension PXResultViewModel: PXCongratsTrackingDataProtocol {
     }
 
     func hasExpenseSplitView() -> Bool {
-        return getExpenseSplit() != nil && MLBusinessAppDataService().getAppIdentifier() == .mp ? true : false
+        return getExpenseSplit() != nil && MLBusinessAppDataService().isMp() ? true : false
     }
 
     func getScoreLevel() -> Int? {


### PR DESCRIPTION
##  Cambios introducidos : 
- Se producia un crash al intentar seleccionar una tarjeta con un indice invalido.
- Se valida que el indice sea valido antes de seleccionar la tarjeta y se agrego un default y un friction para casos no contemplados