### PR TITLE
[Congrats] Remove callback from NewResultViewController init

### DIFF
--- a/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
+++ b/ExampleObjectiveC/MercadoPagoSDKExamplesObjectiveC/MainExamplesViewController.m
@@ -18,7 +18,7 @@
                                                withHeaderWithTitle: @"¡Listo! Ya le pagaste a SuperMarket" imageURL: @"https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg" closeAction:^{
                                                    NSLog(@"Continuar");
                                                }]
-                                             withReceiptWithReceiptId: @"123" action: nil]
+                                             withReceiptWithShouldShowReceipt:true receiptId:@"123" action:nil]
                                              withFooterMainAction: [[PXAction alloc] initWithLabel:@"Continuar" action:^{
                                                  NSLog(@"Continuar");
                                              }]]

--- a/ExampleSwift/ExampleSwift/Controllers/CongratsSelectorViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/CongratsSelectorViewController.swift
@@ -29,7 +29,7 @@ class CongratsSelectorViewController: UITableViewController {
                                 .withHeader(title: "¡Listo! Ya le pagaste a SuperMarket", imageURL: "https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg") {
                                     self.navigationController?.popViewController(animated: true)
                                 }
-                                .withReceipt(receiptId: "123", action: nil)
+                                .withReceipt(shouldShowReceipt: true, receiptId: "123", action: nil)
                                 .withFooterMainAction(PXAction(label: "Continuar", action: {
                                     self.navigationController?.popViewController(animated: true)
                                 }))
@@ -48,7 +48,7 @@ class CongratsSelectorViewController: UITableViewController {
             .withHeader(title: "¡Listo! Ya le pagaste a SuperMarket", imageURL: "https://mla-s2-p.mlstatic.com/600619-MLA32239048138_092019-O.jpg") {
                 self.navigationController?.popViewController(animated: true)
             }
-        .withReceipt( receiptId: "123", action: nil)
+        .withReceipt(shouldShowReceipt: true, receiptId: "123", action: nil)
             .withFooterMainAction(PXAction(label: "Continuar", action: {
                self.navigationController?.popViewController(animated: true)
             }))

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckoutScreens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckoutScreens.swift
@@ -171,8 +171,8 @@ extension MercadoPagoCheckout {
         if viewModel.paymentResult == nil, let payment = viewModel.payment {
             viewModel.paymentResult = PaymentResult(payment: payment, paymentData: viewModel.paymentData)
         }
-        
-        let viewController = PXNewResultViewController(viewModel: viewModel.resultViewModel(), callback: { [weak self] congratsState, remedyText in
+        let resultViewModel = viewModel.resultViewModel()
+        resultViewModel.setCallback(callback: { [weak self] congratsState, remedyText in
             guard let self = self else { return }
             self.viewModel.pxNavigationHandler.navigationController.setNavigationBarHidden(false, animated: false)
             switch congratsState {
@@ -226,7 +226,8 @@ extension MercadoPagoCheckout {
             default:
                 self.finish()
             }
-        }, finishButtonAnimation: { [weak self] in
+        })
+        let viewController = PXNewResultViewController(viewModel: resultViewModel, finishButtonAnimation: { [weak self] in
             // Remedy view has an animated button. This closure is called after the animation has finished
             self?.executeNextStep()
         })
@@ -239,10 +240,10 @@ extension MercadoPagoCheckout {
         }
 
         let pxBusinessResultViewModel = PXBusinessResultViewModel(businessResult: businessResult, paymentData: viewModel.paymentData, amountHelper: viewModel.amountHelper, pointsAndDiscounts: viewModel.pointsAndDiscounts)
-        
-        let congratsViewController = PXNewResultViewController(viewModel: pxBusinessResultViewModel, callback: { [weak self] _, _ in
+        pxBusinessResultViewModel.setCallback(callback: { [weak self] _, _ in
             self?.finish()
         })
+        let congratsViewController = PXNewResultViewController(viewModel: pxBusinessResultViewModel)
         viewModel.pxNavigationHandler.pushViewController(viewController: congratsViewController, animated: false)
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentCongrats.swift
@@ -27,6 +27,7 @@ public final class PXPaymentCongrats: NSObject {
     
     // Receipt
     private(set) var receiptId: String?
+    private(set) var shouldShowReceipt: Bool = false
     
     /* --- Points & Discounts --- */
     // Points
@@ -152,12 +153,14 @@ extension PXPaymentCongrats {
     }
     /**
      Defines if the receipt view should be shown, in affirmative case, the receiptId must be supplied.
+     - parameter shouldShowReceipt: a boolean indicating if the receipt view is displayed.
      - parameter receiptId: ID of the receipt
      - parameter action: action when the receipt view is pressed.
      - returns: this builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func withReceipt(receiptId: String?, action: PXRemoteAction?) -> PXPaymentCongrats {
+    public func withReceipt(shouldShowReceipt: Bool, receiptId: String?, action: PXRemoteAction?) -> PXPaymentCongrats {
+        self.shouldShowReceipt = shouldShowReceipt
         self.receiptId = receiptId
         self.receiptAction = action
         return self
@@ -252,20 +255,38 @@ extension PXPaymentCongrats {
         self.secondaryAction = action
         return self
     }
-    
+
     /**
-     Custom views to be displayed.
+     Top Custom view to be displayed.
      - Parameters:
-        - important: some `UIView`
-        - top: some `UIView`
-        - bottom: some `UIView`
+        - view: some `UIView`
      - returns: this builder `PXPaymentCongrats`
     */
     @discardableResult
-    public func withCustomViews(important: UIView?, top: UIView?, bottom: UIView?) -> PXPaymentCongrats {
-        self.importantView = important
-        self.topView = top
-        self.bottomView = bottom
+    public func withTopView(_ view: UIView?)  -> PXPaymentCongrats {
+        self.topView = view
+        return self
+    }
+    /**
+     Important Custom view to be displayed.
+     - Parameters:
+        - view: some `UIView`
+     - returns: this builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func withImportantView(_ view: UIView?)  -> PXPaymentCongrats {
+        self.importantView = view
+        return self
+    }
+    /**
+     Bottom Custom view to be displayed.
+     - Parameters:
+        - view: some `UIView`
+     - returns: this builder `PXPaymentCongrats`
+    */
+    @discardableResult
+    public func withBottomView(_ view: UIView?)  -> PXPaymentCongrats {
+        self.bottomView = view
         return self
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
@@ -22,9 +22,8 @@ class PXNewResultViewController: MercadoPagoUIViewController {
 
     private var touchpointView: MLBusinessTouchpointsView?
 
-    init(viewModel: PXNewResultViewModelInterface, callback: @escaping ( _ status: PaymentResult.CongratsState, String?) -> Void, finishButtonAnimation: (() -> Void)? = nil) {
+    init(viewModel: PXNewResultViewModelInterface, finishButtonAnimation: (() -> Void)? = nil) {
         self.viewModel = viewModel
-        self.viewModel.setCallback(callback: callback)
         self.finishButtonAnimation = finishButtonAnimation
         super.init(nibName: nil, bundle: nil)
         self.shouldHideNavigationBar = true

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
@@ -16,7 +16,7 @@ class PXPaymentCongratsViewModel {
     }
     
     func launch() {
-        let vc = PXNewResultViewController(viewModel: self, callback:{_,_ in })
+        let vc = PXNewResultViewController(viewModel: self)
         paymentCongrats.navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
@@ -76,7 +76,7 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
     
     //RECEIPT
     func mustShowReceipt() -> Bool {
-        return paymentCongrats.receiptId != nil
+        return paymentCongrats.shouldShowReceipt
     }
     
     func getReceiptId() -> String? {


### PR DESCRIPTION
##  Cambios introducidos : 
Se elimina el set del callback al momento de instanciar el NewResultViewController, ahora el callback se setea directamente en el viewmodel para una posterior transformacion en payment Congrats.
