### PR TITLE
[Congrats] Use payment type enum instead raw value

### DIFF
--- a/ExampleSwift/ExampleSwift/Controllers/CongratsSelectorViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/CongratsSelectorViewController.swift
@@ -48,7 +48,7 @@ class CongratsSelectorViewController: UITableViewController, PXTrackerListener {
                                 .withDiscounts(discounts)
                                 .withCrossSelling(crosseling)
                                 .shouldShowPaymentMethod(true)
-                                .withSplitPaymenInfo(PXCongratsPaymentInfo(paidAmount: "$ 500", rawAmount: "$ 5000", paymentMethodName: "Dinero en cuenta", paymentMethodLastFourDigits: "", paymentMethodDescription: nil, paymentMethodId: "account_money", paymentMethodType: .ACCOUNT_MONEY))
+            .withSplitPaymentInfo(PXCongratsPaymentInfo(paidAmount: "$ 500", rawAmount: "$ 5000", paymentMethodName: "Dinero en cuenta", paymentMethodDescription: nil, paymentMethodId: "account_money", paymentMethodType: .ACCOUNT_MONEY, installmentsCount: 1, installmentsAmount: "$ 500", installmentsTotalAmount: "$ 500", discountName: nil))
             .withTracking(trackingProperties: PXPaymentCongratsTracking(campaingId: nil, currencyId: "ARS", paymentStatusDetail: "The payment has been approved succesfully", totalAmount: 200, paymentId: 123), trackingConfiguration: PXTrackingConfiguration(trackListener: self, flowName: "testAPP", flowDetails: nil, sessionId: nil)))
     }()
     
@@ -66,7 +66,7 @@ class CongratsSelectorViewController: UITableViewController, PXTrackerListener {
                                     self.navigationController?.popViewController(animated: true)
                                 }))
                                 .withCrossSelling([PXCrossSellingItem(title: "Gane 200 pesos por sus pagos diarios", icon: "https://mobile.mercadolibre.com/remote_resources/image/merchengine_mgm_icon_ml?density=xxhdpi&locale=es_AR", contentId: "cross_selling_mgm_ml", action: PXRemoteAction(label: "Invita a más amigos a usar la aplicación", target: "meli://invite/wallet"))])
-                                .withSplitPaymenInfo(PXCongratsPaymentInfo(paidAmount: "$ 500", rawAmount: "$ 5000", paymentMethodName: "Dinero en cuenta", paymentMethodLastFourDigits: "", paymentMethodDescription: nil, paymentMethodId: "account_money", paymentMethodType: .ACCOUNT_MONEY)))
+                                .withSplitPaymentInfo(PXCongratsPaymentInfo(paidAmount: "$ 500", rawAmount: "$ 5000", paymentMethodName: "Dinero en cuenta", paymentMethodDescription: nil, paymentMethodId: "account_money", paymentMethodType: .ACCOUNT_MONEY, installmentsCount: 1, installmentsAmount: "$ 500", installmentsTotalAmount: "$ 500", discountName: nil)))
     }()
     
     private lazy var congratsWithInstallments : CongratsType = {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultUtil.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultUtil.swift
@@ -149,14 +149,15 @@ extension PXNewResultUtil {
     
     //PAYMENT METHOD ICON
     class func getPaymentMethodIcon(paymentMethod: PXPaymentMethod) -> UIImage? {
-        return getPaymentMethodIcon(paymentTypeId: paymentMethod.paymentTypeId, paymentMethodId: paymentMethod.id, externalPaymentMethodImage: paymentMethod.externalPaymentPluginImageData as Data?)
+        guard let paymentType = PXPaymentTypes(rawValue: paymentMethod.paymentTypeId) else { return nil }
+        return getPaymentMethodIcon(paymentType: paymentType, paymentMethodId: paymentMethod.id, externalPaymentMethodImage: paymentMethod.externalPaymentPluginImageData as Data?)
     }
     
-    class func getPaymentMethodIcon(paymentTypeId: String, paymentMethodId: String, externalPaymentMethodImage: Data? = nil) -> UIImage? {
-        let defaultColor = paymentTypeId == PXPaymentTypes.ACCOUNT_MONEY.rawValue && paymentTypeId != PXPaymentTypes.PAYMENT_METHOD_PLUGIN.rawValue
+    class func getPaymentMethodIcon(paymentType: PXPaymentTypes, paymentMethodId: String, externalPaymentMethodImage: Data? = nil) -> UIImage? {
+        let defaultColor = paymentType == PXPaymentTypes.ACCOUNT_MONEY && paymentType != PXPaymentTypes.PAYMENT_METHOD_PLUGIN
         var paymentMethodImage: UIImage? =  ResourceManager.shared.getImageForPaymentMethod(withDescription: paymentMethodId, defaultColor: defaultColor)
         // Retrieve image for payment plugin or any external payment method.
-        if paymentTypeId == PXPaymentTypes.PAYMENT_METHOD_PLUGIN.rawValue, let data = externalPaymentMethodImage {
+        if paymentType == PXPaymentTypes.PAYMENT_METHOD_PLUGIN, let data = externalPaymentMethodImage {
             paymentMethodImage = UIImage(data: data)
         }
         return paymentMethodImage
@@ -225,18 +226,18 @@ extension PXNewResultUtil {
     }
     
     // PM Second String
-    class func formatPaymentMethodSecondString(paymentMethodName: String?, paymentMethodLastFourDigits lastFourDigits: String?, paymentTypeIdValue: String) -> NSAttributedString? {
-        guard let description = assembleSecondString(paymentMethodName: paymentMethodName ?? "", paymentMethodLastFourDigits: lastFourDigits, paymentTypeIdValue: paymentTypeIdValue) else { return nil }
+    class func formatPaymentMethodSecondString(paymentMethodName: String?, paymentMethodLastFourDigits lastFourDigits: String?, paymentType: PXPaymentTypes) -> NSAttributedString? {
+        guard let description = assembleSecondString(paymentMethodName: paymentMethodName ?? "", paymentMethodLastFourDigits: lastFourDigits, paymentType: paymentType) else { return nil }
         return secondStringAttributed(description)
     }
     
-    class func assembleSecondString(paymentMethodName: String, paymentMethodLastFourDigits lastFourDigits: String?, paymentTypeIdValue: String) -> String? {
+    class func assembleSecondString(paymentMethodName: String, paymentMethodLastFourDigits lastFourDigits: String?, paymentType: PXPaymentTypes) -> String? {
         var pmDescription: String = ""
-        if let paymentType = PXPaymentTypes(rawValue: paymentTypeIdValue), paymentType.isCard() {
+        if paymentType.isCard() {
             if let lastFourDigits = lastFourDigits {
                 pmDescription = paymentMethodName + " " + "terminada en".localized + " " + lastFourDigits
             }
-        } else if paymentTypeIdValue == "digital_currency" {
+        } else if paymentType == PXPaymentTypes.DIGITAL_CURRENCY {
             pmDescription = paymentMethodName
         } else {
             return nil

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
@@ -26,11 +26,11 @@ class PXPaymentCongratsViewModel {
         
         let secondString = PXNewResultUtil.formatPaymentMethodSecondString(paymentMethodName: paymentInfo.paymentMethodName,
                                                                            paymentMethodLastFourDigits: paymentInfo.paymentMethodLastFourDigits,
-                                                                           paymentTypeIdValue: paymentInfo.paymentMethodType.rawValue)
+                                                                           paymentType: paymentInfo.paymentMethodType)
         
         let thirdString = PXNewResultUtil.formatPaymentMethodThirdString(paymentInfo.paymentMethodDescription)
         
-        let icon = PXNewResultUtil.getPaymentMethodIcon(paymentTypeId: paymentInfo.paymentMethodType.rawValue, paymentMethodId: paymentInfo.paymentMethodId, externalPaymentMethodImage: paymentInfo.externalPaymentMethodImage)
+        let icon = PXNewResultUtil.getPaymentMethodIcon(paymentType: paymentInfo.paymentMethodType, paymentMethodId: paymentInfo.paymentMethodId, externalPaymentMethodImage: paymentInfo.externalPaymentMethodImage)
         
         return PXNewCustomViewData(firstString: firstString, secondString: secondString, thirdString: thirdString, icon: icon, iconURL: nil, action: nil, color: .white)
     }


### PR DESCRIPTION
##  Cambios introducidos : 
Se cambiar a user el enum PXPaymentTypes en vez del raw value en los metodos para crear el paymentInfo y posteriormente la payment method view en la congrats