### PR TITLE
Chore/px network layer

### DIFF
--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -15,10 +15,10 @@ class ViewController: UIViewController {
     private var checkout: MercadoPagoCheckout?
     
     // Collector Public Key
-    private var publicKey : String = "TEST-e28d5a35-dece-45c9-9618-e8cc5dec6c42"
+    private var publicKey : String = ""
     
     // Payer private key
-    private var privateKey : String = "TEST-7215456036166479-101915-223c2540d9126044887a840cfae544a9-660760647"
+    private var privateKey : String = ""
     
     // Preference ID
     private var preferenceId : String = "656525290-d1ccf64a-3eb7-44b7-b7f6-bf29ed92ce1a"

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -15,10 +15,10 @@ class ViewController: UIViewController {
     private var checkout: MercadoPagoCheckout?
     
     // Collector Public Key
-    private var publicKey : String = ""
+    private var publicKey : String = "TEST-e28d5a35-dece-45c9-9618-e8cc5dec6c42"
     
     // Payer private key
-    private var privateKey : String = ""
+    private var privateKey : String = "TEST-7169122440478352-062213-d23fa9fb38e4b3e94feee29864f0fae2-443064294"
     
     // Preference ID
     private var preferenceId : String = "656525290-7bda964b-26d9-4352-a04c-1b04801627ee"

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -18,10 +18,10 @@ class ViewController: UIViewController {
     private var publicKey : String = "TEST-e28d5a35-dece-45c9-9618-e8cc5dec6c42"
     
     // Payer private key
-    private var privateKey : String = "TEST-7169122440478352-062213-d23fa9fb38e4b3e94feee29864f0fae2-443064294"
+    private var privateKey : String = "TEST-7215456036166479-101915-223c2540d9126044887a840cfae544a9-660760647"
     
     // Preference ID
-    private var preferenceId : String = "656525290-7bda964b-26d9-4352-a04c-1b04801627ee"
+    private var preferenceId : String = "656525290-d1ccf64a-3eb7-44b7-b7f6-bf29ed92ce1a"
     
     @IBAction func initDefault(_ sender: Any) {
 //         runMercadoPagoCheckout()

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -15,13 +15,13 @@ class ViewController: UIViewController {
     private var checkout: MercadoPagoCheckout?
     
     // Collector Public Key
-    private var publicKey : String = "TEST-e28d5a35-dece-45c9-9618-e8cc5dec6c42"
+    private var publicKey : String = ""
     
     // Payer private key
-    private var privateKey : String = "TEST-7215456036166479-101915-223c2540d9126044887a840cfae544a9-660760647"
+    private var privateKey : String = ""
     
     // Preference ID
-    private var preferenceId : String = "656525290-d1ccf64a-3eb7-44b7-b7f6-bf29ed92ce1a"
+    private var preferenceId : String = "
     
     @IBAction func initDefault(_ sender: Any) {
 //         runMercadoPagoCheckout()

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
     private var privateKey : String = ""
     
     // Preference ID
-    private var preferenceId : String = "656525290-d1ccf64a-3eb7-44b7-b7f6-bf29ed92ce1a"
+    private var preferenceId : String = ""
     
     @IBAction func initDefault(_ sender: Any) {
 //         runMercadoPagoCheckout()

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
     private var privateKey : String = ""
     
     // Preference ID
-    private var preferenceId : String = "
+    private var preferenceId : String = ""
     
     @IBAction func initDefault(_ sender: Any) {
 //         runMercadoPagoCheckout()

--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -15,13 +15,13 @@ class ViewController: UIViewController {
     private var checkout: MercadoPagoCheckout?
     
     // Collector Public Key
-    private var publicKey : String = ""
+    private var publicKey : String = "TEST-e28d5a35-dece-45c9-9618-e8cc5dec6c42"
     
     // Payer private key
-    private var privateKey : String = ""
+    private var privateKey : String = "TEST-7215456036166479-101915-223c2540d9126044887a840cfae544a9-660760647"
     
     // Preference ID
-    private var preferenceId : String = ""
+    private var preferenceId : String = "656525290-d1ccf64a-3eb7-44b7-b7f6-bf29ed92ce1a"
     
     @IBAction func initDefault(_ sender: Any) {
 //         runMercadoPagoCheckout()

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+PaymentFlowHandler.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+PaymentFlowHandler.swift
@@ -13,10 +13,12 @@ extension MercadoPagoCheckout: PXPaymentResultHandlerProtocol {
     func finishPaymentFlow(error: MPSDKError) {
         let lastViewController = viewModel.pxNavigationHandler.navigationController.viewControllers.last
         if lastViewController is PXNewResultViewController || lastViewController is PXSecurityCodeViewController {
-            if let newResultViewController = lastViewController as? PXNewResultViewController {
-                newResultViewController.progressButtonAnimationTimeOut()
-            } else if let securityCodeVC = lastViewController as? PXSecurityCodeViewController {
-                resetButtonAndCleanToken(securityCodeVC: securityCodeVC)
+            DispatchQueue.main.async {
+                if let newResultViewController = lastViewController as? PXNewResultViewController {
+                    newResultViewController.progressButtonAnimationTimeOut()
+                } else if let securityCodeVC = lastViewController as? PXSecurityCodeViewController {
+                    resetButtonAndCleanToken(securityCodeVC: securityCodeVC)
+                }
             }
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+PaymentFlowHandler.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+PaymentFlowHandler.swift
@@ -17,7 +17,7 @@ extension MercadoPagoCheckout: PXPaymentResultHandlerProtocol {
                 if let newResultViewController = lastViewController as? PXNewResultViewController {
                     newResultViewController.progressButtonAnimationTimeOut()
                 } else if let securityCodeVC = lastViewController as? PXSecurityCodeViewController {
-                    resetButtonAndCleanToken(securityCodeVC: securityCodeVC)
+                    self.resetButtonAndCleanToken(securityCodeVC: securityCodeVC)
                 }
             }
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/MercadoPagoCheckout.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/MercadoPagoCheckout.swift
@@ -147,27 +147,29 @@ extension MercadoPagoCheckout {
     }
 
     internal func executeNextStep() {
-        switch self.viewModel.nextStep() {
-        case .START :
-            self.initialize()
-        case .SERVICE_CREATE_CARD_TOKEN:
-            self.createCardToken()
-        case .SCREEN_SECURITY_CODE:
-            self.showSecurityCodeScreen()
-        case .SERVICE_POST_PAYMENT:
-            self.createPayment()
-        case .SERVICE_GET_REMEDY:
-            self.getRemedy()
-        case .SCREEN_PAYMENT_RESULT:
-            self.showPaymentResultScreen()
-        case .ACTION_FINISH:
-            self.finish()
-        case .SCREEN_ERROR:
-            self.showErrorScreen()
-        case .SCREEN_PAYMENT_METHOD_PLUGIN_CONFIG:
-            self.showPaymentMethodPluginConfigScreen()
-        case .FLOW_ONE_TAP:
-            self.startOneTapFlow()
+        DispatchQueue.main.async {
+            switch self.viewModel.nextStep() {
+            case .START :
+                self.initialize()
+            case .SERVICE_CREATE_CARD_TOKEN:
+                self.createCardToken()
+            case .SCREEN_SECURITY_CODE:
+                self.showSecurityCodeScreen()
+            case .SERVICE_POST_PAYMENT:
+                self.createPayment()
+            case .SERVICE_GET_REMEDY:
+                self.getRemedy()
+            case .SCREEN_PAYMENT_RESULT:
+                self.showPaymentResultScreen()
+            case .ACTION_FINISH:
+                self.finish()
+            case .SCREEN_ERROR:
+                self.showErrorScreen()
+            case .SCREEN_PAYMENT_METHOD_PLUGIN_CONFIG:
+                self.showPaymentMethodPluginConfigScreen()
+            case .FLOW_ONE_TAP:
+                self.startOneTapFlow()
+            }
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/PXNavigationHandler.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/PXNavigationHandler.swift
@@ -66,13 +66,16 @@ internal class PXNavigationHandler: NSObject {
     func dismissLoading(animated: Bool = true, finishCallback:(() -> Void)? = nil) {
         self.countLoadings = 0
         if self.currentLoadingView != nil {
-            self.currentLoadingView?.modalTransitionStyle = .crossDissolve
-            self.currentLoadingView!.dismiss(animated: animated, completion: {
-                self.currentLoadingView = nil
-                if let callback = finishCallback {
-                    callback()
-                }
-            })
+            DispatchQueue.main.async {
+                self.currentLoadingView?.modalTransitionStyle = .crossDissolve
+                self.currentLoadingView!.dismiss(animated: animated, completion: {
+                    self.currentLoadingView = nil
+                    if let callback = finishCallback {
+                        callback()
+                    }
+                })
+            }
+            
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/InitFlow+Services.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/InitFlow+Services.swift
@@ -32,10 +32,10 @@ extension InitFlow {
 
         if let prefId = pref.id, prefId.isNotEmpty {
             // CLOSED PREFERENCE
-            serviceAdapter.getClosedPrefInitSearch(preferenceId: prefId, cardsWithEsc: cardIdsWithEsc, splitEnabled: splitEnabled, discountParamsConfiguration: discountParamsConfiguration, flow: flowName, charges: charges, headers: headers, callback: callback(_:), failure: failure(_:))
+            serviceAdapter.getClosedPrefInitSearch(preferenceId: prefId, cardsWithEsc: cardIdsWithEsc, oneTapEnabled: true, splitEnabled: splitEnabled, discountParamsConfiguration: discountParamsConfiguration, flow: flowName, charges: charges, headers: headers, callback: callback(_:), failure: failure(_:))
         } else {
             // OPEN PREFERENCE
-            serviceAdapter.getOpenPrefInitSearch(pref: pref, cardsWithEsc: cardIdsWithEsc, splitEnabled: splitEnabled, discountParamsConfiguration: discountParamsConfiguration, flow: flowName, charges: charges, headers: headers, callback: callback(_:), failure: failure(_:))
+            serviceAdapter.getOpenPrefInitSearch(pref: pref, cardsWithEsc: cardIdsWithEsc, oneTapEnabled: true, splitEnabled: splitEnabled, discountParamsConfiguration: discountParamsConfiguration, flow: flowName, charges: charges, headers: headers, callback: callback(_:), failure: failure(_:))
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/InitFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/InitFlow.swift
@@ -43,14 +43,14 @@ extension InitFlow: PXFlow {
 
     func executeNextStep() {
         DispatchQueue.main.async {
-            let nextStep = initFlowModel.nextStep()
+            let nextStep = self.initFlowModel.nextStep()
             switch nextStep {
             case .SERVICE_GET_INIT:
-                getInitSearch()
+                self.getInitSearch()
             case .FINISH:
-                finishFlow()
+                self.finishFlow()
             case .ERROR:
-                cancelFlow()
+                self.cancelFlow()
             }
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/InitFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/InitFlow/InitFlow.swift
@@ -42,14 +42,16 @@ extension InitFlow: PXFlow {
     }
 
     func executeNextStep() {
-        let nextStep = initFlowModel.nextStep()
-        switch nextStep {
-        case .SERVICE_GET_INIT:
-            getInitSearch()
-        case .FINISH:
-            finishFlow()
-        case .ERROR:
-            cancelFlow()
+        DispatchQueue.main.async {
+            let nextStep = initFlowModel.nextStep()
+            switch nextStep {
+            case .SERVICE_GET_INIT:
+                getInitSearch()
+            case .FINISH:
+                finishFlow()
+            case .ERROR:
+                cancelFlow()
+            }
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+PaymentFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+PaymentFlow.swift
@@ -39,13 +39,13 @@ extension OneTapFlow {
 extension OneTapFlow: PXPaymentResultHandlerProtocol {
     func finishPaymentFlow(error: MPSDKError) {
         DispatchQueue.main.async {
-            let lastViewController = pxNavigationHandler.navigationController.viewControllers.last
+            let lastViewController = self.pxNavigationHandler.navigationController.viewControllers.last
             if let oneTapViewController = lastViewController as? PXOneTapViewController {
-                dismissLoading(finishCallback: {
+                self.dismissLoading(finishCallback: {
                     oneTapViewController.resetButton(error: error)
                 })
             } else if let securityCodeVC = lastViewController as? PXSecurityCodeViewController {
-                dismissLoading(finishCallback: { [weak self] in
+                self.dismissLoading(finishCallback: { [weak self] in
                     self?.resetButtonAndCleanToken(securityCodeVC: securityCodeVC, error: error)
                 })
             }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+PaymentFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+PaymentFlow.swift
@@ -38,15 +38,17 @@ extension OneTapFlow {
 
 extension OneTapFlow: PXPaymentResultHandlerProtocol {
     func finishPaymentFlow(error: MPSDKError) {
-        let lastViewController = pxNavigationHandler.navigationController.viewControllers.last
-        if let oneTapViewController = lastViewController as? PXOneTapViewController {
-            dismissLoading(finishCallback: { 
-                oneTapViewController.resetButton(error: error)
-            })
-        } else if let securityCodeVC = lastViewController as? PXSecurityCodeViewController {
-            dismissLoading(finishCallback: { [weak self] in
-                self?.resetButtonAndCleanToken(securityCodeVC: securityCodeVC, error: error)
-            })
+        DispatchQueue.main.async {
+            let lastViewController = pxNavigationHandler.navigationController.viewControllers.last
+            if let oneTapViewController = lastViewController as? PXOneTapViewController {
+                dismissLoading(finishCallback: {
+                    oneTapViewController.resetButton(error: error)
+                })
+            } else if let securityCodeVC = lastViewController as? PXSecurityCodeViewController {
+                dismissLoading(finishCallback: { [weak self] in
+                    self?.resetButtonAndCleanToken(securityCodeVC: securityCodeVC, error: error)
+                })
+            }
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow.swift
@@ -45,23 +45,24 @@ final class OneTapFlow: NSObject, PXFlow {
     }
 
     func executeNextStep() {
-        switch self.model.nextStep() {
-        case .screenOneTap:
-            self.showOneTapViewController()
-        case .screenSecurityCode:
-            self.showSecurityCodeScreen()
-        case .serviceCreateESCCardToken:
-            self.getTokenizationService().createCardToken()
-        case .serviceCreateWebPayCardToken:
-            self.getTokenizationService().createCardToken(securityCode: "")
-        case .screenKyC:
-            self.showKyCScreen()
-        case .payment:
-            self.startPaymentFlow()
-        case .finish:
-            self.finishFlow()
+        DispatchQueue.main.async {
+            switch self.model.nextStep() {
+            case .screenOneTap:
+                self.showOneTapViewController()
+            case .screenSecurityCode:
+                self.showSecurityCodeScreen()
+            case .serviceCreateESCCardToken:
+                self.getTokenizationService().createCardToken()
+            case .serviceCreateWebPayCardToken:
+                self.getTokenizationService().createCardToken(securityCode: "")
+            case .screenKyC:
+                self.showKyCScreen()
+            case .payment:
+                self.startPaymentFlow()
+            case .finish:
+                self.finishFlow()
+            }
         }
-        print("")
     }
 
     func refreshInitFlow(cardId: String) {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow.swift
@@ -52,19 +52,21 @@ internal final class PXPaymentFlow: NSObject, PXFlow {
     }
 
     func executeNextStep() {
-        switch self.model.nextStep() {
-        case .createDefaultPayment:
-            createPayment()
-        case .createPaymentPlugin:
-            createPaymentWithPlugin(plugin: model.paymentPlugin)
-        case .createPaymentPluginScreen:
-            showPaymentProcessor(paymentProcessor: model.paymentPlugin)
-        case .getPointsAndDiscounts:
-            getPointsAndDiscounts()
-        case .getInstructions:
-            getInstructions()
-        case .finish:
-            finishFlow()
+        DispatchQueue.main.async {
+            switch self.model.nextStep() {
+            case .createDefaultPayment:
+                self.createPayment()
+            case .createPaymentPlugin:
+                self.createPaymentWithPlugin(plugin: self.model.paymentPlugin)
+            case .createPaymentPluginScreen:
+                self.showPaymentProcessor(paymentProcessor: self.model.paymentPlugin)
+            case .getPointsAndDiscounts:
+                self.getPointsAndDiscounts()
+            case .getInstructions:
+                self.getInstructions()
+            case .finish:
+                self.finishFlow()
+            }
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomParametersModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomParametersModel.swift
@@ -9,8 +9,8 @@ struct CustomParametersModel {
     let paymentMethodIds: String
     let paymentiDS: String
     let ifpe: String
-    let prefId: String
-    let campaignId: String
-    let flowName: String
-    let merchantOrderId: String
+    let prefId: String?
+    let campaignId: String?
+    let flowName: String?
+    let merchantOrderId: String?
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomParametersModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomParametersModel.swift
@@ -1,0 +1,16 @@
+//
+//  CustomParametersModel.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 08/02/21.
+//
+
+struct CustomParametersModel {
+    let paymentMethodIds: String
+    let paymentiDS: String
+    let ifpe: String
+    let prefId: String
+    let campaignId: String
+    let flowName: String
+    let merchantOrderId: String
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomParametersModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomParametersModel.swift
@@ -7,7 +7,7 @@
 
 struct CustomParametersModel {
     let paymentMethodIds: String
-    let paymentiDS: String
+    let paymentId: String
     let ifpe: String
     let prefId: String?
     let campaignId: String?

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
@@ -1,0 +1,75 @@
+//
+//  CustomRequestInfos.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 08/02/21.
+//
+
+enum CustomRequestInfos {
+    case resetESCCap(privateKey: String)
+    case getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel)
+    case createPayment(privateKey: String?, publicKey: String, data: Data?, header: [String : String]?)
+}
+
+extension CustomRequestInfos: RequestInfos {
+    var endpoint: String {
+        switch self {
+        case .resetESCCap(_): return "px_mobile/v1/esc_cap"
+        case .getPointsAndDiscounts(_, _): return "px_mobile/congrats"
+        case .createPayment(_, _, _, _): return "px_mobile/payments"
+        }
+    }
+    
+    var method: HTTPMethodType {
+        switch self {
+        case .resetESCCap(_): return .delete
+        case .getPointsAndDiscounts(_, _): return .get
+        case .createPayment(_, _, _, _): return .post
+        }
+    }
+    
+    var parameters: [String : Any]? {
+        switch self {
+        case .resetESCCap(let privateKey): return ["access_token" : privateKey]
+        case .getPointsAndDiscounts(_, let parameters): return [
+            "payment_methods_ids" : parameters.paymentMethodIds,
+            "payment_ids" : parameters.paymentiDS,
+            "api_version" : "2.0",
+            "ifpe" : parameters.ifpe,
+            "pref_id" : parameters.prefId,
+            "campaign_id" : parameters.campaignId,
+            "flow_name" : parameters.flowName,
+            "merchant_order_id" : parameters.merchantOrderId,
+            "platform" : MLBusinessAppDataService().getAppIdentifier().rawValue
+        ]
+        case .createPayment(let privateKey, let publicKey, _, _):
+            if let token = privateKey {
+                return [
+                    "access_token" : token,
+                    "public_key" : publicKey,
+                    "api_version" : "2.0"
+                ]
+            } else {
+                return [
+                    "public_key" : publicKey,
+                    "api_version" : "2.0"
+                ]
+            }
+        }
+    }
+    
+    var headers: [String : String]? {
+        switch self {
+        case .resetESCCap(_), .getPointsAndDiscounts(_, _): return nil
+        case .createPayment(_, _, _, let header): return header
+        }
+    }
+    
+    var body: Data? {
+        switch self {
+        case .resetESCCap(_): return nil
+        case .getPointsAndDiscounts(let data, _): return data
+        case .createPayment(_, _, let data, _): return data
+        }
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
@@ -31,17 +31,7 @@ extension CustomRequestInfos: RequestInfos {
     var parameters: [String : Any]? {
         switch self {
         case .resetESCCap(_, let privateKey): if let privateKey = privateKey { return ["access_token" : privateKey] } else { return nil }
-        case .getPointsAndDiscounts(_, let parameters): return [
-            "payment_methods_ids" : parameters.paymentMethodIds,
-            "payment_ids" : parameters.paymentiDS,
-            "api_version" : "2.0",
-            "ifpe" : parameters.ifpe,
-            "pref_id" : parameters.prefId,
-            "campaign_id" : parameters.campaignId,
-            "flow_name" : parameters.flowName,
-            "merchant_order_id" : parameters.merchantOrderId,
-            "platform" : MLBusinessAppDataService().getAppIdentifier().rawValue
-        ]
+        case .getPointsAndDiscounts(_, let parameters): return organizeParameters(parameters: parameters)
         case .createPayment(let privateKey, let publicKey, _, _):
             if let token = privateKey {
                 return [
@@ -60,16 +50,51 @@ extension CustomRequestInfos: RequestInfos {
     
     var headers: [String : String]? {
         switch self {
-        case .resetESCCap(_), .getPointsAndDiscounts(_, _): return nil
+        case .resetESCCap(_, _), .getPointsAndDiscounts(_, _): return nil
         case .createPayment(_, _, _, let header): return header
         }
     }
     
     var body: Data? {
         switch self {
-        case .resetESCCap(_): return nil
+        case .resetESCCap(_, _): return nil
         case .getPointsAndDiscounts(let data, _): return data
         case .createPayment(_, _, let data, _): return data
         }
+    }
+}
+
+extension CustomRequestInfos {
+    func organizeParameters(parameters: CustomParametersModel) -> [String : Any] {
+        var filteredParameters: [String : Any] = [:]
+        
+        if parameters.paymentMethodIds != "" {
+            filteredParameters.updateValue(parameters.paymentMethodIds, forKey: "payment_methods_ids")
+        }
+        
+        if parameters.paymentiDS != "" {
+            filteredParameters.updateValue(parameters.paymentiDS, forKey: "payment_ids")
+        }
+        
+        if let prefId = parameters.prefId {
+            filteredParameters.updateValue(prefId, forKey: "pref_id")
+        }
+        
+        if let campaignId = parameters.campaignId {
+            filteredParameters.updateValue(campaignId, forKey: "campaign_id")
+        }
+        
+        if let flowName = parameters.flowName {
+            filteredParameters.updateValue(flowName, forKey: "flow_name")
+        }
+        
+        if let merchantOrderId = parameters.merchantOrderId {
+            filteredParameters.updateValue(merchantOrderId, forKey: "merchant_order_id")
+        }
+        
+        filteredParameters.updateValue("2.0", forKey: "api_version")
+        filteredParameters.updateValue(parameters.ifpe, forKey: "ifpe")
+        
+        return filteredParameters
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
@@ -6,7 +6,7 @@
 //
 
 enum CustomRequestInfos {
-    case resetESCCap(privateKey: String)
+    case resetESCCap(cardId: String, privateKey: String?)
     case getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel)
     case createPayment(privateKey: String?, publicKey: String, data: Data?, header: [String : String]?)
 }
@@ -14,7 +14,7 @@ enum CustomRequestInfos {
 extension CustomRequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .resetESCCap(_): return "px_mobile/v1/esc_cap"
+        case .resetESCCap(let cardId, _): return "px_mobile/v1/esc_cap/\(cardId)"
         case .getPointsAndDiscounts(_, _): return "px_mobile/congrats"
         case .createPayment(_, _, _, _): return "px_mobile/payments"
         }
@@ -22,7 +22,7 @@ extension CustomRequestInfos: RequestInfos {
     
     var method: HTTPMethodType {
         switch self {
-        case .resetESCCap(_): return .delete
+        case .resetESCCap(_, _): return .delete
         case .getPointsAndDiscounts(_, _): return .get
         case .createPayment(_, _, _, _): return .post
         }
@@ -30,7 +30,7 @@ extension CustomRequestInfos: RequestInfos {
     
     var parameters: [String : Any]? {
         switch self {
-        case .resetESCCap(let privateKey): return ["access_token" : privateKey]
+        case .resetESCCap(_, let privateKey): if let privateKey = privateKey { return ["access_token" : privateKey] } else { return nil }
         case .getPointsAndDiscounts(_, let parameters): return [
             "payment_methods_ids" : parameters.paymentMethodIds,
             "payment_ids" : parameters.paymentiDS,

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
@@ -16,7 +16,7 @@ extension CustomRequestInfos: RequestInfos {
         switch self {
         case .resetESCCap(let cardId, _): return "px_mobile/v1/esc_cap/\(cardId)"
         case .getCongrats(_, _): return "px_mobile/congrats"
-        case .createPayment(_, _, _, _): return "px_mobile/payments"
+        case .createPayment(_, _, _, _): return "v1/px_mobile/payments"
         }
     }
     
@@ -25,6 +25,13 @@ extension CustomRequestInfos: RequestInfos {
         case .resetESCCap(_, _): return .delete
         case .getCongrats(_, _): return .get
         case .createPayment(_, _, _, _): return .post
+        }
+    }
+    
+    var shouldSetEnvironment: Bool {
+        switch self {
+        case .resetESCCap(_, _), .getCongrats(_, _): return true
+        case .createPayment(_, _, _, _): return false
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomRequestInfos.swift
@@ -7,7 +7,7 @@
 
 enum CustomRequestInfos {
     case resetESCCap(cardId: String, privateKey: String?)
-    case getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel)
+    case getCongrats(data: Data?, congratsModel: CustomParametersModel)
     case createPayment(privateKey: String?, publicKey: String, data: Data?, header: [String : String]?)
 }
 
@@ -15,7 +15,7 @@ extension CustomRequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
         case .resetESCCap(let cardId, _): return "px_mobile/v1/esc_cap/\(cardId)"
-        case .getPointsAndDiscounts(_, _): return "px_mobile/congrats"
+        case .getCongrats(_, _): return "px_mobile/congrats"
         case .createPayment(_, _, _, _): return "px_mobile/payments"
         }
     }
@@ -23,7 +23,7 @@ extension CustomRequestInfos: RequestInfos {
     var method: HTTPMethodType {
         switch self {
         case .resetESCCap(_, _): return .delete
-        case .getPointsAndDiscounts(_, _): return .get
+        case .getCongrats(_, _): return .get
         case .createPayment(_, _, _, _): return .post
         }
     }
@@ -31,7 +31,7 @@ extension CustomRequestInfos: RequestInfos {
     var parameters: [String : Any]? {
         switch self {
         case .resetESCCap(_, let privateKey): if let privateKey = privateKey { return ["access_token" : privateKey] } else { return nil }
-        case .getPointsAndDiscounts(_, let parameters): return organizeParameters(parameters: parameters)
+        case .getCongrats(_, let parameters): return organizeParameters(parameters: parameters)
         case .createPayment(let privateKey, let publicKey, _, _):
             if let token = privateKey {
                 return [
@@ -50,7 +50,7 @@ extension CustomRequestInfos: RequestInfos {
     
     var headers: [String : String]? {
         switch self {
-        case .resetESCCap(_, _), .getPointsAndDiscounts(_, _): return nil
+        case .resetESCCap(_, _), .getCongrats(_, _): return nil
         case .createPayment(_, _, _, let header): return header
         }
     }
@@ -58,7 +58,7 @@ extension CustomRequestInfos: RequestInfos {
     var body: Data? {
         switch self {
         case .resetESCCap(_, _): return nil
-        case .getPointsAndDiscounts(let data, _): return data
+        case .getCongrats(let data, _): return data
         case .createPayment(_, _, let data, _): return data
         }
     }
@@ -72,8 +72,8 @@ extension CustomRequestInfos {
             filteredParameters.updateValue(parameters.paymentMethodIds, forKey: "payment_methods_ids")
         }
         
-        if parameters.paymentiDS != "" {
-            filteredParameters.updateValue(parameters.paymentiDS, forKey: "payment_ids")
+        if parameters.paymentId != "" {
+            filteredParameters.updateValue(parameters.paymentId, forKey: "payment_ids")
         }
         
         if let prefId = parameters.prefId {

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomServices.swift
@@ -22,7 +22,7 @@ final class CustomServicesImpl: CustomServices {
     
     // MARK: - Public methods
     func getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel, response: @escaping (PXPointsAndDiscounts?, Void?) -> Void) {
-        service.requestObject(model: PXPointsAndDiscounts.self, .getPointsAndDiscounts(data: data, parameters: parameters)) { model, error in
+        service.requestObject(model: PXPointsAndDiscounts.self, .getCongrats(data: data, congratsModel: parameters)) { model, error in
             if let _ = error {
                 response(nil, ())
             } else {
@@ -32,9 +32,13 @@ final class CustomServicesImpl: CustomServices {
     }
     
     func resetESCCap(cardId:String, privateKey: String?, response: @escaping (Void?, PXError?) -> Void) {
+        guard let privateKey = privateKey else {
+            response(nil, PXError(domain: ApiDomain.RESET_ESC_CAP, code: ErrorTypes.API_UNKNOWN_ERROR, userInfo: ["message": "Missing key"]))
+            return
+        }
         service.requestData(target: .resetESCCap(cardId: cardId, privateKey: privateKey)) { _, error in
-            if let _ = error {
-                response(nil, PXError(domain: ApiDomain.RESET_ESC_CAP, code: ErrorTypes.NO_INTERNET_ERROR, userInfo: ["message": "Response cannot be decoded"]))
+            if let error = error {
+                response(nil, PXError(domain: ApiDomain.RESET_ESC_CAP, code: ErrorTypes.NO_INTERNET_ERROR, userInfo: ["message": error.localizedDescription]))
             } else {
                 response((), nil)
             }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomServices.swift
@@ -7,7 +7,7 @@
 
 protocol CustomServices {
     func getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel, response: @escaping (PXPointsAndDiscounts?, Void?) -> Void)
-    func resetESCCap(privateKey: String, response: @escaping (Void?, PXError?) -> Void)
+    func resetESCCap(cardId:String, privateKey: String?, response: @escaping (Void?, PXError?) -> Void)
     func createPayment(privateKey: String?, publicKey: String, data: Data?, header: [String : String]?, response: @escaping (PXPayment?, PXError?) -> Void)
 }
 
@@ -31,8 +31,8 @@ final class CustomServicesImpl: CustomServices {
         }
     }
     
-    func resetESCCap(privateKey: String, response: @escaping (Void?, PXError?) -> Void) {
-        service.requestData(target: .resetESCCap(privateKey: privateKey)) { _, error in
+    func resetESCCap(cardId:String, privateKey: String?, response: @escaping (Void?, PXError?) -> Void) {
+        service.requestData(target: .resetESCCap(cardId: cardId, privateKey: privateKey)) { _, error in
             if let _ = error {
                 response(nil, PXError(domain: ApiDomain.RESET_ESC_CAP, code: ErrorTypes.NO_INTERNET_ERROR, userInfo: ["message": "Response cannot be decoded"]))
             } else {

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Custom/CustomServices.swift
@@ -1,0 +1,53 @@
+//
+//  CustomServices.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 08/02/21.
+//
+
+protocol CustomServices {
+    func getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel, response: @escaping (PXPointsAndDiscounts?, Void?) -> Void)
+    func resetESCCap(privateKey: String, response: @escaping (Void?, PXError?) -> Void)
+    func createPayment(privateKey: String?, publicKey: String, data: Data?, header: [String : String]?, response: @escaping (PXPayment?, PXError?) -> Void)
+}
+
+final class CustomServicesImpl: CustomServices {
+    // MARK: - private properties
+    private let service: Requesting<CustomRequestInfos>
+    
+    // MARK: - Initialization
+    init(service: Requesting<CustomRequestInfos> = Requesting<CustomRequestInfos>()) {
+        self.service = service
+    }
+    
+    // MARK: - Public methods
+    func getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel, response: @escaping (PXPointsAndDiscounts?, Void?) -> Void) {
+        service.requestObject(model: PXPointsAndDiscounts.self, .getPointsAndDiscounts(data: data, parameters: parameters)) { model, error in
+            if let _ = error {
+                response(nil, ())
+            } else {
+                response(model, nil)
+            }
+        }
+    }
+    
+    func resetESCCap(privateKey: String, response: @escaping (Void?, PXError?) -> Void) {
+        service.requestData(target: .resetESCCap(privateKey: privateKey)) { _, error in
+            if let _ = error {
+                response(nil, PXError(domain: ApiDomain.RESET_ESC_CAP, code: ErrorTypes.NO_INTERNET_ERROR, userInfo: ["message": "Response cannot be decoded"]))
+            } else {
+                response((), nil)
+            }
+        }
+    }
+    
+    func createPayment(privateKey: String?, publicKey: String, data: Data?, header: [String : String]?, response: @escaping (PXPayment?, PXError?) -> Void) {
+        service.requestObject(model: PXPayment.self, .createPayment(privateKey: privateKey, publicKey: publicKey, data: data, header: header)) { payment, error in
+            if let _ = error {
+                response(nil, PXError(domain: ApiDomain.CREATE_PAYMENT, code: ErrorTypes.API_UNKNOWN_ERROR, userInfo: ["message": "PAYMENT_ERROR"]))
+            } else {
+                response(payment, nil)
+            }
+        }
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
@@ -16,7 +16,7 @@ extension GatewayRequestInfos: RequestInfos {
         switch self {
         case .getToken(_, _, _): return "v1/card_tokens"
         case .cloneToken(let tokenId, _): return "\(tokenId)/clone"
-        case .validateToken(let tokenId, _, _): return "tokenId"
+        case .validateToken(let tokenId, _, _): return "\(tokenId)"
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
@@ -6,7 +6,7 @@
 //
 
 enum GatewayRequestInfos {
-    case getToken(String?, String, Data)
+    case getToken(String?, String, Data?)
     case cloneToken(String, String)
     case validateToken(String, String, Data)
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
@@ -1,0 +1,60 @@
+//
+//  GatewayRequestInfos.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 06/02/21.
+//
+
+enum GatewayRequestInfos {
+    case getToken(String?, String, Data)
+    case cloneToken(String, String)
+    case validateToken(String, String, Data)
+}
+
+extension GatewayRequestInfos: RequestInfos {
+    var endpoint: String {
+        switch self {
+        case .getToken(_, _, _): return "v1/card_tokens"
+        case .cloneToken(let tokenId, _): return "\(tokenId)/clone"
+        case .validateToken(let tokenId, _, _): return "tokenId"
+        }
+    }
+    
+    var method: HTTPMethodType {
+        switch self {
+        case .getToken(_, _, _), .cloneToken(_, _): return .post
+        case .validateToken(_, _, _): return .put
+        }
+    }
+    
+
+    var parameters: [String : Any]? {
+        switch self {
+        case .getToken(let accessToken, let publicKey, _):
+            if let token = accessToken {
+                return [
+                    "access_token" : token,
+                    "public_key" : publicKey
+                ]
+            } else {
+                return [ "public_key" : publicKey ]
+            }
+        case .cloneToken(_, let publicKey), .validateToken(_, let publicKey, _): return [ "public_key" : publicKey ]
+        }
+    }
+    
+    
+    var headers: [String : String]? {
+        switch self {
+        case .getToken(_, _, _), .cloneToken(_, _), .validateToken(_, _, _): return nil
+        }
+    }
+    
+    var body: Data? {
+        switch self {
+        case .getToken(_, _, let data): return data
+        case .cloneToken(_, _): return nil
+        case  .validateToken(_, _, let data): return data
+        }
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
@@ -15,7 +15,7 @@ extension GatewayRequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
         case .getToken(_, _, _): return "v1/card_tokens"
-        case .cloneToken(let tokenId, _): return "\(tokenId)/clone"
+        case .cloneToken(let tokenId, _): return "v1/card_tokens\(tokenId)/clone"
         case .validateToken(let tokenId, _, _): return "\(tokenId)"
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayRequestInfos.swift
@@ -27,6 +27,13 @@ extension GatewayRequestInfos: RequestInfos {
         }
     }
     
+    var shouldSetEnvironment: Bool {
+        switch self {
+        case .getToken(_, _, _): return false
+        case .validateToken(_, _, _), .cloneToken(_, _): return true
+        }
+    }
+    
 
     var parameters: [String : Any]? {
         switch self {

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayServices.swift
@@ -1,0 +1,83 @@
+//
+//  GatewayServices.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 06/02/21.
+//
+
+protocol GatewayServices {
+    func getToken(accessToken: String?,
+                  publicKey: String,
+                  cardTokenJSON: Data,
+                  completion: @escaping (Data?, PXError?) -> Void)
+    
+    func cloneToken(tokeniD: String, publicKey: String, securityCode: String, completion: @escaping (Data?, PXError?) -> Void)
+    func validateToken(tokenId: String, publicKey: String, body: Data, completion: @escaping (Data?, PXError?) -> Void)
+}
+
+final class GatewayServicesImpl: GatewayServices {
+    // MARK: - Private properties
+    private let service: Requesting<GatewayRequestInfos>
+    
+    // MARK: - Initialization
+    init(service: Requesting<GatewayRequestInfos> = Requesting<GatewayRequestInfos>()) {
+        self.service = service
+    }
+    
+    // MARK: - Public methods
+    func getToken(accessToken: String?, publicKey: String, cardTokenJSON: Data, completion: @escaping (Data?, PXError?) -> Void) {
+        service.requestData(target: .getToken(accessToken, publicKey, cardTokenJSON)) { data, error in
+            if let _ = error {
+                completion(nil, PXError(domain: ApiDomain.GET_TOKEN,
+                                        code: ErrorTypes.NO_INTERNET_ERROR,
+                                        userInfo: [
+                                            NSLocalizedDescriptionKey: "Hubo un error",
+                                            NSLocalizedFailureReasonErrorKey: "Verifique su conexión a internet e intente nuevamente"])
+                )
+            } else {
+                completion(data, nil)
+            }
+        }
+    }
+    
+    func cloneToken(tokeniD: String, publicKey: String, securityCode: String, completion: @escaping (Data?, PXError?) -> Void) {
+        service.requestData(target: .cloneToken(tokeniD, publicKey)) { [weak self] data, error in
+            if let data = data, let token = try? JSONDecoder().decode(PXToken.self , from: data) {
+                let secCodeDic : [String: Any] = ["security_code": securityCode]
+                guard let jsonData = try? JSONSerialization.data(withJSONObject: secCodeDic, options: .prettyPrinted) else {
+                    completion(nil, PXError(domain: ApiDomain.CLONE_TOKEN,
+                                            code: ErrorTypes.NO_INTERNET_ERROR,
+                                            userInfo: [
+                                                NSLocalizedDescriptionKey: "Hubo un error",
+                                                NSLocalizedFailureReasonErrorKey: "Verifique su conexión a internet e intente nuevamente"])
+                    )
+                    return
+                }
+                
+                self?.validateToken(tokenId: token.id, publicKey: publicKey, body: jsonData) { data, error in
+                    if let error = error {
+                        completion(nil, error)
+                    } else {
+                        completion(data, nil)
+                    }
+                }
+            }
+        }
+    }
+    
+    func validateToken(tokenId: String, publicKey: String, body: Data, completion: @escaping (Data?, PXError?) -> Void) {
+        service.requestData(target: .validateToken(tokenId, publicKey, body)) { data, error in
+            if let _ = error {
+                completion(nil, PXError(domain: ApiDomain.CLONE_TOKEN,
+                                        code: ErrorTypes.NO_INTERNET_ERROR,
+                                        userInfo: [
+                                            NSLocalizedDescriptionKey: "Hubo un error",
+                                            NSLocalizedFailureReasonErrorKey: "Verifique su conexión a internet e intente nuevamente"])
+                )
+            } else {
+                completion(data, nil)
+            }
+        }
+    }
+}
+

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Gateway/GatewayServices.swift
@@ -8,11 +8,11 @@
 protocol GatewayServices {
     func getToken(accessToken: String?,
                   publicKey: String,
-                  cardTokenJSON: Data,
-                  completion: @escaping (Data?, PXError?) -> Void)
+                  cardTokenJSON: Data?,
+                  completion: @escaping (PXToken?, PXError?) -> Void)
     
-    func cloneToken(tokeniD: String, publicKey: String, securityCode: String, completion: @escaping (Data?, PXError?) -> Void)
-    func validateToken(tokenId: String, publicKey: String, body: Data, completion: @escaping (Data?, PXError?) -> Void)
+    func cloneToken(tokeniD: String, publicKey: String, securityCode: String, completion: @escaping (PXToken?, PXError?) -> Void)
+    func validateToken(tokenId: String, publicKey: String, body: Data, completion: @escaping (PXToken?, PXError?) -> Void)
 }
 
 final class GatewayServicesImpl: GatewayServices {
@@ -25,8 +25,8 @@ final class GatewayServicesImpl: GatewayServices {
     }
     
     // MARK: - Public methods
-    func getToken(accessToken: String?, publicKey: String, cardTokenJSON: Data, completion: @escaping (Data?, PXError?) -> Void) {
-        service.requestData(target: .getToken(accessToken, publicKey, cardTokenJSON)) { data, error in
+    func getToken(accessToken: String?, publicKey: String, cardTokenJSON: Data?, completion: @escaping (PXToken?, PXError?) -> Void) {
+        service.requestObject(model: PXToken.self, .getToken(accessToken, publicKey, cardTokenJSON)) { token, error in
             if let _ = error {
                 completion(nil, PXError(domain: ApiDomain.GET_TOKEN,
                                         code: ErrorTypes.NO_INTERNET_ERROR,
@@ -35,12 +35,12 @@ final class GatewayServicesImpl: GatewayServices {
                                             NSLocalizedFailureReasonErrorKey: "Verifique su conexión a internet e intente nuevamente"])
                 )
             } else {
-                completion(data, nil)
+                completion(token, nil)
             }
         }
     }
     
-    func cloneToken(tokeniD: String, publicKey: String, securityCode: String, completion: @escaping (Data?, PXError?) -> Void) {
+    func cloneToken(tokeniD: String, publicKey: String, securityCode: String, completion: @escaping (PXToken?, PXError?) -> Void) {
         service.requestData(target: .cloneToken(tokeniD, publicKey)) { [weak self] data, error in
             if let data = data, let token = try? JSONDecoder().decode(PXToken.self , from: data) {
                 let secCodeDic : [String: Any] = ["security_code": securityCode]
@@ -65,8 +65,8 @@ final class GatewayServicesImpl: GatewayServices {
         }
     }
     
-    func validateToken(tokenId: String, publicKey: String, body: Data, completion: @escaping (Data?, PXError?) -> Void) {
-        service.requestData(target: .validateToken(tokenId, publicKey, body)) { data, error in
+    func validateToken(tokenId: String, publicKey: String, body: Data, completion: @escaping (PXToken?, PXError?) -> Void) {
+        service.requestObject(model: PXToken.self, .validateToken(tokenId, publicKey, body)) { token, error in
             if let _ = error {
                 completion(nil, PXError(domain: ApiDomain.CLONE_TOKEN,
                                         code: ErrorTypes.NO_INTERNET_ERROR,
@@ -75,7 +75,7 @@ final class GatewayServicesImpl: GatewayServices {
                                             NSLocalizedFailureReasonErrorKey: "Verifique su conexión a internet e intente nuevamente"])
                 )
             } else {
-                completion(data, nil)
+                completion(token, nil)
             }
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsServices.swift
@@ -7,6 +7,7 @@
 
 protocol InstructionsServices {
     func getInstructions(paymentId: String,
+                         paymentTypeId: String,
                          accessToken: String?,
                          publicKey: String,
                          completion: @escaping (PXInstructions?, PXError?) -> Void)
@@ -22,8 +23,8 @@ final class InstructionsServicesImpl: InstructionsServices {
     }
     
     // MARK: - Public methods
-    func getInstructions(paymentId: String, accessToken: String?, publicKey: String, completion: @escaping (PXInstructions?, PXError?) -> Void) {
-        service.requestObject(model: PXInstructions.self, .getInstructions(paymentId, accessToken, publicKey)) { instruction, error in
+    func getInstructions(paymentId: String, paymentTypeId: String, accessToken: String?, publicKey: String, completion: @escaping (PXInstructions?, PXError?) -> Void) {
+        service.requestObject(model: PXInstructions.self, .getInstructions(paymentId: paymentId, paymentTypeId: paymentTypeId, privateKey: accessToken, publicKey: publicKey)) { instruction, error in
             if let _ = error {
                 completion(nil, PXError(domain: ApiDomain.GET_INSTRUCTIONS, code: ErrorTypes.NO_INTERNET_ERROR,
                                         userInfo: [

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsServices.swift
@@ -1,0 +1,40 @@
+//
+//  InstructionsServices.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 06/02/21.
+//
+
+protocol InstructionsServices {
+    func getInstructions(paymentId: String,
+                         accessToken: String?,
+                         publicKey: String,
+                         completion: @escaping (PXInstructions?, PXError?) -> Void)
+}
+
+final class InstructionsServicesImpl: InstructionsServices {
+    // MARK: - Private properties
+    private let service: Requesting<InstructionsrequestInfos>
+    
+    // MARK: - Initialization
+    init(service: Requesting<InstructionsrequestInfos> = Requesting<InstructionsrequestInfos>()) {
+        self.service = service
+    }
+    
+    // MARK: - Public methods
+    func getInstructions(paymentId: String, accessToken: String?, publicKey: String, completion: @escaping (PXInstructions?, PXError?) -> Void) {
+        service.requestObject(model: PXInstructions.self, .getInstructions(paymentId, accessToken, publicKey)) { instruction, error in
+            if let _ = error {
+                completion(nil, PXError(domain: ApiDomain.GET_INSTRUCTIONS, code: ErrorTypes.NO_INTERNET_ERROR,
+                                        userInfo: [
+                                            NSLocalizedDescriptionKey: "Hubo un error",
+                                            NSLocalizedFailureReasonErrorKey: "Verifique su conexión a internet e intente nuevamente"
+                                        ]))
+            } else {
+                completion(instruction, nil)
+            }
+        }
+    }
+}
+
+

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsrequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsrequestInfos.swift
@@ -12,7 +12,7 @@ enum InstructionsrequestInfos {
 extension InstructionsrequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .getInstructions(let paymentId, _, _, _): return "checkout/payments/\(paymentId)/results"
+        case .getInstructions(let paymentId, _, _, _): return "v1/checkout/payments/\(paymentId)/results"
         }
     }
     
@@ -36,6 +36,10 @@ extension InstructionsrequestInfos: RequestInfos {
                 ]
             }
         }
+    }
+    
+    var shouldSetEnvironment: Bool {
+        return false
     }
     
     var headers: [String : String]? {

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsrequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsrequestInfos.swift
@@ -1,0 +1,46 @@
+//
+//  InstructionsrequestInfos.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 06/02/21.
+//
+
+enum InstructionsrequestInfos {
+    case getInstructions(String, String?, String)
+}
+
+extension InstructionsrequestInfos: RequestInfos {
+    var endpoint: String {
+        switch self {
+        case .getInstructions(let paymentId, _, _): return "/checkout/payments/\(paymentId)/results"
+        }
+    }
+    
+    var method: HTTPMethodType {
+        return .get
+    }
+    
+    var parameters: [String : Any]? {
+        switch self {
+        case .getInstructions(_, let accessToken, let publicKey):
+            if let token = accessToken {
+                return [
+                    "access_token" : token,
+                    "public_key" : publicKey
+                ]
+            } else {
+                return [ "public_key" : publicKey ]
+            }
+        }
+    }
+    
+    var headers: [String : String]? {
+        return nil
+    }
+    
+    var body: Data? {
+        return nil
+    }
+    
+    
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsrequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsrequestInfos.swift
@@ -12,7 +12,7 @@ enum InstructionsrequestInfos {
 extension InstructionsrequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .getInstructions(let paymentId, _, _): return "/checkout/payments/\(paymentId)/results"
+        case .getInstructions(let paymentId, _, _): return "checkout/payments/\(paymentId)/results"
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsrequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Instructions/InstructionsrequestInfos.swift
@@ -6,13 +6,13 @@
 //
 
 enum InstructionsrequestInfos {
-    case getInstructions(String, String?, String)
+    case getInstructions(paymentId: String, paymentTypeId: String, privateKey: String?, publicKey: String)
 }
 
 extension InstructionsrequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .getInstructions(let paymentId, _, _): return "checkout/payments/\(paymentId)/results"
+        case .getInstructions(let paymentId, _, _, _): return "checkout/payments/\(paymentId)/results"
         }
     }
     
@@ -22,14 +22,18 @@ extension InstructionsrequestInfos: RequestInfos {
     
     var parameters: [String : Any]? {
         switch self {
-        case .getInstructions(_, let accessToken, let publicKey):
+        case .getInstructions(_, let paymentId, let accessToken, let publicKey):
             if let token = accessToken {
                 return [
                     "access_token" : token,
-                    "public_key" : publicKey
+                    "public_key" : publicKey,
+                    "payment_type" : paymentId
                 ]
             } else {
-                return [ "public_key" : publicKey ]
+                return [
+                    "public_key" : publicKey,
+                    "payment_type" : paymentId
+                ]
             }
         }
     }
@@ -41,6 +45,4 @@ extension InstructionsrequestInfos: RequestInfos {
     var body: Data? {
         return nil
     }
-    
-    
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/ParameterEncode.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/ParameterEncode.swift
@@ -1,0 +1,76 @@
+//
+//  ParameterEncoding.swift
+//  AndesUI
+//
+//  Created by Matheus Leandro Martins on 05/02/21.
+//
+
+import Foundation
+
+protocol ParameterEncode {
+    func encode(request: URLRequest?, parameters: [String: Any]?) throws -> URLRequest
+}
+
+final class ParameterEncodingImpl: ParameterEncode {
+    func encode(request: URLRequest?, parameters: [String : Any]?) throws -> URLRequest {
+        guard var urlRequest = request, let url = urlRequest.url else {
+            throw NSError()
+        }
+        
+        guard let parameters = parameters,
+            let httpMethod = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"),
+            (httpMethod == .get || httpMethod == .delete),
+            var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return urlRequest }
+        
+        var components: [(String, String)] = []
+        
+        for key in parameters.keys.sorted(by: <) {
+            let value = parameters[key]!
+            components += parseParameter(fromKey: key, value: value)
+        }
+        
+        urlComponents.percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0 + "&" } ?? "") +
+            components.map { "\($0)=\($1)" }.joined(separator: "&")
+        
+        urlRequest.url = urlComponents.url
+        
+        return urlRequest
+    }
+    
+    private func parseParameter(fromKey key: String, value: Any) -> [(String, String)] {
+        var components: [(String, String)] = []
+        
+        if let dictionary = value as? [String: Any] {
+            for (nestedKey, value) in dictionary {
+                components += parseParameter(fromKey: "\(key)[\(nestedKey)]", value: value)
+            }
+        } else if let array = value as? [Any] {
+            for value in array {
+                components += parseParameter(fromKey: "\(key)[]", value: value)
+            }
+        } else if let value = value as? NSNumber {
+            if value == 1 || value == 0 {
+                components.append((escape(key), escape((value.boolValue ? "1" : "0"))))
+            } else {
+                components.append((escape(key), escape("\(value)")))
+            }
+        } else if let bool = value as? Bool {
+            components.append((escape(key), escape((bool ? "1" : "0"))))
+        } else {
+            components.append((escape(key), escape("\(value)")))
+        }
+        
+        return components
+    }
+    
+    private func escape(_ string: String) -> String {
+        let generalDelimitersToEncode = ":#[]@"
+        let subDelimitersToEncode = "!$&'()*+,;="
+        
+        var allowedCharacterSet = CharacterSet.urlQueryAllowed
+        allowedCharacterSet.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+        
+        guard let escaped = string.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) else { return "" }
+        return escaped
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentRequestInfos.swift
@@ -14,7 +14,13 @@ enum PaymentRequestInfos {
 extension PaymentRequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .getInit(let preferenceId, _, _, _): return "px_mobile/v2/checkout/\(preferenceId ?? "")"
+        case .getInit(let preferenceId, _, _, _):
+            if let preferenceId = preferenceId {
+                return "px_mobile/v2/checkout/\(preferenceId)"
+            } else {
+                return "px_mobile/v2/checkout"
+            }
+            
         }
     }
     
@@ -36,8 +42,8 @@ extension PaymentRequestInfos: RequestInfos {
     
     var parameters: [String : Any]? {
         switch self {
-        case .getInit(_, let accessToken, _, _):
-        if let token = accessToken { return [ "access_token" : token ] } else { return nil }
+        case .getInit(let preferenceId, let accessToken, _, _):
+        if let token = accessToken, preferenceId != nil { return [ "access_token" : token ] } else { return nil }
         }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentRequestInfos.swift
@@ -19,7 +19,7 @@ extension PaymentRequestInfos: RequestInfos {
     }
     
     var method: HTTPMethodType {
-        .post
+        return .post
     }
     
     var body: Data? {

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentRequestInfos.swift
@@ -1,0 +1,43 @@
+//
+//  PaymentRequestInfos.swift
+//  AndesUI
+//
+//  Created by Matheus Leandro Martins on 05/02/21.
+//
+
+import Foundation
+
+enum PaymentRequestInfos {
+    case getInit(String?, String?, Data?, [String: String]?)
+}
+
+extension PaymentRequestInfos: RequestInfos {
+    var endpoint: String {
+        switch self {
+        case .getInit(let preferenceId, _, _, _): return "/px_mobile/v2/checkout/\(preferenceId ?? "")"
+        }
+    }
+    
+    var method: HTTPMethodType {
+        .post
+    }
+    
+    var body: Data? {
+        switch self {
+        case .getInit(_, _, let body, _): return body
+        }
+    }
+    
+    var headers: [String : String]? {
+        switch self {
+        case .getInit(_, _, _, let header): return header
+        }
+    }
+    
+    var parameters: [String : Any]? {
+        switch self {
+        case .getInit(_, let accessToken, _, _):
+        if let token = accessToken { return [ "access_token" : token ] } else { return nil }
+        }
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentRequestInfos.swift
@@ -14,7 +14,7 @@ enum PaymentRequestInfos {
 extension PaymentRequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .getInit(let preferenceId, _, _, _): return "/px_mobile/v2/checkout/\(preferenceId ?? "")"
+        case .getInit(let preferenceId, _, _, _): return "px_mobile/v2/checkout/\(preferenceId ?? "")"
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Payment/PaymentServices.swift
@@ -1,0 +1,41 @@
+//
+//  PaymentServices.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 05/02/21.
+//
+
+protocol PaymentServices {
+    func getInit(preferenceId: String?,
+                 privateKey: String?,
+                 body: Data?,
+                 headers: [String: String]?,
+                 completion: @escaping (PXInitDTO?, PXError?) -> Void)
+}
+
+final class PaymentServicesImpl: PaymentServices {
+    // MARK: - Private properties
+    private let service: Requesting<PaymentRequestInfos>
+    
+    // MARK: - Initialization
+    init(service: Requesting<PaymentRequestInfos> = Requesting<PaymentRequestInfos>()) {
+        self.service = service
+    }
+    
+    // MARK: - Public methods
+    func getInit(preferenceId: String?, privateKey: String?, body: Data?, headers: [String: String]?, completion: @escaping (PXInitDTO?, PXError?) -> Void) {
+        service.requestObject(model: PXInitDTO.self, .getInit(preferenceId, privateKey, body, headers)) { payment, error in
+            if let _ = error {
+                completion(nil, PXError(domain: ApiDomain.GET_REMEDY,
+                                        code: ErrorTypes.NO_INTERNET_ERROR,
+                                        userInfo: [
+                                            NSLocalizedDescriptionKey: "Hubo un error",
+                                            NSLocalizedFailureReasonErrorKey: "Verifique su conexión a internet e intente nuevamente"
+                                        ]))
+            } else {
+                completion(payment, nil)
+            }
+        }
+    }
+}
+

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
@@ -6,13 +6,13 @@
 //
 
 enum RemedyRequestInfos {
-    case getRemedy(String, Bool, Data?)
+    case getRemedy(String?, Bool, Data?)
 }
 
 extension RemedyRequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .getRemedy(let paymentId, _, _): return "px_mobile/v1/remedies/\(paymentId)/"
+        case .getRemedy(let paymentId, _, _): return paymentId == nil ? "px_mobile/v1/remedies/" : "px_mobile/v1/remedies/\(paymentId ?? "")/"
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
@@ -12,7 +12,9 @@ enum RemedyRequestInfos {
 extension RemedyRequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .getRemedy(let paymentId, _, _): return paymentId == nil ? "px_mobile/v1/remedies/" : "px_mobile/v1/remedies/\(paymentId ?? "")/"
+        case .getRemedy(let paymentId, _, _):
+            let paymentId = paymentId ?? ""
+            return "px_mobile/v1/remedies/\(paymentId)/"
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
@@ -1,0 +1,37 @@
+//
+//  RemedyRequestInfos.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 05/02/21.
+//
+
+enum RemedyRequestInfos {
+    case getRemedy(String, Bool, Data?)
+}
+
+extension RemedyRequestInfos: RequestInfos {
+    var endpoint: String {
+        switch self {
+        case .getRemedy(let paymentId, _, _): return "/px_mobile/v1/remedies/\(paymentId)/"
+        }
+    }
+    
+    var method: HTTPMethodType {
+        .post
+    }
+    
+    var body: Data? {
+        switch self {
+        case .getRemedy(_, _, let body): return body
+        }
+    }
+    
+    
+    var parameters: [String : Any]? {
+        switch self {
+        case .getRemedy(_, let oneTap, _): return [
+            "one_tap" : oneTap ? "true" : "false"
+        ]
+        }
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
@@ -12,9 +12,8 @@ enum RemedyRequestInfos {
 extension RemedyRequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .getRemedy(let paymentId, _, _):
-            let paymentId = paymentId ?? ""
-            return "px_mobile/v1/remedies/\(paymentId)/"
+        case .getRemedy(_, _, _):
+            return "px_mobile/v1/remedies/1234135506"
         }
     }
     
@@ -36,7 +35,10 @@ extension RemedyRequestInfos: RequestInfos {
     
     var parameters: [String : Any]? {
         switch self {
-        case .getRemedy(_, let oneTap, _): return [
+        case .getRemedy(let privateKey, let oneTap, _):
+            let key = privateKey ?? ""
+            return [
+            "access_token" : key,
             "one_tap" : oneTap ? "true" : "false"
         ]
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
@@ -26,6 +26,11 @@ extension RemedyRequestInfos: RequestInfos {
         }
     }
     
+    var headers: [String : String]? {
+        switch self {
+        case .getRemedy(_, _, _): return nil
+        }
+    }
     
     var parameters: [String : Any]? {
         switch self {

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyRequestInfos.swift
@@ -12,7 +12,7 @@ enum RemedyRequestInfos {
 extension RemedyRequestInfos: RequestInfos {
     var endpoint: String {
         switch self {
-        case .getRemedy(let paymentId, _, _): return "/px_mobile/v1/remedies/\(paymentId)/"
+        case .getRemedy(let paymentId, _, _): return "px_mobile/v1/remedies/\(paymentId)/"
         }
     }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyServices.swift
@@ -6,11 +6,11 @@
 //
 
 protocol RemedyServices {
-    func getRemedy(privateKey: String,
+    func getRemedy(privateKey: String?,
                    oneTap: Bool,
                    payerPaymentMethodRejected: PXPayerPaymentMethodRejected,
                    alternativePayerPaymentMethods: [PXRemedyPaymentMethod]?,
-                   completion: @escaping (Data?, PXError?) -> Void)
+                   completion: @escaping (PXRemedy?, PXError?) -> Void)
 }
 
 final class RemedyServicesImpl: RemedyServices {
@@ -23,13 +23,13 @@ final class RemedyServicesImpl: RemedyServices {
     }
     
     // MARK: - Public methods
-    func getRemedy(privateKey: String, oneTap: Bool, payerPaymentMethodRejected: PXPayerPaymentMethodRejected, alternativePayerPaymentMethods: [PXRemedyPaymentMethod]?, completion: @escaping (Data?, PXError?) -> Void) {
+    func getRemedy(privateKey: String?, oneTap: Bool, payerPaymentMethodRejected: PXPayerPaymentMethodRejected, alternativePayerPaymentMethods: [PXRemedyPaymentMethod]?, completion: @escaping (PXRemedy?, PXError?) -> Void) {
         let remedyBody = PXRemedyBody(payerPaymentMethodRejected: payerPaymentMethodRejected, alternativePayerPaymentMethods: alternativePayerPaymentMethods)
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         let body = try? encoder.encode(remedyBody)
         
-        service.requestData(target: .getRemedy(privateKey, oneTap, body)) { data, error in
+        service.requestObject(model: PXRemedy.self, .getRemedy(privateKey, oneTap, body)) { remedy, error in
             if let _ = error {
                 completion(nil, PXError(domain: ApiDomain.GET_REMEDY,
                                         code: ErrorTypes.NO_INTERNET_ERROR,
@@ -38,7 +38,7 @@ final class RemedyServicesImpl: RemedyServices {
                                             NSLocalizedFailureReasonErrorKey: "Verifique su conexión a internet e intente nuevamente"
                                         ]))
             } else {
-                completion(data, nil)
+                completion(remedy, nil)
             }
         }
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/Remedy/RemedyServices.swift
@@ -1,0 +1,45 @@
+//
+//  RemedyServices.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 05/02/21.
+//
+
+protocol RemedyServices {
+    func getRemedy(privateKey: String,
+                   oneTap: Bool,
+                   payerPaymentMethodRejected: PXPayerPaymentMethodRejected,
+                   alternativePayerPaymentMethods: [PXRemedyPaymentMethod]?,
+                   completion: @escaping (Data?, PXError?) -> Void)
+}
+
+final class RemedyServicesImpl: RemedyServices {
+    // MARK: - Private properties
+    private let service: Requesting<RemedyRequestInfos>
+    
+    // MARK: - Initialization
+    init(service: Requesting<RemedyRequestInfos> = Requesting<RemedyRequestInfos>()) {
+        self.service = service
+    }
+    
+    // MARK: - Public methods
+    func getRemedy(privateKey: String, oneTap: Bool, payerPaymentMethodRejected: PXPayerPaymentMethodRejected, alternativePayerPaymentMethods: [PXRemedyPaymentMethod]?, completion: @escaping (Data?, PXError?) -> Void) {
+        let remedyBody = PXRemedyBody(payerPaymentMethodRejected: payerPaymentMethodRejected, alternativePayerPaymentMethods: alternativePayerPaymentMethods)
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let body = try? encoder.encode(remedyBody)
+        
+        service.requestData(target: .getRemedy(privateKey, oneTap, body)) { data, error in
+            if let _ = error {
+                completion(nil, PXError(domain: ApiDomain.GET_REMEDY,
+                                        code: ErrorTypes.NO_INTERNET_ERROR,
+                                        userInfo: [
+                                            NSLocalizedDescriptionKey: "Hubo un error",
+                                            NSLocalizedFailureReasonErrorKey: "Verifique su conexión a internet e intente nuevamente"
+                                        ]))
+            } else {
+                completion(data, nil)
+            }
+        }
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
@@ -1,0 +1,39 @@
+//
+//  RequestInfos.swift
+//  AndesUI
+//
+//  Created by Matheus Leandro Martins on 05/02/21.
+//
+
+import Foundation
+
+enum HTTPMethodType: String {
+    case get     = "GET"
+    case post    = "POST"
+    case put     = "PUT"
+    case delete  = "DELETE"
+}
+
+protocol RequestInfos {
+    
+    var baseURL: URL { get }
+    
+    var endpoint: String { get }
+    
+    var method: HTTPMethodType { get }
+    
+    var parameters: [String: Any]? { get }
+    
+    var parameterEncoding: ParameterEncode { get }
+
+}
+
+extension RequestInfos {
+    var baseURL: URL {
+        return URL(string: "https://api.mercadolibre.com/sites/MLA/")!
+    }
+    
+    var parameterEncoding: ParameterEncode {
+        return ParameterEncodingImpl()
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
@@ -24,13 +24,15 @@ protocol RequestInfos {
     
     var parameters: [String: Any]? { get }
     
+    var body: Data? { get }
+    
     var parameterEncoding: ParameterEncode { get }
 
 }
 
 extension RequestInfos {
     var baseURL: URL {
-        return URL(string: "https://api.mercadolibre.com/sites/MLA/")!
+        return URL(string: "https://api.mercadopago.com/")!
     }
     
     var parameterEncoding: ParameterEncode {

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
@@ -14,9 +14,17 @@ enum HTTPMethodType: String {
     case delete  = "DELETE"
 }
 
+enum BackendEnvironment: String {
+    case alpha = "alpha/"
+    case beta = "beta/"
+    case prod = "v1/"
+}
+
 internal protocol RequestInfos {
     
     var baseURL: URL { get }
+    
+    var environment: BackendEnvironment { get }
     
     var endpoint: String { get }
     
@@ -39,5 +47,9 @@ extension RequestInfos {
     
     var parameterEncoding: ParameterEncode {
         return ParameterEncodingImpl()
+    }
+    
+    var environment: BackendEnvironment {
+        return .beta
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
@@ -14,7 +14,7 @@ enum HTTPMethodType: String {
     case delete  = "DELETE"
 }
 
-protocol RequestInfos {
+internal protocol RequestInfos {
     
     var baseURL: URL { get }
     
@@ -23,6 +23,8 @@ protocol RequestInfos {
     var method: HTTPMethodType { get }
     
     var parameters: [String: Any]? { get }
+    
+    var headers: [String: String]? { get }
     
     var body: Data? { get }
     

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestInfos.swift
@@ -17,7 +17,7 @@ enum HTTPMethodType: String {
 enum BackendEnvironment: String {
     case alpha = "alpha/"
     case beta = "beta/"
-    case prod = "v1/"
+    case prod = "production/"
 }
 
 internal protocol RequestInfos {
@@ -25,6 +25,8 @@ internal protocol RequestInfos {
     var baseURL: URL { get }
     
     var environment: BackendEnvironment { get }
+    
+    var shouldSetEnvironment: Bool { get }
     
     var endpoint: String { get }
     
@@ -50,6 +52,10 @@ extension RequestInfos {
     }
     
     var environment: BackendEnvironment {
-        return .beta
+        return .prod
+    }
+    
+    var shouldSetEnvironment: Bool {
+        return true
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
@@ -26,10 +26,10 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         
         var request = URLRequest(url: url)
         
-        do {
-            request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.headers)
-        } catch {
-            completionHandler(nil, NSError())
+        if let headers = target.headers {
+            for header in headers {
+                request.setValue(header.key, forHTTPHeaderField: header.value)
+            }
         }
     
         do {
@@ -48,7 +48,7 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
             let value = "PX/iOS/" + sdkVersion
             request.setValue(value, forHTTPHeaderField: MercadoPagoService.HeaderField.userAgent.rawValue)
         }
-
+        
         // Add session id
         request.setValue(MPXTracker.sharedInstance.getRequestId(), forHTTPHeaderField: MercadoPagoService.HeaderField.requestId.rawValue)
         request.setValue(MPXTracker.sharedInstance.getSessionID(), forHTTPHeaderField: MercadoPagoService.HeaderField.sessionId.rawValue)
@@ -90,14 +90,9 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
             
             do {
                 let modelList = try JSONDecoder().decode(Model.self , from: data)
-                DispatchQueue.main.async {
-                    completionHandler(modelList, nil)
-                }
-                
+                completionHandler(modelList, nil)
             } catch {
-                DispatchQueue.main.async {
-                    completionHandler(nil, NSError())
-                }
+                completionHandler(nil, NSError())
             }
         }.resume()
     }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
@@ -24,6 +24,12 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         }
         
         var request = URLRequest(url: url)
+        
+        do {
+            request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.headers)
+        } catch {
+            completionHandler(nil, NSError())
+        }
     
         do {
             request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.parameters)
@@ -61,6 +67,12 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         var request = URLRequest(url: url)
         
         do {
+            request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.headers)
+        } catch {
+            completionHandler(nil, NSError())
+        }
+        
+        do {
             request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.parameters)
         } catch {
             completionHandler(nil, NSError())
@@ -94,6 +106,12 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         }
         
         var request = URLRequest(url: url)
+        
+        do {
+            request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.headers)
+        } catch {
+            completionHandler(nil, NSError())
+        }
         
         do {
             request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.parameters)

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
@@ -11,7 +11,6 @@ protocol RequestProtocol {
     associatedtype
     Target: RequestInfos
     func requestObject<Model: Codable>(model: Model.Type, _ target: Target, completionHandler: @escaping (_ result: Model?, _ error: Error?) -> Void)
-    func requestArray<Model: Codable>(model: Model.Type, _ target: Target, completionHandler: @escaping (_ result: [Model]?, _ error: Error?) -> Void)
     func requestData(target: Target, completionHandler: @escaping (_ data: Data?, _ error: Error?) -> Void)
 }
 
@@ -90,85 +89,6 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
             
             do {
                 let modelList = try JSONDecoder().decode(Model.self , from: data)
-                completionHandler(modelList, nil)
-            } catch {
-                completionHandler(nil, NSError())
-            }
-        }.resume()
-    }
-    
-    func requestArray<Model: Codable>(model: Model.Type, _ target: Target, completionHandler: @escaping (_ result: [Model]?, _ error: Error?) -> Void) {
-        guard let url = URL(string: "\(target.baseURL)\(target.environment.rawValue)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
-            completionHandler(nil, NSError())
-            return
-        }
-        
-        var request = URLRequest(url: url)
-        
-        do {
-            request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.headers)
-        } catch {
-            completionHandler(nil, NSError())
-        }
-        
-        do {
-            request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.parameters)
-        } catch {
-            completionHandler(nil, NSError())
-        }
-        
-        request.httpBody = target.body
-        request.httpMethod = target.method.rawValue
-        request.cachePolicy = .useProtocolCachePolicy
-        request.timeoutInterval = 15.0
-        
-        request.setValue("application/json", forHTTPHeaderField: MercadoPagoService.HeaderField.contentType.rawValue)
-        if let sdkVersion = MercadoPagoBundle.bundleShortVersionString() {
-            let value = "PX/iOS/" + sdkVersion
-            request.setValue(value, forHTTPHeaderField: MercadoPagoService.HeaderField.userAgent.rawValue)
-        }
-
-        // Add session id
-        request.setValue(MPXTracker.sharedInstance.getRequestId(), forHTTPHeaderField: MercadoPagoService.HeaderField.requestId.rawValue)
-        request.setValue(MPXTracker.sharedInstance.getSessionID(), forHTTPHeaderField: MercadoPagoService.HeaderField.sessionId.rawValue)
-
-        // Language
-        request.setValue(Localizator.sharedInstance.getLanguage(), forHTTPHeaderField: MercadoPagoService.HeaderField.language.rawValue)
-
-        //Density Header
-        request.setValue("xxxhdpi", forHTTPHeaderField: MercadoPagoService.HeaderField.density.rawValue)
-
-        //Product ID Header
-        if target.headers?[MercadoPagoService.HeaderField.productId.rawValue] == nil {
-            request.setValue(MP_DEFAULT_PRODUCT_ID, forHTTPHeaderField: MercadoPagoService.HeaderField.productId.rawValue)
-        }
-
-        // Add platform
-        request.setValue(MLBusinessAppDataService().getAppIdentifier().rawValue, forHTTPHeaderField: MercadoPagoService.HeaderField.platform.rawValue)
-        
-        // Add flow id
-        request.setValue(MPXTracker.sharedInstance.getFlowName() ?? "unknown", forHTTPHeaderField: MercadoPagoService.HeaderField.flowId.rawValue)
-
-        if let headers = target.headers {
-            for header in headers {
-                request.setValue(header.value, forHTTPHeaderField: header.key)
-            }
-        }
-
-        UIApplication.shared.isNetworkActivityIndicatorVisible = true
-        
-        URLSession.shared.dataTask(with: request) { data, resp, error in
-            if let error = error {
-                completionHandler(nil, error)
-            }
-            
-            guard let data = data else {
-                completionHandler(nil, NSError())
-                return
-            }
-            
-            do {
-                let modelList = try JSONDecoder().decode([Model].self , from: data)
                 completionHandler(modelList, nil)
             } catch {
                 completionHandler(nil, NSError())

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
@@ -24,12 +24,14 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         }
         
         var request = URLRequest(url: url)
-        
+    
         do {
             request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.parameters)
         } catch {
             completionHandler(nil, NSError())
         }
+        
+        request.httpBody = target.body
         
         URLSession.shared.dataTask(with: request) { data, resp, error in
             if let error = error {
@@ -64,6 +66,8 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
             completionHandler(nil, NSError())
         }
         
+        request.httpBody = target.body
+        
         URLSession.shared.dataTask(with: request) { data, resp, error in
             if let error = error {
                 completionHandler(nil, error)
@@ -96,6 +100,8 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         } catch {
             completionHandler(nil, NSError())
         }
+        
+        request.httpBody = target.body
         
         URLSession.shared.dataTask(with: request) { data, resp, error in
             if let error = error {

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
@@ -19,7 +19,7 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
     let MP_DEFAULT_PRODUCT_ID = "BJEO9TFBF6RG01IIIOU0"
     //MARK: - Public methods
     func requestObject<Model>(model: Model.Type, _ target: Target, completionHandler: @escaping (Model?, Error?) -> Void) where Model : Codable {
-        guard let url = URL(string: "\(target.baseURL)\(target.environment.rawValue)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
+        guard let url = URL(string: "\(target.baseURL)\(target.shouldSetEnvironment ?  target.environment.rawValue : "")\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
             completionHandler(nil, NSError())
             return
         }
@@ -77,7 +77,6 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         }
 
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
-
         
         URLSession.shared.dataTask(with: request) { data, resp, error in
             if let error = error {
@@ -91,9 +90,14 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
             
             do {
                 let modelList = try JSONDecoder().decode(Model.self , from: data)
-                completionHandler(modelList, nil)
+                DispatchQueue.main.async {
+                    completionHandler(modelList, nil)
+                }
+                
             } catch {
-                completionHandler(nil, NSError())
+                DispatchQueue.main.async {
+                    completionHandler(nil, NSError())
+                }
             }
         }.resume()
     }
@@ -119,6 +123,44 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         }
         
         request.httpBody = target.body
+        request.httpMethod = target.method.rawValue
+        request.cachePolicy = .useProtocolCachePolicy
+        request.timeoutInterval = 15.0
+        
+        request.setValue("application/json", forHTTPHeaderField: MercadoPagoService.HeaderField.contentType.rawValue)
+        if let sdkVersion = MercadoPagoBundle.bundleShortVersionString() {
+            let value = "PX/iOS/" + sdkVersion
+            request.setValue(value, forHTTPHeaderField: MercadoPagoService.HeaderField.userAgent.rawValue)
+        }
+
+        // Add session id
+        request.setValue(MPXTracker.sharedInstance.getRequestId(), forHTTPHeaderField: MercadoPagoService.HeaderField.requestId.rawValue)
+        request.setValue(MPXTracker.sharedInstance.getSessionID(), forHTTPHeaderField: MercadoPagoService.HeaderField.sessionId.rawValue)
+
+        // Language
+        request.setValue(Localizator.sharedInstance.getLanguage(), forHTTPHeaderField: MercadoPagoService.HeaderField.language.rawValue)
+
+        //Density Header
+        request.setValue("xxxhdpi", forHTTPHeaderField: MercadoPagoService.HeaderField.density.rawValue)
+
+        //Product ID Header
+        if target.headers?[MercadoPagoService.HeaderField.productId.rawValue] == nil {
+            request.setValue(MP_DEFAULT_PRODUCT_ID, forHTTPHeaderField: MercadoPagoService.HeaderField.productId.rawValue)
+        }
+
+        // Add platform
+        request.setValue(MLBusinessAppDataService().getAppIdentifier().rawValue, forHTTPHeaderField: MercadoPagoService.HeaderField.platform.rawValue)
+        
+        // Add flow id
+        request.setValue(MPXTracker.sharedInstance.getFlowName() ?? "unknown", forHTTPHeaderField: MercadoPagoService.HeaderField.flowId.rawValue)
+
+        if let headers = target.headers {
+            for header in headers {
+                request.setValue(header.value, forHTTPHeaderField: header.key)
+            }
+        }
+
+        UIApplication.shared.isNetworkActivityIndicatorVisible = true
         
         URLSession.shared.dataTask(with: request) { data, resp, error in
             if let error = error {
@@ -160,6 +202,44 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         }
         
         request.httpBody = target.body
+        request.httpMethod = target.method.rawValue
+        request.cachePolicy = .useProtocolCachePolicy
+        request.timeoutInterval = 15.0
+        
+        request.setValue("application/json", forHTTPHeaderField: MercadoPagoService.HeaderField.contentType.rawValue)
+        if let sdkVersion = MercadoPagoBundle.bundleShortVersionString() {
+            let value = "PX/iOS/" + sdkVersion
+            request.setValue(value, forHTTPHeaderField: MercadoPagoService.HeaderField.userAgent.rawValue)
+        }
+
+        // Add session id
+        request.setValue(MPXTracker.sharedInstance.getRequestId(), forHTTPHeaderField: MercadoPagoService.HeaderField.requestId.rawValue)
+        request.setValue(MPXTracker.sharedInstance.getSessionID(), forHTTPHeaderField: MercadoPagoService.HeaderField.sessionId.rawValue)
+
+        // Language
+        request.setValue(Localizator.sharedInstance.getLanguage(), forHTTPHeaderField: MercadoPagoService.HeaderField.language.rawValue)
+
+        //Density Header
+        request.setValue("xxxhdpi", forHTTPHeaderField: MercadoPagoService.HeaderField.density.rawValue)
+
+        //Product ID Header
+        if target.headers?[MercadoPagoService.HeaderField.productId.rawValue] == nil {
+            request.setValue(MP_DEFAULT_PRODUCT_ID, forHTTPHeaderField: MercadoPagoService.HeaderField.productId.rawValue)
+        }
+
+        // Add platform
+        request.setValue(MLBusinessAppDataService().getAppIdentifier().rawValue, forHTTPHeaderField: MercadoPagoService.HeaderField.platform.rawValue)
+        
+        // Add flow id
+        request.setValue(MPXTracker.sharedInstance.getFlowName() ?? "unknown", forHTTPHeaderField: MercadoPagoService.HeaderField.flowId.rawValue)
+
+        if let headers = target.headers {
+            for header in headers {
+                request.setValue(header.value, forHTTPHeaderField: header.key)
+            }
+        }
+
+        UIApplication.shared.isNetworkActivityIndicatorVisible = true
         
         URLSession.shared.dataTask(with: request) { data, resp, error in
             if let error = error {

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
@@ -19,7 +19,7 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
     let MP_DEFAULT_PRODUCT_ID = "BJEO9TFBF6RG01IIIOU0"
     //MARK: - Public methods
     func requestObject<Model>(model: Model.Type, _ target: Target, completionHandler: @escaping (Model?, Error?) -> Void) where Model : Codable {
-        guard let url = URL(string: "\(target.baseURL)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
+        guard let url = URL(string: "\(target.baseURL)\(target.environment.rawValue)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
             completionHandler(nil, NSError())
             return
         }
@@ -99,7 +99,7 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
     }
     
     func requestArray<Model: Codable>(model: Model.Type, _ target: Target, completionHandler: @escaping (_ result: [Model]?, _ error: Error?) -> Void) {
-        guard let url = URL(string: "\(target.baseURL)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
+        guard let url = URL(string: "\(target.baseURL)\(target.environment.rawValue)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
             completionHandler(nil, NSError())
             return
         }
@@ -140,7 +140,7 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
     }
     
     func requestData(target: Target, completionHandler: @escaping (_ data: Data?, _ error: Error?) -> Void) {
-        guard let url = URL(string: "\(target.baseURL)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
+        guard let url = URL(string: "\(target.baseURL)\(target.environment.rawValue)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
             completionHandler(nil, NSError())
             return
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
@@ -42,32 +42,12 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         request.cachePolicy = .useProtocolCachePolicy
         request.timeoutInterval = 15.0
         
-        request.setValue("application/json", forHTTPHeaderField: MercadoPagoService.HeaderField.contentType.rawValue)
-        if let sdkVersion = MercadoPagoBundle.bundleShortVersionString() {
-            let value = "PX/iOS/" + sdkVersion
-            request.setValue(value, forHTTPHeaderField: MercadoPagoService.HeaderField.userAgent.rawValue)
-        }
+        request = setupStandardHeaders(baseRequest: request)
         
-        // Add session id
-        request.setValue(MPXTracker.sharedInstance.getRequestId(), forHTTPHeaderField: MercadoPagoService.HeaderField.requestId.rawValue)
-        request.setValue(MPXTracker.sharedInstance.getSessionID(), forHTTPHeaderField: MercadoPagoService.HeaderField.sessionId.rawValue)
-
-        // Language
-        request.setValue(Localizator.sharedInstance.getLanguage(), forHTTPHeaderField: MercadoPagoService.HeaderField.language.rawValue)
-
-        //Density Header
-        request.setValue("xxxhdpi", forHTTPHeaderField: MercadoPagoService.HeaderField.density.rawValue)
-
         //Product ID Header
         if target.headers?[MercadoPagoService.HeaderField.productId.rawValue] == nil {
             request.setValue(MP_DEFAULT_PRODUCT_ID, forHTTPHeaderField: MercadoPagoService.HeaderField.productId.rawValue)
         }
-
-        // Add platform
-        request.setValue(MLBusinessAppDataService().getAppIdentifier().rawValue, forHTTPHeaderField: MercadoPagoService.HeaderField.platform.rawValue)
-        
-        // Add flow id
-        request.setValue(MPXTracker.sharedInstance.getFlowName() ?? "unknown", forHTTPHeaderField: MercadoPagoService.HeaderField.flowId.rawValue)
 
         if let headers = target.headers {
             for header in headers {
@@ -121,32 +101,12 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
         request.cachePolicy = .useProtocolCachePolicy
         request.timeoutInterval = 15.0
         
-        request.setValue("application/json", forHTTPHeaderField: MercadoPagoService.HeaderField.contentType.rawValue)
-        if let sdkVersion = MercadoPagoBundle.bundleShortVersionString() {
-            let value = "PX/iOS/" + sdkVersion
-            request.setValue(value, forHTTPHeaderField: MercadoPagoService.HeaderField.userAgent.rawValue)
-        }
-
-        // Add session id
-        request.setValue(MPXTracker.sharedInstance.getRequestId(), forHTTPHeaderField: MercadoPagoService.HeaderField.requestId.rawValue)
-        request.setValue(MPXTracker.sharedInstance.getSessionID(), forHTTPHeaderField: MercadoPagoService.HeaderField.sessionId.rawValue)
-
-        // Language
-        request.setValue(Localizator.sharedInstance.getLanguage(), forHTTPHeaderField: MercadoPagoService.HeaderField.language.rawValue)
-
-        //Density Header
-        request.setValue("xxxhdpi", forHTTPHeaderField: MercadoPagoService.HeaderField.density.rawValue)
-
+        request = setupStandardHeaders(baseRequest: request)
+        
         //Product ID Header
         if target.headers?[MercadoPagoService.HeaderField.productId.rawValue] == nil {
             request.setValue(MP_DEFAULT_PRODUCT_ID, forHTTPHeaderField: MercadoPagoService.HeaderField.productId.rawValue)
         }
-
-        // Add platform
-        request.setValue(MLBusinessAppDataService().getAppIdentifier().rawValue, forHTTPHeaderField: MercadoPagoService.HeaderField.platform.rawValue)
-        
-        // Add flow id
-        request.setValue(MPXTracker.sharedInstance.getFlowName() ?? "unknown", forHTTPHeaderField: MercadoPagoService.HeaderField.flowId.rawValue)
 
         if let headers = target.headers {
             for header in headers {
@@ -169,6 +129,34 @@ final class Requesting<Target: RequestInfos> : RequestProtocol {
             completionHandler(data, nil)
 
         }.resume()
+    }
+    
+    // MARK: - Private merthods
+    private func setupStandardHeaders(baseRequest: URLRequest) -> URLRequest {
+        var request = baseRequest
+        request.setValue("application/json", forHTTPHeaderField: MercadoPagoService.HeaderField.contentType.rawValue)
+        if let sdkVersion = MercadoPagoBundle.bundleShortVersionString() {
+            let value = "PX/iOS/" + sdkVersion
+            request.setValue(value, forHTTPHeaderField: MercadoPagoService.HeaderField.userAgent.rawValue)
+        }
+
+        // Add session id
+        request.setValue(MPXTracker.sharedInstance.getRequestId(), forHTTPHeaderField: MercadoPagoService.HeaderField.requestId.rawValue)
+        request.setValue(MPXTracker.sharedInstance.getSessionID(), forHTTPHeaderField: MercadoPagoService.HeaderField.sessionId.rawValue)
+
+        // Language
+        request.setValue(Localizator.sharedInstance.getLanguage(), forHTTPHeaderField: MercadoPagoService.HeaderField.language.rawValue)
+
+        //Density Header
+        request.setValue("xxxhdpi", forHTTPHeaderField: MercadoPagoService.HeaderField.density.rawValue)
+
+        // Add platform
+        request.setValue(MLBusinessAppDataService().getAppIdentifier().rawValue, forHTTPHeaderField: MercadoPagoService.HeaderField.platform.rawValue)
+        
+        // Add flow id
+        request.setValue(MPXTracker.sharedInstance.getFlowName() ?? "unknown", forHTTPHeaderField: MercadoPagoService.HeaderField.flowId.rawValue)
+        
+        return request
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/NetworkLayer/RequestProtocol.swift
@@ -1,0 +1,114 @@
+//
+//  RequestProtocol.swift
+//  AndesUI
+//
+//  Created by Matheus Leandro Martins on 05/02/21.
+//
+
+import Foundation
+
+protocol RequestProtocol {
+    associatedtype
+    Target: RequestInfos
+    func requestObject<Model: Codable>(model: Model.Type, _ target: Target, completionHandler: @escaping (_ result: Model?, _ error: Error?) -> Void)
+    func requestArray<Model: Codable>(model: Model.Type, _ target: Target, completionHandler: @escaping (_ result: [Model]?, _ error: Error?) -> Void)
+    func requestData(target: Target, completionHandler: @escaping (_ data: Data?, _ error: Error?) -> Void)
+}
+
+final class Requesting<Target: RequestInfos> : RequestProtocol {
+    //MARK: - Public methods
+    func requestObject<Model>(model: Model.Type, _ target: Target, completionHandler: @escaping (Model?, Error?) -> Void) where Model : Codable {
+        guard let url = URL(string: "\(target.baseURL)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
+            completionHandler(nil, NSError())
+            return
+        }
+        
+        var request = URLRequest(url: url)
+        
+        do {
+            request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.parameters)
+        } catch {
+            completionHandler(nil, NSError())
+        }
+        
+        URLSession.shared.dataTask(with: request) { data, resp, error in
+            if let error = error {
+                completionHandler(nil, error)
+            }
+            
+            guard let data = data else {
+                completionHandler(nil, NSError())
+                return
+            }
+            
+            do {
+                let modelList = try JSONDecoder().decode(Model.self , from: data)
+                completionHandler(modelList, nil)
+            } catch {
+                completionHandler(nil, NSError())
+            }
+        }.resume()
+    }
+    
+    func requestArray<Model: Codable>(model: Model.Type, _ target: Target, completionHandler: @escaping (_ result: [Model]?, _ error: Error?) -> Void) {
+        guard let url = URL(string: "\(target.baseURL)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
+            completionHandler(nil, NSError())
+            return
+        }
+        
+        var request = URLRequest(url: url)
+        
+        do {
+            request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.parameters)
+        } catch {
+            completionHandler(nil, NSError())
+        }
+        
+        URLSession.shared.dataTask(with: request) { data, resp, error in
+            if let error = error {
+                completionHandler(nil, error)
+            }
+            
+            guard let data = data else {
+                completionHandler(nil, NSError())
+                return
+            }
+            
+            do {
+                let modelList = try JSONDecoder().decode([Model].self , from: data)
+                completionHandler(modelList, nil)
+            } catch {
+                completionHandler(nil, NSError())
+            }
+        }.resume()
+    }
+    
+    func requestData(target: Target, completionHandler: @escaping (_ data: Data?, _ error: Error?) -> Void) {
+        guard let url = URL(string: "\(target.baseURL)\(target.endpoint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else {
+            completionHandler(nil, NSError())
+            return
+        }
+        
+        var request = URLRequest(url: url)
+        
+        do {
+            request = try target.parameterEncoding.encode(request: URLRequest(url: url), parameters: target.parameters)
+        } catch {
+            completionHandler(nil, NSError())
+        }
+        
+        URLSession.shared.dataTask(with: request) { data, resp, error in
+            if let error = error {
+                completionHandler(nil, error)
+            }
+            
+            guard let data = data else {
+                completionHandler(nil, NSError())
+                return
+            }
+            
+            completionHandler(data, nil)
+
+        }.resume()
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
@@ -120,12 +120,6 @@ internal class MercadoPagoServices: NSObject {
                 failure(error)
             }
         }
-
-        
-        
-//        let paymentMethodSearchService = PaymentMethodSearchService(baseURL: baseURL, merchantPublicKey: publicKey, payerAccessToken: privateKey, processingModes: processingModes, branchId: branchId)
-//
-//        paymentMethodSearchService.getClosedPrefInit(preferenceId: preferenceId, cardsWithEsc: cardsWithEsc, oneTapEnabled: oneTapEnabled, splitEnabled: splitEnabled, discountParamsConfiguration: discountParamsConfiguration, flow: flow, charges: charges, headers: headers, success: callback, failure: failure)
     }
 
     func createPayment(url: String, uri: String, transactionId: String? = nil, paymentDataJSON: Data, query: [String: String]? = nil, headers: [String: String]? = nil, callback : @escaping (PXPayment) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {
@@ -218,28 +212,6 @@ internal class MercadoPagoServices: NSObject {
                 failure(error)
             }
         }
-        
-//        let service: GatewayService = GatewayService(baseURL: getGatewayURL(), merchantPublicKey: publicKey, payerAccessToken: privateKey)
-//        guard let cardToken = cardToken else {
-//            return
-//        }
-//        service.getToken(cardTokenJSON: cardToken, success: {(data: Data) -> Void in
-//            do {
-//                let jsonResult = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
-//                var token : PXToken
-//                if let tokenDic = jsonResult as? NSDictionary {
-//                    if tokenDic["error"] == nil {
-//                        token = try JSONDecoder().decode(PXToken.self, from: data) as PXToken
-//                        callback(token)
-//                    } else {
-//                        let apiException = try JSONDecoder().decode(PXApiException.self, from: data) as PXApiException
-//                        failure(PXError(domain: ApiDomain.GET_TOKEN, code: ErrorTypes.API_EXCEPTION_ERROR, userInfo: tokenDic as? [String: Any], apiException: apiException))
-//                    }
-//                }
-//            } catch {
-//                failure(PXError(domain: ApiDomain.GET_TOKEN, code: ErrorTypes.API_UNKNOWN_ERROR, userInfo: [NSLocalizedDescriptionKey: "Hubo un error", NSLocalizedFailureReasonErrorKey: "No se ha podido crear el token"]))
-//            }
-//        }, failure: failure)
     }
 
     func cloneToken(tokenId: String, securityCode: String, callback : @escaping (PXToken) -> Void, failure: @escaping ((_ error: NSError) -> Void)) {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
@@ -147,7 +147,7 @@ internal class MercadoPagoServices: NSObject {
 
     func getPointsAndDiscounts(url: String, uri: String, paymentIds: [String]? = nil, paymentMethodsIds: [String]? = nil, campaignId: String?, prefId: String?, platform: String, ifpe: Bool, merchantOrderId: Int?, headers: [String: String], callback : @escaping (PXPointsAndDiscounts) -> Void, failure: @escaping (() -> Void)) {
         let parameters = CustomParametersModel(paymentMethodIds: getPaymentMethodsIds(paymentMethodsIds),
-                                               paymentiDS: getPaymentIds(paymentIds),
+                                               paymentId: getPaymentIds(paymentIds),
                                                ifpe: String(ifpe),
                                                prefId: prefId,
                                                campaignId: campaignId,

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
@@ -78,12 +78,6 @@ internal class MercadoPagoServices: NSObject {
                 failure(error)
             }
         }
-        
-        
-//        let instructionsService = InstructionsService(baseURL: baseURL, merchantPublicKey: publicKey, payerAccessToken: privateKey)
-//        instructionsService.getInstructions(for: paymentId, paymentTypeId: paymentTypeId, success: { (instructionsInfo : PXInstructions) -> Void in
-//            callback(instructionsInfo)
-//        }, failure: failure)
     }
 
     func getOpenPrefInitSearch(pref: PXCheckoutPreference, cardsWithEsc: [String], oneTapEnabled: Bool, splitEnabled: Bool, discountParamsConfiguration: PXDiscountParamsConfiguration?, flow: String?, charges: [PXPaymentTypeChargeRule], headers: [String: String]?, callback : @escaping (PXInitDTO) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {
@@ -101,10 +95,6 @@ internal class MercadoPagoServices: NSObject {
                 failure(error)
             }
         }
-        
-//        let paymentMethodSearchService = PaymentMethodSearchService(baseURL: baseURL, merchantPublicKey: publicKey, payerAccessToken: privateKey, processingModes: processingModes, branchId: branchId)
-//
-//        paymentMethodSearchService.getOpenPrefInit(pref: pref, cardsWithEsc: cardsWithEsc, oneTapEnabled: oneTapEnabled, splitEnabled: splitEnabled, discountParamsConfiguration: discountParamsConfiguration, flow: flow, charges: charges, headers: headers, success: callback, failure: failure)
     }
 
     func getClosedPrefInitSearch(preferenceId: String, cardsWithEsc: [String], oneTapEnabled: Bool, splitEnabled: Bool, discountParamsConfiguration: PXDiscountParamsConfiguration?, flow: String?, charges: [PXPaymentTypeChargeRule], headers: [String: String]?, callback : @escaping (PXInitDTO) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {
@@ -131,18 +121,6 @@ internal class MercadoPagoServices: NSObject {
                 failure(error)
             }
         }
-        
-        
-//        let service: CustomService = CustomService(baseURL: url, URI: uri)
-//
-//
-//        var params = MercadoPagoServices.getParamsPublicKeyAndAcessToken(publicKey, privateKey)
-//        params.paramsAppend(key: ApiParam.API_VERSION, value: PXServicesURLConfigs.API_VERSION)
-//        if let queryParams = query as NSDictionary? {
-//            params = queryParams.parseToQuery()
-//        }
-//
-//        service.createPayment(headers: headers, body: paymentDataJSON, params: params, success: callback, failure: failure)
     }
 
     func getPointsAndDiscounts(url: String, uri: String, paymentIds: [String]? = nil, paymentMethodsIds: [String]? = nil, campaignId: String?, prefId: String?, platform: String, ifpe: Bool, merchantOrderId: Int?, headers: [String: String], callback : @escaping (PXPointsAndDiscounts) -> Void, failure: @escaping (() -> Void)) {
@@ -160,35 +138,6 @@ internal class MercadoPagoServices: NSObject {
                 failure()
             }
         }
-        
-        
-        
-        
-        
-        
-//
-//        let service: CustomService = CustomService(baseURL: url, URI: uri)
-//
-//        var params = MercadoPagoServices.getParamsAccessTokenAndPaymentIdsAndPlatform(privateKey, paymentIds, platform)
-//        params.paramsAppend(key: ApiParam.PAYMENT_METHODS_IDS, value: getPaymentMethodsIds(paymentMethodsIds))
-//
-//        params.paramsAppend(key: ApiParam.API_VERSION, value: PXServicesURLConfigs.API_VERSION)
-//        params.paramsAppend(key: ApiParam.IFPE, value: String(ifpe))
-//        params.paramsAppend(key: ApiParam.PREF_ID, value: prefId)
-//
-//        if let campaignId = campaignId {
-//            params.paramsAppend(key: ApiParam.CAMPAIGN_ID, value: campaignId)
-//        }
-//
-//        if let flowName = MPXTracker.sharedInstance.getFlowName() {
-//            params.paramsAppend(key: ApiParam.FLOW_NAME, value: flowName)
-//        }
-//
-//        if let merchantOrderId = merchantOrderId {
-//            params.paramsAppend(key: ApiParam.MERCHANT_ORDER_ID, value: String(merchantOrderId))
-//        }
-//
-//        service.getPointsAndDiscounts(headers: headers, body: nil, params: params, success: callback, failure: failure)
     }
 
     func createToken(cardToken: PXCardToken, callback : @escaping (PXToken) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {
@@ -204,7 +153,6 @@ internal class MercadoPagoServices: NSObject {
     }
 
     func createToken(cardToken: Data?, callback : @escaping (PXToken) -> Void, failure: @escaping ((_ error: PXError) -> Void)) {
-        
         gatewayService.getToken(accessToken: privateKey, publicKey: publicKey, cardTokenJSON: cardToken) { token, error in
             if let token = token {
                 callback(token)
@@ -222,12 +170,7 @@ internal class MercadoPagoServices: NSObject {
                 failure(error)
             }
         }
-        
-        
-        
-        
-        
-        
+
 //        let service: GatewayService = GatewayService(baseURL: getGatewayURL(), merchantPublicKey: publicKey, payerAccessToken: privateKey)
 //        service.cloneToken(public_key: publicKey, tokenId: tokenId, securityCode: securityCode, success: {(data: Data) -> Void in
 //            do {
@@ -257,23 +200,6 @@ internal class MercadoPagoServices: NSObject {
                 failure(error)
             }
         }
-        
-//        let service = RemedyService(baseURL: baseURL, payerAccessToken: privateKey)
-
-//        service.getRemedy(for: paymentMethodId, payerPaymentMethodRejected: payerPaymentMethodRejected, alternativePayerPaymentMethods: alternativePayerPaymentMethods, oneTap: oneTap, success: { data -> Void in
-//            guard let data = data else {
-//                failure(PXError(domain: ApiDomain.GET_REMEDY, code: ErrorTypes.API_UNKNOWN_ERROR, userInfo: [NSLocalizedDescriptionKey: "Hubo un error", NSLocalizedFailureReasonErrorKey: "No se ha podido obtener el remedy"]))
-//                return
-//            }
-//            do {
-//                let decoder = JSONDecoder()
-//                decoder.keyDecodingStrategy = .convertFromSnakeCase
-//                let responseObject = try decoder.decode(PXRemedy.self, from: data)
-//                success(responseObject)
-//            } catch {
-//                failure(PXError(domain: ApiDomain.GET_REMEDY, code: ErrorTypes.API_UNKNOWN_ERROR, userInfo: [NSLocalizedDescriptionKey: "Hubo un error", NSLocalizedFailureReasonErrorKey: "No se ha podido obtener el remedy"]))
-//            }
-//        }, failure: failure)
     }
 
     //SETS

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAvailableFeatures.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXAvailableFeatures.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PXAvailableFeatures: Decodable {
+struct PXAvailableFeatures: Codable {
     let id: String
     let enabled: Bool
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCrossSellingItem.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXCrossSellingItem.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objcMembers
-public class PXCrossSellingItem: NSObject ,Decodable {
+public class PXCrossSellingItem: NSObject, Codable {
 
     let title: String
     let icon: String

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXDiscounts.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXDiscounts.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objcMembers
-public class PXDiscounts: NSObject , Decodable {
+public class PXDiscounts: NSObject , Codable {
 
     let title: String?
     let subtitle: String?

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXDiscountsItem.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXDiscountsItem.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objcMembers
-public class PXDiscountsItem: NSObject, Decodable {
+public class PXDiscountsItem: NSObject, Codable {
 
     let icon: String
     let title: String

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXDiscountsTouchpoint.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXDiscountsTouchpoint.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objcMembers
-public class PXDiscountsTouchpoint: NSObject, Decodable {
+public class PXDiscountsTouchpoint: NSObject, Codable {
 
     let id: String
     let type: String

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXDownloadAction.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXDownloadAction.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objcMembers
-public class PXDownloadAction: NSObject, Decodable {
+public class PXDownloadAction: NSObject, Codable {
     let title: String
     let action: PXRemoteAction
     

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXExperiment.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXExperiment.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PXExperiment: Decodable {
+struct PXExperiment: Codable {
     let id: Int
     let name: String
     let variant: PXVariant

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXInitConfigurations.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXInitConfigurations.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class PXInitConfigurations: Decodable {
+final class PXInitConfigurations: Codable {
     let ESCBlacklistedStatus: [String]?
 
     enum CodingKeys: String, CodingKey {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXInitDTO.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXInitDTO.swift
@@ -25,7 +25,7 @@ public struct PXModal: Codable {
 
 import Foundation
 /// :nodoc:
-final class PXInitDTO: NSObject, Decodable {
+final class PXInitDTO: NSObject, Codable {
     public var preference: PXCheckoutPreference?
     public var oneTap: [PXOneTapDto]?
     public var currency: PXCurrency

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPoints.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPoints.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objcMembers
-public class PXPoints: NSObject, Decodable {
+public class PXPoints: NSObject, Codable {
 
     let progress: PXPointsProgress
     let title: String

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPointsAndDiscounts.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPointsAndDiscounts.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PXPointsAndDiscounts: Decodable {
+struct PXPointsAndDiscounts: Codable {
 
     let points: PXPoints?
     let discounts: PXDiscounts?

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPointsProgress.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPointsProgress.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objcMembers
-public class PXPointsProgress: NSObject, Decodable {
+public class PXPointsProgress: NSObject, Codable {
 
     let percentage: Double
     let levelColor: String

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXVariant.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXVariant.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PXVariant: Decodable {
+struct PXVariant: Codable {
     let id: Int
     let name: String
     let availableFeatures: [PXAvailableFeatures]

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoServicesTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoServicesTest.swift
@@ -1,0 +1,33 @@
+//
+//  MercadoPagoServicesTest.swift
+//  Pods
+//
+//  Created by Matheus Leandro Martins on 10/02/21.
+//
+
+import XCTest
+@testable import MercadoPagoSDKV4
+
+class MercadoPagoServicesTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoServicesTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoServicesTest.swift
@@ -8,26 +8,345 @@
 import XCTest
 @testable import MercadoPagoSDKV4
 
+class CustomServiceMock: CustomServices {
+    var successResponse = true
+    var calledGetPointsAndDiscounts = false
+    var calledResetESCCap = false
+    var calledCreatePayment = false
+    
+    func getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel, response: @escaping (PXPointsAndDiscounts?, Void?) -> Void) {
+        calledGetPointsAndDiscounts = true
+        successResponse ? response(PXPointsAndDiscounts(points: nil,
+                                                        discounts: nil,
+                                                        crossSelling: nil,
+                                                        viewReceiptAction: nil,
+                                                        topTextBox: nil,
+                                                        customOrder: nil,
+                                                        expenseSplit: nil,
+                                                        paymentMethodsImages: nil,
+                                                        primaryButton: nil,
+                                                        secondaryButton: nil,
+                                                        redirectUrl: nil,
+                                                        backUrl: nil,
+                                                        autoReturn: nil), nil) : response(nil, ())
+    }
+    
+    func resetESCCap(cardId: String, privateKey: String?, response: @escaping (Void?, PXError?) -> Void) {
+        calledResetESCCap = true
+        successResponse ? response((), nil) : response(nil, PXError(domain: "", code: 0))
+    }
+    
+    func createPayment(privateKey: String?, publicKey: String, data: Data?, header: [String : String]?, response: @escaping (PXPayment?, PXError?) -> Void) {
+        calledCreatePayment = true
+        successResponse ? response(PXPayment(id: 0, status: ""), nil) : response(nil, PXError(domain: "", code: 0))
+    }
+}
+
+class RemedyServicesMock: RemedyServices {
+    var successResponse = true
+    var calledGetRemedy = false
+    
+    func getRemedy(privateKey: String?, oneTap: Bool, payerPaymentMethodRejected: PXPayerPaymentMethodRejected, alternativePayerPaymentMethods: [PXRemedyPaymentMethod]?, completion: @escaping (PXRemedy?, PXError?) -> Void) {
+        calledGetRemedy = true
+        successResponse ? completion(PXRemedy(), nil) : completion(nil, PXError(domain: "", code: 0))
+    }
+}
+
+class InstructionsServicesMock: InstructionsServices {
+    var successResponse = true
+    var calledGetInstructions = false
+    
+    func getInstructions(paymentId: String, paymentTypeId: String, accessToken: String?, publicKey: String, completion: @escaping (PXInstructions?, PXError?) -> Void) {
+        calledGetInstructions = true
+        successResponse ? completion(PXInstructions(amountInfo: nil, instructions: []), nil) : completion(nil, PXError(domain: "", code: 0))
+    }
+}
+
+class GatewayServicesMock: GatewayServices {
+    var successResponse = true
+    var calledGetToken = false
+    var calledCloneToken = false
+    var calledValidateToken = false
+    
+    func getToken(accessToken: String?, publicKey: String, cardTokenJSON: Data?, completion: @escaping (PXToken?, PXError?) -> Void) {
+        calledGetToken = true
+        successResponse ? completion(PXToken(id: "", publicKey: nil, cardId: "", luhnValidation: nil, status: nil, usedDate: nil, cardNumberLength: 0, dateCreated: nil, securityCodeLength: 0, expirationMonth: 0, expirationYear: 0, dateLastUpdated: nil, dueDate: nil, firstSixDigits: "", lastFourDigits: "", cardholder: nil, esc: nil), nil) : completion(nil, PXError(domain: "", code: 0))
+    }
+    
+    func cloneToken(tokeniD: String, publicKey: String, securityCode: String, completion: @escaping (PXToken?, PXError?) -> Void) {
+        calledCloneToken = true
+        successResponse ? completion(PXToken(id: "", publicKey: nil, cardId: "", luhnValidation: nil, status: nil, usedDate: nil, cardNumberLength: 0, dateCreated: nil, securityCodeLength: 0, expirationMonth: 0, expirationYear: 0, dateLastUpdated: nil, dueDate: nil, firstSixDigits: "", lastFourDigits: "", cardholder: nil, esc: nil), nil) : completion(nil, PXError(domain: "", code: 0))
+    }
+    
+    func validateToken(tokenId: String, publicKey: String, body: Data, completion: @escaping (PXToken?, PXError?) -> Void) {
+        calledValidateToken = true
+        successResponse ? completion(PXToken(id: "", publicKey: nil, cardId: "", luhnValidation: nil, status: nil, usedDate: nil, cardNumberLength: 0, dateCreated: nil, securityCodeLength: 0, expirationMonth: 0, expirationYear: 0, dateLastUpdated: nil, dueDate: nil, firstSixDigits: "", lastFourDigits: "", cardholder: nil, esc: nil), nil) : completion(nil, PXError(domain: "", code: 0))
+    }
+}
+
+class PaymentServicesMock: PaymentServices {
+    var successResponse = true
+    var calledGetInit = false
+    func getInit(preferenceId: String?, privateKey: String?, body: Data?, headers: [String : String]?, completion: @escaping (PXInitDTO?, PXError?) -> Void) {
+        calledGetInit = true
+        successResponse ? completion(PXInitDTO(preference: nil, oneTap: nil, currency: PXCurrency(id: "", description: nil, symbol: nil, decimalPlaces: nil, decimalSeparator: nil, thousandSeparator: nil), site: PXSite(id: "", currencyId: nil, termsAndConditionsUrl: "", shouldWarnAboutBankInterests: nil), generalCoupon: "", coupons: [:], groups: [], payerPaymentMethods: [], availablePaymentMethods: [], experiments: nil, payerCompliance: nil, configurations: nil, modals: [:]), nil) : completion(nil, PXError(domain: "", code: 0))
+    }
+}
+
 class MercadoPagoServicesTest: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    var sut: MercadoPagoServices!
+    
+    var customService: CustomServiceMock!
+    var remedyService: RemedyServicesMock!
+    var instructionsService: InstructionsServicesMock!
+    var gatewayService: GatewayServicesMock!
+    var paymentService: PaymentServicesMock!
+    
+    
+    override func setUp() {
+        super.setUp()
+        customService = CustomServiceMock()
+        remedyService = RemedyServicesMock()
+        instructionsService = InstructionsServicesMock()
+        gatewayService = GatewayServicesMock()
+        paymentService = PaymentServicesMock()
+        sut = MercadoPagoServices(publicKey: "Test",
+                                  privateKey: "Tests",
+                                  customService: customService,
+                                  remedyService: remedyService,
+                                  instructionsService: instructionsService,
+                                  gatewayService: gatewayService,
+                                  paymentService: paymentService)
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    
+    //Has same behavior on success and failure
+    func testResetESCCap() {
+        var hadCallback = false
+        XCTAssertTrue(customService.calledResetESCCap == false)
+        sut.resetESCCap(cardId: "") {
+            hadCallback = true
         }
+        XCTAssertTrue(hadCallback == true)
+        XCTAssertTrue(customService.calledResetESCCap == true)
     }
+    
+    func testCreatePaymentSuccess() {
+        var hasError = true
+        XCTAssertTrue(customService.calledCreatePayment == false)
+        sut.createPayment(url: "", uri: "", transactionId: "", paymentDataJSON: Data(), query: nil, headers: nil) { _ in
+            hasError = false
+        } failure: {  _ in
+            hasError = true
+        }
+        XCTAssertTrue(customService.calledCreatePayment == true)
+        XCTAssertTrue(hasError == false)
+    }
+    
+    func testCreatePaymentFailure() {
+        customService.successResponse = false
+        var hasError = false
+        XCTAssertTrue(customService.calledCreatePayment == false)
+        sut.createPayment(url: "", uri: "", transactionId: "", paymentDataJSON: Data(), query: nil, headers: nil) { _ in
+            hasError = false
+        } failure: {  _ in
+            hasError = true
+        }
+        XCTAssertTrue(customService.calledCreatePayment == true)
+        XCTAssertTrue(hasError == true)
+    }
+    
+    func testGetPointsAndDiscountsSuccess() {
+        var hasError = true
+        XCTAssertTrue(customService.calledGetPointsAndDiscounts == false)
+        sut.getPointsAndDiscounts(url: "", uri: "", paymentIds: nil, paymentMethodsIds: nil, campaignId: nil, prefId: nil, platform: "", ifpe: true, merchantOrderId: 0, headers: [:]) { _ in
+            hasError = false
+        } failure: {
+            hasError = true
+        }
 
+        XCTAssertTrue(customService.calledGetPointsAndDiscounts == true)
+        XCTAssertTrue(hasError == false)
+    }
+    
+    func testGetPointsAndDiscountsFailure() {
+        customService.successResponse = false
+        var hasError = false
+        XCTAssertTrue(customService.calledGetPointsAndDiscounts == false)
+        sut.getPointsAndDiscounts(url: "", uri: "", paymentIds: nil, paymentMethodsIds: nil, campaignId: nil, prefId: nil, platform: "", ifpe: true, merchantOrderId: 0, headers: [:]) { _ in
+            hasError = false
+        } failure: {
+            hasError = true
+        }
+
+        XCTAssertTrue(customService.calledGetPointsAndDiscounts == true)
+        XCTAssertTrue(hasError == true)
+    }
+    
+    func testGetRemedySuccess() {
+        var hasError = true
+        XCTAssertTrue(remedyService.calledGetRemedy == false)
+        sut.getRemedy(for: "", payerPaymentMethodRejected: PXPayerPaymentMethodRejected(customOptionId: nil, paymentMethodId: nil, paymentTypeId: nil, issuerName: nil, lastFourDigit: nil, securityCodeLocation: nil, securityCodeLength: nil, totalAmount: nil, installments: nil, escStatus: nil), alternativePayerPaymentMethods: nil, oneTap: true) { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+
+        XCTAssertTrue(remedyService.calledGetRemedy == true)
+        XCTAssertTrue(hasError == false)
+    }
+    
+    func testGetRemedyFailure() {
+        remedyService.successResponse = false
+        var hasError = false
+        XCTAssertTrue(remedyService.calledGetRemedy == false)
+        sut.getRemedy(for: "", payerPaymentMethodRejected: PXPayerPaymentMethodRejected(customOptionId: nil, paymentMethodId: nil, paymentTypeId: nil, issuerName: nil, lastFourDigit: nil, securityCodeLocation: nil, securityCodeLength: nil, totalAmount: nil, installments: nil, escStatus: nil), alternativePayerPaymentMethods: nil, oneTap: true) { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+
+        XCTAssertTrue(remedyService.calledGetRemedy == true)
+        XCTAssertTrue(hasError == true)
+    }
+    
+    func testGetInstructionsSuccess() {
+        var hasError = true
+        XCTAssertTrue(instructionsService.calledGetInstructions == false)
+        sut.getInstructions(paymentId: 0, paymentTypeId: "") { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+        
+        XCTAssertTrue(instructionsService.calledGetInstructions == true)
+        XCTAssertTrue(hasError == false)
+    }
+    
+    func testGetInstructionsFailure() {
+        instructionsService.successResponse = false
+        var hasError = true
+        XCTAssertTrue(instructionsService.calledGetInstructions == false)
+        sut.getInstructions(paymentId: 0, paymentTypeId: "") { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+        
+        XCTAssertTrue(instructionsService.calledGetInstructions == true)
+        XCTAssertTrue(hasError == true)
+    }
+    
+    func testCreateTokenSuccess() {
+        var hasError = true
+        XCTAssertTrue(gatewayService.calledGetToken == false)
+        sut.createToken(cardToken: PXCardToken(cardNumber: nil, expirationMonth: 0, expirationYear: 0, securityCode: nil, cardholderName: "", docType: "", docNumber: "")) { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+
+        
+        XCTAssertTrue(gatewayService.calledGetToken == true)
+        XCTAssertTrue(hasError == false)
+    }
+    
+    func testCreateTokenFailure() {
+        gatewayService.successResponse = false
+        var hasError = false
+        XCTAssertTrue(gatewayService.calledGetToken == false)
+        sut.createToken(cardToken: PXCardToken(cardNumber: nil, expirationMonth: 0, expirationYear: 0, securityCode: nil, cardholderName: "", docType: "", docNumber: "")) { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+
+        
+        XCTAssertTrue(gatewayService.calledGetToken == true)
+        XCTAssertTrue(hasError == true)
+    }
+    
+    func testCloneTokenSuccess() {
+        var hasError = true
+        XCTAssertTrue(gatewayService.calledCloneToken == false)
+        sut.cloneToken(tokenId: "", securityCode: "") { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+        
+        XCTAssertTrue(gatewayService.calledCloneToken == true)
+        XCTAssertTrue(hasError == false)
+    }
+    
+    func testCloneTokenFailure() {
+        gatewayService.successResponse = false
+        var hasError = true
+        XCTAssertTrue(gatewayService.calledCloneToken == false)
+        sut.cloneToken(tokenId: "", securityCode: "") { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+        
+        XCTAssertTrue(gatewayService.calledCloneToken == true)
+        XCTAssertTrue(hasError == true)
+    }
+    
+    func testGetOpenPrefInitSearchSuccess() {
+        var hasError = true
+        XCTAssertTrue(paymentService.calledGetInit == false)
+        sut.getOpenPrefInitSearch(pref: PXCheckoutPreference(preferenceId: ""), cardsWithEsc: [], oneTapEnabled: true, splitEnabled: true, discountParamsConfiguration: nil, flow: nil, charges: [], headers: nil) { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+
+        
+        XCTAssertTrue(paymentService.calledGetInit == true)
+        XCTAssertTrue(hasError == false)
+    }
+    
+    func testGetOpenPrefInitSearchFailure() {paymentService.successResponse = false
+        var hasError = true
+        XCTAssertTrue(paymentService.calledGetInit == false)
+        sut.getOpenPrefInitSearch(pref: PXCheckoutPreference(preferenceId: ""), cardsWithEsc: [], oneTapEnabled: true, splitEnabled: true, discountParamsConfiguration: nil, flow: nil, charges: [], headers: nil) { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+        
+        XCTAssertTrue(paymentService.calledGetInit == true)
+        XCTAssertTrue(hasError == true)
+    }
+    
+    func testGetClosedPrefInitSearchSuccess() {
+        var hasError = true
+        XCTAssertTrue(paymentService.calledGetInit == false)
+        sut.getClosedPrefInitSearch(preferenceId: "", cardsWithEsc: [], oneTapEnabled: true, splitEnabled: true, discountParamsConfiguration: nil, flow: nil, charges: [], headers: nil) { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+
+
+        
+        XCTAssertTrue(paymentService.calledGetInit == true)
+        XCTAssertTrue(hasError == false)
+    }
+    
+    func testGetClosedPrefInitSearchFailure() {
+        paymentService.successResponse = false
+        var hasError = true
+        XCTAssertTrue(paymentService.calledGetInit == false)
+        sut.getClosedPrefInitSearch(preferenceId: "", cardsWithEsc: [], oneTapEnabled: true, splitEnabled: true, discountParamsConfiguration: nil, flow: nil, charges: [], headers: nil) { _ in
+            hasError = false
+        } failure: { _ in
+            hasError = true
+        }
+
+
+        
+        XCTAssertTrue(paymentService.calledGetInit == true)
+        XCTAssertTrue(hasError == true)
+    }
 }

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoServicesTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoServicesTest.swift
@@ -14,9 +14,9 @@ class CustomServiceMock: CustomServices {
     var calledResetESCCap = false
     var calledCreatePayment = false
     
-    func getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel, response: @escaping (PXPointsAndDiscounts?, Void?) -> Void) {
+    func getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel, completion: @escaping (PXPointsAndDiscounts?, Void?) -> Void) {
         calledGetPointsAndDiscounts = true
-        successResponse ? response(PXPointsAndDiscounts(points: nil,
+        successResponse ? completion(PXPointsAndDiscounts(points: nil,
                                                         discounts: nil,
                                                         crossSelling: nil,
                                                         viewReceiptAction: nil,
@@ -28,7 +28,7 @@ class CustomServiceMock: CustomServices {
                                                         secondaryButton: nil,
                                                         redirectUrl: nil,
                                                         backUrl: nil,
-                                                        autoReturn: nil), nil) : response(nil, ())
+                                                        autoReturn: nil), nil) : completion(nil, ())
     }
     
     func resetESCCap(cardId: String, privateKey: String?, response: @escaping (Void?, PXError?) -> Void) {
@@ -126,6 +126,7 @@ class MercadoPagoServicesTest: XCTestCase {
         sut.resetESCCap(cardId: "") {
             hadCallback = true
         }
+        
         XCTAssertTrue(hadCallback == true)
         XCTAssertTrue(customService.calledResetESCCap == true)
     }
@@ -138,6 +139,7 @@ class MercadoPagoServicesTest: XCTestCase {
         } failure: {  _ in
             hasError = true
         }
+        
         XCTAssertTrue(customService.calledCreatePayment == true)
         XCTAssertTrue(hasError == false)
     }
@@ -151,6 +153,7 @@ class MercadoPagoServicesTest: XCTestCase {
         } failure: {  _ in
             hasError = true
         }
+        
         XCTAssertTrue(customService.calledCreatePayment == true)
         XCTAssertTrue(hasError == true)
     }
@@ -245,7 +248,6 @@ class MercadoPagoServicesTest: XCTestCase {
             hasError = true
         }
 
-        
         XCTAssertTrue(gatewayService.calledGetToken == true)
         XCTAssertTrue(hasError == false)
     }
@@ -259,7 +261,6 @@ class MercadoPagoServicesTest: XCTestCase {
         } failure: { _ in
             hasError = true
         }
-
         
         XCTAssertTrue(gatewayService.calledGetToken == true)
         XCTAssertTrue(hasError == true)
@@ -327,8 +328,6 @@ class MercadoPagoServicesTest: XCTestCase {
         } failure: { _ in
             hasError = true
         }
-
-
         
         XCTAssertTrue(paymentService.calledGetInit == true)
         XCTAssertTrue(hasError == false)
@@ -343,8 +342,6 @@ class MercadoPagoServicesTest: XCTestCase {
         } failure: { _ in
             hasError = true
         }
-
-
         
         XCTAssertTrue(paymentService.calledGetInit == true)
         XCTAssertTrue(hasError == true)

--- a/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoServicesTest.swift
+++ b/MercadoPagoSDK/MercadoPagoSDKTests/MercadoPagoServicesTest.swift
@@ -14,7 +14,7 @@ class CustomServiceMock: CustomServices {
     var calledResetESCCap = false
     var calledCreatePayment = false
     
-    func getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel, completion: @escaping (PXPointsAndDiscounts?, Void?) -> Void) {
+    func getPointsAndDiscounts(data: Data?, parameters: CustomParametersModel, response completion: @escaping (PXPointsAndDiscounts?, Void?) -> Void) {
         calledGetPointsAndDiscounts = true
         successResponse ? completion(PXPointsAndDiscounts(points: nil,
                                                         discounts: nil,


### PR DESCRIPTION
###  This PR changes network layer on SDK and setup things to allow it to be tested through ExampleSwift

#### Things to be done yet: 
- Remove files related to old style to make requests
- Adjust some class to be easier to be read
- Rename network files that contains a s on it's end to not conflict with the existing ones (that i did not erase yet because i could not test every call px makes)
- Class `MercadoPagoServices` has some commented lines, it’s mark the requests i could not trigger

#### Things i would like you guys to test
- Every single request that is possible to do on PX and assure its behavior is whats its suppose to be
- Files that can be deteled

###  Other infos

This PR also removes old tests that were no longer useful to us and tests `MercadoPagoServices` that has all SDK requests in it


