### PR TITLE
Add extraInfo for consumer credits

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel+Tracking.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel+Tracking.swift
@@ -77,7 +77,7 @@ extension PXOneTapViewModel {
             properties["review_type"] = "one_tap"
             var extraInfo: [String: Any] = [:]
             extraInfo["balance"] = selectedCard.accountMoneyBalance
-            extraInfo["selected_installment"] = amountHelper.getPaymentData().payerCost?.getPayerCostForTracking(paymentMethod.paymentTypeId)
+            extraInfo["selected_installment"] = amountHelper.getPaymentData().payerCost?.getPayerCostForTracking(isDigitalCurrency: paymentMethod.paymentTypeId == PXPaymentTypes.DIGITAL_CURRENCY.rawValue)
             properties["extra_info"] = extraInfo
         }
         return properties

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel+Tracking.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel+Tracking.swift
@@ -77,6 +77,7 @@ extension PXOneTapViewModel {
             properties["review_type"] = "one_tap"
             var extraInfo: [String: Any] = [:]
             extraInfo["balance"] = selectedCard.accountMoneyBalance
+            extraInfo["selected_installment"] = amountHelper.getPaymentData().payerCost?.getPayerCostForTracking(paymentMethod.paymentTypeId)
             properties["extra_info"] = extraInfo
         }
         return properties

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel+Tracking.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel+Tracking.swift
@@ -77,7 +77,7 @@ extension PXOneTapViewModel {
             properties["review_type"] = "one_tap"
             var extraInfo: [String: Any] = [:]
             extraInfo["balance"] = selectedCard.accountMoneyBalance
-            extraInfo["selected_installment"] = amountHelper.getPaymentData().payerCost?.getPayerCostForTracking(isDigitalCurrency: paymentMethod.paymentTypeId == PXPaymentTypes.DIGITAL_CURRENCY.rawValue)
+            extraInfo["selected_installment"] = amountHelper.getPaymentData().payerCost?.getPayerCostForTracking(isDigitalCurrency: paymentMethod.isDigitalCurrency)
             properties["extra_info"] = extraInfo
         }
         return properties

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPayerCost+Business.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPayerCost+Business.swift
@@ -53,12 +53,12 @@ extension PXPayerCost: Cellable {
         return getLabels()["TEA"]
     }
 
-    func getPayerCostForTracking(_ paymentTypeId: String? = nil) -> [String: Any] {
+    func getPayerCostForTracking(isDigitalCurrency: Bool = false) -> [String: Any] {
         var installmentDic: [String: Any] = [:]
         installmentDic["quantity"] = installments
         installmentDic["installment_amount"] = installmentAmount
         installmentDic["interest_rate"] = installmentRate
-        if hasInstallmentsRate() || paymentTypeId == PXPaymentTypes.DIGITAL_CURRENCY.rawValue {
+        if hasInstallmentsRate() || isDigitalCurrency {
             installmentDic["visible_total_price"] = totalAmount
         }
         return installmentDic

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPayerCost+Business.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPayerCost+Business.swift
@@ -53,12 +53,12 @@ extension PXPayerCost: Cellable {
         return getLabels()["TEA"]
     }
 
-    func getPayerCostForTracking() -> [String: Any] {
+    func getPayerCostForTracking(_ paymentTypeId: String? = nil) -> [String: Any] {
         var installmentDic: [String: Any] = [:]
         installmentDic["quantity"] = installments
         installmentDic["installment_amount"] = installmentAmount
         installmentDic["interest_rate"] = installmentRate
-        if hasInstallmentsRate() {
+        if hasInstallmentsRate() || paymentTypeId == PXPaymentTypes.DIGITAL_CURRENCY.rawValue {
             installmentDic["visible_total_price"] = totalAmount
         }
         return installmentDic

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentData+Tracking.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentData+Tracking.swift
@@ -36,7 +36,7 @@ extension PXPaymentData {
             // extraInfo["balance"] =
             // properties["extra_info"] = extraInfo
         } else if paymentMethod.isDigitalCurrency {
-            extraInfo["selected_installment"] = payerCost?.getPayerCostForTracking(paymentMethod.paymentTypeId)
+            extraInfo["selected_installment"] = payerCost?.getPayerCostForTracking(isDigitalCurrency: paymentMethod.paymentTypeId == PXPaymentTypes.DIGITAL_CURRENCY.rawValue)
             properties["extra_info"] = extraInfo
         }
         return properties

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentData+Tracking.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentData+Tracking.swift
@@ -19,8 +19,8 @@ extension PXPaymentData {
 
         properties["payment_method_type"] = paymentMethod.getPaymentTypeForTracking()
         properties["payment_method_id"] = paymentMethod.getPaymentIdForTracking()
+        var extraInfo: [String: Any] = [:]
         if paymentMethod.isCard {
-            var extraInfo: [String: Any] = [:]
             if let cardId = token?.cardId {
                 extraInfo["card_id"] = cardId
                 extraInfo["has_esc"] = cardIdsEsc.contains(cardId)
@@ -35,6 +35,9 @@ extension PXPaymentData {
             // var extraInfo: [String: Any] = [:]
             // extraInfo["balance"] =
             // properties["extra_info"] = extraInfo
+        } else if paymentMethod.isDigitalCurrency {
+            extraInfo["selected_installment"] = payerCost?.getPayerCostForTracking(paymentMethod.paymentTypeId)
+            properties["extra_info"] = extraInfo
         }
         return properties
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentData+Tracking.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentData+Tracking.swift
@@ -36,7 +36,7 @@ extension PXPaymentData {
             // extraInfo["balance"] =
             // properties["extra_info"] = extraInfo
         } else if paymentMethod.isDigitalCurrency {
-            extraInfo["selected_installment"] = payerCost?.getPayerCostForTracking(isDigitalCurrency: paymentMethod.paymentTypeId == PXPaymentTypes.DIGITAL_CURRENCY.rawValue)
+            extraInfo["selected_installment"] = payerCost?.getPayerCostForTracking(isDigitalCurrency: true)
             properties["extra_info"] = extraInfo
         }
         return properties


### PR DESCRIPTION
##  Cambios introducidos : 
En los tracks de /confirm y /result para el medio de pago "credits" no se está mandando información sobre la cuota seleccionada (al igual de como se hace para TC). Se replica el modelo de TC para CC.
