### PR TITLE
[Congrats] Add whitespace in discount label

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultUtil.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultUtil.swift
@@ -210,7 +210,7 @@ extension PXNewResultUtil {
         discountString.appendWithSpace(attributedAmount)
 
         let attributedMessage = NSAttributedString(string: text, attributes: interestRateAttributes)
-        discountString.append(attributedMessage)
+        discountString.appendWithSpace(attributedMessage)
 
         return discountString
     }


### PR DESCRIPTION
##  Cambios introducidos : 
Se añade el whiteSpace faltante en el label de descuentos, entre el rawAmount y el porcentaje de descuentos  de la Congrats
![image](https://user-images.githubusercontent.com/59614028/94567285-ab008580-0241-11eb-8565-4c77e4212bdc.png)
