### PR TITLE
Implemented security code mode check

### DIFF
--- a/ExampleSwift/ExampleSwift.xcodeproj/project.pbxproj
+++ b/ExampleSwift/ExampleSwift.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 /* Begin XCBuildConfiguration section */
 		23EDA1432147DFC90085CA7A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5AE9791B259B89BF00D32A84 /* Config.example.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -369,6 +370,7 @@
 		};
 		23EDA1442147DFC90085CA7A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5AE9791B259B89BF00D32A84 /* Config.example.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -456,6 +458,7 @@
 		};
 		5AE8259D258B80AD002C7F74 /* Alpha */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5AE9791B259B89BF00D32A84 /* Config.example.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckoutScreens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckoutScreens.swift
@@ -12,6 +12,10 @@ extension MercadoPagoCheckout {
 
     func showSecurityCodeScreen() {
         guard !viewModel.isPXSecurityCodeViewControllerLastVC() else { return }
+        if viewModel.paymentData.paymentMethod?.settings.first?.securityCode?.mode == .optional {
+            return
+        }
+        
         let securityCodeViewModel = viewModel.getPXSecurityCodeViewModel(isCallForAuth: true)
 
         let securityCodeVC = PXSecurityCodeViewController(

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+Screens.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow+Screens.swift
@@ -53,6 +53,9 @@ extension OneTapFlow {
     }
 
     func showSecurityCodeScreen() {
+        if model.paymentData.paymentMethod?.settings.first?.securityCode?.mode == .optional {
+            return
+        }
         guard !isPXSecurityCodeViewControllerLastVC() else { return }
         let securityCodeVc = PXSecurityCodeViewController(viewModel: model.savedCardSecurityCodeViewModel(),
             finishButtonAnimationCallback: { [weak self] in

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXSecurityCode.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXSecurityCode.swift
@@ -11,10 +11,10 @@ import Foundation
 open class PXSecurityCode: NSObject, Codable {
 
     open var cardLocation: String?
-    open var mode: String?
+    open var mode: PXSecurityMode?
     open var length: Int = 0
 
-    public init(cardLocation: String?, mode: String?, length: Int) {
+    public init(cardLocation: String?, mode: PXSecurityMode?, length: Int) {
         self.cardLocation = cardLocation
         self.mode = mode
         self.length = length
@@ -25,11 +25,16 @@ open class PXSecurityCode: NSObject, Codable {
         case mode
         case length
     }
+    
+    public enum PXSecurityMode: String, Codable {
+        case mandatory
+        case optional
+    }
 
     required public convenience init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: PXSecurityCodeKeys.self)
         let cardLocation: String? = try container.decodeIfPresent(String.self, forKey: .cardLocation)
-        let mode: String? = try container.decodeIfPresent(String.self, forKey: .mode)
+        let mode: PXSecurityMode? = try container.decodeIfPresent(PXSecurityMode.self, forKey: .mode)
         let length: Int = try container.decodeIfPresent(Int.self, forKey: .length) ?? 0
 
         self.init(cardLocation: cardLocation, mode: mode, length: length)


### PR DESCRIPTION
En la firma de /checkout, dentro del nodo available_payment_methods -> settings, existe el nodo de security_code que tiene información para validar el cvv. Debemos agregar mode como un nuevo campo dentro de ese nodo y tenerlo en cuenta a la hora de solicitar el cvv al usuario.Los valores esperados son: “mandatory” / “optional”