### PR TITLE
feat: Using behaviours from applications node if they're available

### DIFF
--- a/ExampleSwift/ExampleSwift.xcodeproj/project.pbxproj
+++ b/ExampleSwift/ExampleSwift.xcodeproj/project.pbxproj
@@ -269,7 +269,6 @@
 				"${BUILT_PRODUCTS_DIR}/AndesUI/AndesUI.framework",
 				"${BUILT_PRODUCTS_DIR}/FXBlurView/FXBlurView.framework",
 				"${BUILT_PRODUCTS_DIR}/JRSwizzle/JRSwizzle.framework",
-				"${BUILT_PRODUCTS_DIR}/MLBusinessComponents/MLBusinessComponents.framework",
 				"${BUILT_PRODUCTS_DIR}/MLUI/MLUI.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -277,7 +276,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AndesUI.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FXBlurView.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JRSwizzle.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MLBusinessComponents.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MLUI.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewModel.swift
@@ -609,7 +609,9 @@ extension PXOneTapViewModel {
                 }
             }
             
-            let cardSliderApplication = PXCardSliderApplicationData(paymentMethodId: paymentMethodId, paymentTypeId: paymentMethodType, cardData: cardData, cardUI: cardUI, payerCost: payerCosts ?? defaultPayerCost, selectedPayerCost: selectedPayerCost, shouldShowArrow: showArrow, amountConfiguration: amountConfiguration, status: statusConfig, bottomMessage: chargeRuleMessage, benefits: PXPaymentTypes.CREDIT_CARD.rawValue == paymentMethodType ? targetNode.benefits : nil, payerPaymentMethod: payerPaymentMethod, behaviours: targetNode.behaviours, displayInfo: targetNode.displayInfo, displayMessage: displayMessage)
+            let behaviours = application.behaviours ?? targetNode.behaviours
+            
+            let cardSliderApplication = PXCardSliderApplicationData(paymentMethodId: paymentMethodId, paymentTypeId: paymentMethodType, cardData: cardData, cardUI: cardUI, payerCost: payerCosts ?? defaultPayerCost, selectedPayerCost: selectedPayerCost, shouldShowArrow: showArrow, amountConfiguration: amountConfiguration, status: statusConfig, bottomMessage: chargeRuleMessage, benefits: PXPaymentTypes.CREDIT_CARD.rawValue == paymentMethodType ? targetNode.benefits : nil, payerPaymentMethod: payerPaymentMethod, behaviours: behaviours, displayInfo: targetNode.displayInfo, displayMessage: displayMessage)
             
             cardSliderApplications[paymentMethodType] = cardSliderApplication
         }

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/OneTap/PXOneTapApplication.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/OneTap/PXOneTapApplication.swift
@@ -17,11 +17,13 @@ public struct PXApplicationValidationProgram: Codable {
 public struct PXOneTapApplication: Codable {
     var paymentMethod: PXApplicationPaymentMethod
     var validationPrograms: [PXApplicationValidationProgram]?
+    var behaviours: [String: PXBehaviour]?
     var status: PXStatus
 
     public enum CodingKeys: String, CodingKey {
         case paymentMethod = "payment_method"
         case validationPrograms = "validation_programs"
+        case behaviours = "behaviours"
         case status = "status"
     }
 }


### PR DESCRIPTION
## What have changed?

Now backend sends behaviours inside applications node so we use it from there, using the old behaviours node as fallback

## Kind of pr:

- [ ] BugFix
- [ ] Feature
- [x] Improvement

## Extras
