### PR TITLE
Fix nil preference

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/ViewModel/MercadoPagoCheckoutViewModel.swift
@@ -130,18 +130,12 @@ internal class MercadoPagoCheckoutViewModel: NSObject, NSCopying {
             self.advancedConfig = advancedConfig
         }
         self.trackingConfig = trackingConfig
-
-        //let branchId = checkoutPreference.branchId
         mercadoPagoServices = MercadoPagoServices(publicKey: publicKey, privateKey: privateKey)
-
         super.init()
-
-        if !isPreferenceLoaded() {
+        if String.isNullOrEmpty(checkoutPreference.id), checkoutPreference.payer != nil {
             paymentData.updatePaymentDataWith(payer: checkoutPreference.getPayer())
         }
-
         PXConfiguratorManager.escConfig = PXESCConfig.createConfig()
-        
         // Create Init Flow
         createInitFlow()
     }
@@ -747,10 +741,6 @@ internal class MercadoPagoCheckoutViewModel: NSObject, NSCopying {
             PXCheckoutStore.sharedInstance.paymentDatas.append(splitAccountMoney)
         }
         PXCheckoutStore.sharedInstance.checkoutPreference = self.checkoutPreference
-    }
-
-    func isPreferenceLoaded() -> Bool {
-        return !String.isNullOrEmpty(self.checkoutPreference.id)
     }
 
     func getResult() -> PXResult? {


### PR DESCRIPTION
##  Cambios introducidos : 
- En ObjC permite enviar nil en el param `preferenceId` del `MercadoPagoCheckoutBuilder`, ocasionando un crash al querer setear el payer (flujo pref abierta) que es nil.
Si vuelven a enviar nil en preferenceId, ahora no se produce un crash y se finaliza el flujo por `PXLazyInitProtocol -> failureWithCheckout` o muestra pantalla de error si no se inicia como lazy
