### PR TITLE
Se utiliza el Broadcaster de Loyalty

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
@@ -475,6 +475,10 @@ extension PXNewResultViewController {
         if let tapAction = viewModel.getPointsTapAction() {
             pointsView.addTapAction(tapAction)
         }
+        
+        let broadcaster = MLBusinessLoyaltyBroadcaster.instance as MLBusinessLoyaltyBroadcaster
+        
+        broadcaster.updateInfo(MLBusinessLoyaltyBroadcastData(level:data.getRingNumber(),percentage:data.getRingPercentage() ,primaryColor:data.getRingHexaColor()))
 
         return pointsView
     }


### PR DESCRIPTION
##  Cambios introducidos : 

- [Se alinea con lo desarrollado en Android](https://github.com/mercadopago/px-android/pull/2393)

## Motivación y Contexto
- Se utilizará en los distintos componentes de Loyalty de la aplicación para mantenerlos siempre actualizados con la información de los puntos y nivel de user.

- Soluciona algunos casos de inconsistencia donde al user en la congrats se le muestra su nuevo nivel (o X cantidad de puntos) y en otros componentes que no se actualizaron con esta información se muestra información del nivel antiguo.

## Descripción
- Se agrega el broadcaster que envía la nueva información de Loyalty a los diferentes integradores mediante el bus de LoyaltyRing

## Cómo probarlo
- Simplemente hacer cualquier pago que llegue a una congrats de Mercado Pago, por ejemplo "Pago con QR" que muestra los puntos obtenidos por Loyalty

## Tipo de cambio (para el release manager)
- Es limpio para todos los integradores y MP
