### PR TITLE
Fix PXN-1183

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
@@ -253,6 +253,14 @@ extension PXNewResultViewController {
         //Header View
         let view = buildHeaderView()
         views.append(ResultViewData(view: view))
+        
+        //Remedy body View
+        if let view = viewModel.getRemedyView(animatedButtonDelegate: self, remedyViewProtocol: self) {
+            subscribeToKeyboardNotifications()
+            views.append(ResultViewData(view: view))
+            // If payment has remedy don't show anything else in congrats
+            return views
+        }
 
         //Instructions View
         if let view = viewModel.getInstructionsView() {
@@ -332,12 +340,6 @@ extension PXNewResultViewController {
 
         //Error body View
         if let view = viewModel.getErrorBodyView() {
-            views.append(ResultViewData(view: view))
-        }
-
-        //Remedy body View
-        if let view = viewModel.getRemedyView(animatedButtonDelegate: self, remedyViewProtocol: self) {
-            subscribeToKeyboardNotifications()
             views.append(ResultViewData(view: view))
         }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
@@ -253,7 +253,7 @@ extension PXNewResultViewController {
         //Header View
         let view = buildHeaderView()
         views.append(ResultViewData(view: view))
-        
+
         //Remedy body View
         if let view = viewModel.getRemedyView(animatedButtonDelegate: self, remedyViewProtocol: self) {
             subscribeToKeyboardNotifications()


### PR DESCRIPTION
##  Cambios introducidos : 
- La pantalla de recuperos tiene scroll cuando no debería.
- Se subio la view de remedies en `getContentViews()` y se hace un return si existe remedies para que no se incluyan mas vistas

![image-2020-06-23-14-47-28-012](https://user-images.githubusercontent.com/54864543/89047890-7184ca00-d325-11ea-9eeb-52caa3a4724d.png)

