### PR TITLE
Adds a method to return validationProgramId value

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/PXCheckoutStore.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/PXCheckoutStore.swift
@@ -46,6 +46,13 @@ extension PXCheckoutStore {
     public func getCheckoutPreference() -> PXCheckoutPreference? {
         return checkoutPreference
     }
+    
+    /**
+     Get `validationProgramId` propertie.
+     */
+    public func getValidationProgramId() -> String? {
+        return validationProgramId
+    }
 
     /**
      Get `PXSecurity` type.


### PR DESCRIPTION
This PR adds a method to return `validationProgramId` value on PXCheckoutStore