### PR TITLE
Chore/generic error title

### DIFF
--- a/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
+++ b/ExampleSwift/ExampleSwift/Controllers/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
     private var privateKey : String = ""
     
     // Preference ID
-    private var preferenceId : String = "656525290-7bda964b-26d9-4352-a04c-1b04801627ee"
+    private var preferenceId : String = "99997433-5f6141dc-0a60-4b64-96a8-ef781e5d7d76"
     
     @IBAction func initDefault(_ sender: Any) {
 //         runMercadoPagoCheckout()

--- a/ExampleSwift/ExampleSwift/Helpers/CustomPaymentProcessor.swift
+++ b/ExampleSwift/ExampleSwift/Helpers/CustomPaymentProcessor.swift
@@ -23,8 +23,8 @@ class CustomPaymentProcessor : NSObject, PXPaymentProcessor {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0, execute: {
 //            successWithPaymentResult(PXGenericPayment(paymentStatus: .APPROVED, statusDetail: "Pago aprobado desde procesadora custom!"))
-//            successWithPaymentResult(PXGenericPayment(paymentStatus: .REJECTED, statusDetail: "Pago rechazado desde procesadora custom!"))
-            successWithBusinessResult(PXBusinessResult(receiptId: "Random ID", status: .APPROVED, title: "Business title", subtitle: "Business subtitle", icon: nil, mainAction: PXAction(label: "Business action", action: { print("Action business") }), secondaryAction: nil, helpMessage: "Business help message", showPaymentMethod: true, statementDescription: "Business statement description", imageUrl: nil, topCustomView: nil, bottomCustomView: nil, paymentStatus: "Aprobado business", paymentStatusDetail: "Detalle status business", paymentMethodId: "paymentMethodId", paymentTypeId: "paymentTypeId", importantView: nil))
+            successWithPaymentResult(PXGenericPayment(paymentStatus: .REJECTED, statusDetail: "cc_amount_rate_limit_exceeded"))
+//            successWithBusinessResult(PXBusinessResult(receiptId: "Random ID", status: .APPROVED, title: "Business title", subtitle: "Business subtitle", icon: nil, mainAction: PXAction(label: "Business action", action: { print("Action business") }), secondaryAction: nil, helpMessage: "Business help message", showPaymentMethod: true, statementDescription: "Business statement description", imageUrl: nil, topCustomView: nil, bottomCustomView: nil, paymentStatus: "Aprobado business", paymentStatusDetail: "Detalle status business", paymentMethodId: "paymentMethodId", paymentTypeId: "paymentTypeId", importantView: nil))
         })
                 
     }

--- a/Helpers/Double+Extensions.swift
+++ b/Helpers/Double+Extensions.swift
@@ -1,8 +1,0 @@
-//
-//  Double+Extensions.swift
-//  AndesUI
-//
-//  Created by Matheus Leandro Martins on 20/04/21.
-//
-
-import Foundation

--- a/Helpers/Double+Extensions.swift
+++ b/Helpers/Double+Extensions.swift
@@ -1,0 +1,8 @@
+//
+//  Double+Extensions.swift
+//  AndesUI
+//
+//  Created by Matheus Leandro Martins on 20/04/21.
+//
+
+import Foundation

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResourceProvider.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResourceProvider.swift
@@ -123,11 +123,6 @@ internal class PXResourceProvider {
     }
 
     static internal func getErrorTitleKey(statusDetail: String) -> String {
-        switch statusDetail {
-        case PXPayment.StatusDetails.REJECTED_BY_BANK, PXPayment.StatusDetails.REJECTED_INSUFFICIENT_DATA, PXPayment.StatusDetails.REJECTED_BY_REGULATIONS, PXPayment.StatusDetails.REJECTED_OTHER_REASON:
-            return error_title_default
-        default:
-            return statusDetail + "_title"
-        }
+        return error_title_default
     }
 }


### PR DESCRIPTION
This PR always return the generic error title while we do not map every possible scenario 

## How to test?

On `CustomPaymentProcessor` file in line 26, you can give every string as `statusDetail` parameter, it always will show the default error title on congrats