### PR TITLE
Feature CFT text

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapInstallmentInfoView.swift
@@ -96,7 +96,7 @@ extension PXOneTapInstallmentInfoView: FSPagerViewDataSource {
             }
         }
 
-        let label = buildLabel(itemModel.text, UIFont.ml_regularSystemFont(ofSize: PXLayout.XS_FONT), .left)
+        let label = buildLabel(itemModel.text, nil, .left)
         let accessibilityMessage = getAccessibilityMessage(itemModel.text.string, benefitsText)
         cell.setAccessibilityMessage(accessibilityMessage)
         if index == 0 {
@@ -328,11 +328,13 @@ extension PXOneTapInstallmentInfoView {
 
 // MARK: Privates
 private extension PXOneTapInstallmentInfoView {
-    func buildLabel(_ attributedText: NSAttributedString, _ font: UIFont, _ textAlignment: NSTextAlignment, _ numberOfLines: Int = 1) -> UILabel {
+    func buildLabel(_ attributedText: NSAttributedString, _ font: UIFont? = nil, _ textAlignment: NSTextAlignment, _ numberOfLines: Int = 1) -> UILabel {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.attributedText = attributedText
-        label.font = font
+        if let font = font {
+            label.font = font
+        }
         label.textAlignment = textAlignment
         label.numberOfLines = numberOfLines
         return label

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
@@ -92,7 +92,7 @@ extension PXOneTapViewModel {
                 let viewModelCard = PXCardSliderViewModel(paymentMethodId, targetNode.paymentTypeId, "", AccountMoneyCard(), cardData, [PXPayerCost](), nil, accountMoney.getId(), false, amountConfiguration: amountConfiguration, status: statusConfig, bottomMessage: chargeRuleMessage, benefits: benefits, payerPaymentMethod: getPayerPaymentMethod(targetNode.paymentTypeId, nil), behaviours: targetNode.behaviours, displayInfo: targetNode.displayInfo)
 
                 viewModelCard.setAccountMoney(accountMoneyBalance: accountMoney.availableBalance)
-                let attributes: [NSAttributedString.Key: AnyObject] = [NSAttributedString.Key.font: Utils.getFont(size: installmentsRowMessageFontSize), NSAttributedString.Key.foregroundColor: ThemeManager.shared.greyColor()]
+                let attributes: [NSAttributedString.Key: AnyObject] = [NSAttributedString.Key.font: UIFont.ml_regularSystemFont(ofSize: installmentsRowMessageFontSize), NSAttributedString.Key.foregroundColor: ThemeManager.shared.greyColor()]
                 viewModelCard.displayMessage = NSAttributedString(string: accountMoney.sliderTitle ?? "", attributes: attributes)
                 sliderModel.append(viewModelCard)
             } else if let targetCardData = targetNode.oneTapCard {
@@ -430,14 +430,9 @@ extension PXOneTapViewModel {
             }
 
             // Third attr
-            if let cftDisplayStr = payerCostData.getCFT(separator: ":") {
-                if (payerCostData.hasCFTValue() && (payerCostData.installments != 1)) || isDigitalCurrency {
-                    let thirdAttributes: [NSAttributedString.Key: AnyObject] = [NSAttributedString.Key.font: Utils.getFont(size: installmentsRowMessageFontSize), NSAttributedString.Key.foregroundColor: ThemeManager.shared.greyColor()]
-                    let thirdText = " \(cftDisplayStr)"
-                    let thirdAttributedString = NSAttributedString(string: thirdText, attributes: thirdAttributes)
-                    text.append(thirdAttributedString)
-                }
-
+            if let interestRate = payerCostData.interestRate,
+                let thirdAttributedString = interestRate.getAttributedString(fontSize: installmentsRowMessageFontSize) {
+                text.appendWithSpace(thirdAttributedString)
             }
         }
         return text
@@ -476,7 +471,7 @@ extension PXOneTapViewModel {
 
     func getSplitMessageForDebit(amountToPay: Double) -> NSAttributedString {
         var amount: String = ""
-        let attributes: [NSAttributedString.Key: AnyObject] = [NSAttributedString.Key.font: Utils.getSemiBoldFont(size: installmentsRowMessageFontSize), NSAttributedString.Key.foregroundColor: ThemeManager.shared.boldLabelTintColor()]
+        let attributes: [NSAttributedString.Key: AnyObject] = [NSAttributedString.Key.font: UIFont.ml_regularSystemFont(ofSize: installmentsRowMessageFontSize), NSAttributedString.Key.foregroundColor: ThemeManager.shared.boldLabelTintColor()]
 
         amount = Utils.getAmountFormated(amount: amountToPay, forCurrency: SiteManager.shared.getCurrency())
         return NSAttributedString(string: amount, attributes: attributes)

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPayerCost+Business.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPayerCost+Business.swift
@@ -22,37 +22,6 @@ extension PXPayerCost: Cellable {
         return installmentRate > 0.0 && installments > 1
     }
 
-    func hasCFTValue() -> Bool {
-        return !String.isNullOrEmpty(getCFT())
-    }
-
-    private func getLabels() -> [String: String] {
-        let prefixes: [String] = ["CFT", "TEA"]
-        var labelsDictionary: [String: String] = [:]
-        _ = labels.filter { prefixes.contains(where: $0.hasPrefix) }.flatMap { $0.components(separatedBy: "|") }.map { (label) -> String in
-            let array = label.components(separatedBy: "_")
-            if array.count == 2 {
-                labelsDictionary[array[0]] = array[1]
-            }
-            return label
-        }
-        return labelsDictionary
-    }
-
-    func getCFT(separator: String = "") -> String? {
-        let cftString = getLabels().compactMap { (key, value) -> String? in
-            if key.hasPrefix("CFT") {
-                return "\(key)\(separator) \(value)"
-            }
-            return nil
-        }.joined()
-        return cftString
-    }
-
-    func getTEAValue() -> String? {
-        return getLabels()["TEA"]
-    }
-
     func getPayerCostForTracking(isDigitalCurrency: Bool = false) -> [String: Any] {
         var installmentDic: [String: Any] = [:]
         installmentDic["quantity"] = installments

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPayerCost.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPayerCost.swift
@@ -13,6 +13,7 @@ open class PXPayerCost: NSObject, Codable {
 
     open var installmentRate: Double = 0
     open var labels: [String] = []
+    open var interestRate: PXText?
     open var minAllowedAmount: Double = 0
     open var maxAllowedAmount: Double = 0
     open var recommendedMessage: String?
@@ -23,9 +24,10 @@ open class PXPayerCost: NSObject, Codable {
     open var paymentMethodOptionId: String?
     open var agreements: [PXAgreement] = []
 
-    public init(installmentRate: Double, labels: [String], minAllowedAmount: Double, maxAllowedAmount: Double, recommendedMessage: String?, installmentAmount: Double, totalAmount: Double, installments: Int, processingMode: String?, paymentMethodOptionId: String?, agreements: [PXAgreement] = []) {
+    public init(installmentRate: Double, labels: [String], interestRate: PXText?, minAllowedAmount: Double, maxAllowedAmount: Double, recommendedMessage: String?, installmentAmount: Double, totalAmount: Double, installments: Int, processingMode: String?, paymentMethodOptionId: String?, agreements: [PXAgreement] = []) {
         self.installmentRate = installmentRate
         self.labels = labels
+        self.interestRate = interestRate
         self.minAllowedAmount = minAllowedAmount
         self.maxAllowedAmount = maxAllowedAmount
         self.recommendedMessage = recommendedMessage
@@ -40,6 +42,7 @@ open class PXPayerCost: NSObject, Codable {
     public enum PXPayerCostKeys: String, CodingKey {
         case installmentRate = "installment_rate"
         case labels
+        case interestRate = "interest_rate"
         case minAllowedAmount = "min_allowed_amount"
         case maxAllowedAmount = "max_allowed_amount"
         case recommendedMessage = "recommended_message"
@@ -55,6 +58,7 @@ open class PXPayerCost: NSObject, Codable {
         let container = try decoder.container(keyedBy: PXPayerCostKeys.self)
         let installmentRate: Double = try container.decodeIfPresent(Double.self, forKey: .installmentRate) ?? 0
         let labels: [String] = try container.decodeIfPresent([String].self, forKey: .labels) ?? []
+        let interestRate: PXText? = try container.decodeIfPresent(PXText.self, forKey: .interestRate)
         let minAllowedAmount: Double = try container.decodeIfPresent(Double.self, forKey: .minAllowedAmount) ?? 0
         let maxAllowedAmount: Double = try container.decodeIfPresent(Double.self, forKey: .maxAllowedAmount) ?? 0
         let recommendedMessage: String? = try container.decodeIfPresent(String.self, forKey: .recommendedMessage)
@@ -65,13 +69,14 @@ open class PXPayerCost: NSObject, Codable {
         let paymentMethodOptionId: String? = try container.decodeIfPresent(String.self, forKey: .paymentMethodOptionId)
         let agreements: [PXAgreement] = try container.decodeIfPresent([PXAgreement].self, forKey: .agreements) ?? []
 
-        self.init(installmentRate: installmentRate, labels: labels, minAllowedAmount: minAllowedAmount, maxAllowedAmount: maxAllowedAmount, recommendedMessage: recommendedMessage, installmentAmount: installmentAmount, totalAmount: totalAmount, installments: installments,processingMode: processingMode, paymentMethodOptionId: paymentMethodOptionId, agreements: agreements)
+        self.init(installmentRate: installmentRate, labels: labels, interestRate: interestRate, minAllowedAmount: minAllowedAmount, maxAllowedAmount: maxAllowedAmount, recommendedMessage: recommendedMessage, installmentAmount: installmentAmount, totalAmount: totalAmount, installments: installments,processingMode: processingMode, paymentMethodOptionId: paymentMethodOptionId, agreements: agreements)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = try encoder.container(keyedBy: PXPayerCostKeys.self)
         try container.encodeIfPresent(self.installmentRate, forKey: .installmentRate)
         try container.encodeIfPresent(self.labels, forKey: .labels)
+        try container.encodeIfPresent(self.interestRate, forKey: .interestRate)
         try container.encodeIfPresent(self.minAllowedAmount, forKey: .minAllowedAmount)
         try container.encodeIfPresent(self.maxAllowedAmount, forKey: .maxAllowedAmount)
         try container.encodeIfPresent(self.recommendedMessage, forKey: .recommendedMessage)

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPayerCost.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPayerCost.swift
@@ -13,7 +13,6 @@ open class PXPayerCost: NSObject, Codable {
 
     open var installmentRate: Double = 0
     open var labels: [String] = []
-    open var interestRate: PXText?
     open var minAllowedAmount: Double = 0
     open var maxAllowedAmount: Double = 0
     open var recommendedMessage: String?
@@ -23,11 +22,11 @@ open class PXPayerCost: NSObject, Codable {
     open var processingMode: String?
     open var paymentMethodOptionId: String?
     open var agreements: [PXAgreement] = []
+    open var interestRate: PXText?
 
-    public init(installmentRate: Double, labels: [String], interestRate: PXText?, minAllowedAmount: Double, maxAllowedAmount: Double, recommendedMessage: String?, installmentAmount: Double, totalAmount: Double, installments: Int, processingMode: String?, paymentMethodOptionId: String?, agreements: [PXAgreement] = []) {
+    public init(installmentRate: Double, labels: [String], minAllowedAmount: Double, maxAllowedAmount: Double, recommendedMessage: String?, installmentAmount: Double, totalAmount: Double, installments: Int, processingMode: String?, paymentMethodOptionId: String?, agreements: [PXAgreement] = [], interestRate: PXText? = nil) {
         self.installmentRate = installmentRate
         self.labels = labels
-        self.interestRate = interestRate
         self.minAllowedAmount = minAllowedAmount
         self.maxAllowedAmount = maxAllowedAmount
         self.recommendedMessage = recommendedMessage
@@ -37,12 +36,12 @@ open class PXPayerCost: NSObject, Codable {
         self.processingMode = processingMode
         self.paymentMethodOptionId = paymentMethodOptionId
         self.agreements = agreements
+        self.interestRate = interestRate
     }
 
     public enum PXPayerCostKeys: String, CodingKey {
         case installmentRate = "installment_rate"
         case labels
-        case interestRate = "interest_rate"
         case minAllowedAmount = "min_allowed_amount"
         case maxAllowedAmount = "max_allowed_amount"
         case recommendedMessage = "recommended_message"
@@ -52,6 +51,7 @@ open class PXPayerCost: NSObject, Codable {
         case processingMode = "processing_mode"
         case paymentMethodOptionId = "payment_method_option_id"
         case agreements
+        case interestRate = "interest_rate"
     }
 
     required public convenience init(from decoder: Decoder) throws {
@@ -69,7 +69,7 @@ open class PXPayerCost: NSObject, Codable {
         let paymentMethodOptionId: String? = try container.decodeIfPresent(String.self, forKey: .paymentMethodOptionId)
         let agreements: [PXAgreement] = try container.decodeIfPresent([PXAgreement].self, forKey: .agreements) ?? []
 
-        self.init(installmentRate: installmentRate, labels: labels, interestRate: interestRate, minAllowedAmount: minAllowedAmount, maxAllowedAmount: maxAllowedAmount, recommendedMessage: recommendedMessage, installmentAmount: installmentAmount, totalAmount: totalAmount, installments: installments,processingMode: processingMode, paymentMethodOptionId: paymentMethodOptionId, agreements: agreements)
+        self.init(installmentRate: installmentRate, labels: labels, minAllowedAmount: minAllowedAmount, maxAllowedAmount: maxAllowedAmount, recommendedMessage: recommendedMessage, installmentAmount: installmentAmount, totalAmount: totalAmount, installments: installments,processingMode: processingMode, paymentMethodOptionId: paymentMethodOptionId, agreements: agreements, interestRate: interestRate)
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXCFTComponentView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXCFTComponentView.swift
@@ -12,25 +12,19 @@ final class PXCFTComponentView: PXComponentView {
 
     fileprivate lazy var VIEW_HEIGHT: CGFloat = 44
     fileprivate lazy var MATCH_WIDTH_PERCENT: CGFloat = 95
+    fileprivate let cftLabel = UILabel()
 
-    fileprivate let cftLabel: UILabel = UILabel()
-
-    init(withCFTValue: String?, titleColor: UIColor, backgroundColor: UIColor) {
-
+    init(withCFTValue: PXText?, backgroundColor: UIColor) {
         super.init()
-
         self.backgroundColor = backgroundColor
 
-        if let cftValue = withCFTValue {
-
+        if let cftText = withCFTValue {
             cftLabel.translatesAutoresizingMaskIntoConstraints = false
             cftLabel.textAlignment = .center
             cftLabel.numberOfLines = 1
-            cftLabel.attributedText = NSAttributedString(string: cftValue, attributes: [NSAttributedString.Key.font: Utils.getLightFont(size: PXLayout.M_FONT)])
-            cftLabel.textColor = titleColor
+            cftLabel.attributedText = cftText.getAttributedString(fontSize: PXLayout.M_FONT)
             cftLabel.accessibilityIdentifier = "CFT_label"
-            self.addSubview(cftLabel)
-
+            addSubview(cftLabel)
             PXLayout.pinTop(view: cftLabel, to: self).isActive = true
             PXLayout.centerHorizontally(view: cftLabel).isActive = true
             PXLayout.matchWidth(ofView: cftLabel, toView: self, withPercentage: MATCH_WIDTH_PERCENT).isActive = true

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXCFTComponentView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXCFTComponentView.swift
@@ -14,9 +14,9 @@ final class PXCFTComponentView: PXComponentView {
     fileprivate lazy var MATCH_WIDTH_PERCENT: CGFloat = 95
     fileprivate let cftLabel = UILabel()
 
-    init(withCFTValue: PXText?, backgroundColor: UIColor) {
+    init(withCFTValue: PXText?) {
         super.init()
-        self.backgroundColor = backgroundColor
+        backgroundColor = ThemeManager.shared.highlightBackgroundColor()
 
         if let cftText = withCFTValue {
             cftLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewController.swift
@@ -314,11 +314,8 @@ extension PXReviewViewController {
     }
 
     private func getCFTComponentView() -> UIView? {
-        if viewModel.hasPayerCostAddionalInfo() {
-            let cftView = PXCFTComponentView(withCFTValue: self.viewModel.amountHelper.getPaymentData().payerCost?.getCFT(), titleColor: ThemeManager.shared.labelTintColor(), backgroundColor: ThemeManager.shared.highlightBackgroundColor())
-            return cftView
-        }
-        return nil
+        guard viewModel.hasPayerCostAddionalInfo() else { return nil }
+        return PXCFTComponentView(withCFTValue: viewModel.amountHelper.getPaymentData().payerCost?.interestRate, backgroundColor: ThemeManager.shared.highlightBackgroundColor())
     }
 
     private func getFloatingButtonView() -> PXContainedActionButtonView {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewController.swift
@@ -315,7 +315,7 @@ extension PXReviewViewController {
 
     private func getCFTComponentView() -> UIView? {
         guard viewModel.hasPayerCostAddionalInfo() else { return nil }
-        return PXCFTComponentView(withCFTValue: viewModel.amountHelper.getPaymentData().payerCost?.interestRate, backgroundColor: ThemeManager.shared.highlightBackgroundColor())
+        return PXCFTComponentView(withCFTValue: viewModel.amountHelper.getPaymentData().payerCost?.interestRate)
     }
 
     private func getFloatingButtonView() -> PXContainedActionButtonView {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
@@ -116,7 +116,7 @@ extension PXReviewViewModel {
     }
 
     func hasPayerCostAddionalInfo() -> Bool {
-        if amountHelper.getPaymentData().getPayerCost()?.interestRate != nil,
+        if amountHelper.getPaymentData().getPayerCost()?.interestRate?.message != nil,
             let paymentMethod = amountHelper.getPaymentData().paymentMethod, paymentMethod.isCreditCard {
             return true
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
@@ -116,7 +116,11 @@ extension PXReviewViewModel {
     }
 
     func hasPayerCostAddionalInfo() -> Bool {
-        return self.amountHelper.getPaymentData().hasPayerCost() && self.amountHelper.getPaymentData().getPayerCost()!.hasCFTValue() && self.amountHelper.getPaymentData().paymentMethod!.isCreditCard
+        if amountHelper.getPaymentData().getPayerCost()?.interestRate != nil,
+            let paymentMethod = amountHelper.getPaymentData().paymentMethod, paymentMethod.isCreditCard {
+            return true
+        }
+        return false
     }
 
     func hasConfirmAdditionalInfo() -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Payer/PayerCostCFTTableViewCell.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Payer/PayerCostCFTTableViewCell.swift
@@ -51,7 +51,7 @@ class PayerCostCFTTableViewCell: UITableViewCell {
 
     func fillCFTLabel(payerCost: PXPayerCost) {
         CFTLabel.textColor = UIColor.px_grayDark()
-        CFTLabel.text = payerCost.getCFT() ?? ""
+        CFTLabel.text = payerCost.interestRate?.message ?? ""
     }
 
     func addSeparatorLineToBottom(width: Double, height: Double) {


### PR DESCRIPTION
##  Cambios introducidos : 
- Se saca la lógica para formatear el texto de CFT y se setea directamente como viene de backend. 

<img width="568" alt="Captura de Pantalla 2020-08-06 a la(s) 10 46 48" src="https://user-images.githubusercontent.com/49253145/89539825-a041eb00-d7d2-11ea-9bc7-a13820d97e98.png">

<img width="582" alt="Captura de Pantalla 2020-08-06 a la(s) 10 48 54" src="https://user-images.githubusercontent.com/49253145/89539858-aafc8000-d7d2-11ea-903f-e6d05228d5cb.png">
