### PR TITLE
BugFix duplicatedButton on congrats

### DIFF
--- a/ExampleSwift/ExampleSwift.xcodeproj/project.pbxproj
+++ b/ExampleSwift/ExampleSwift.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 				"${BUILT_PRODUCTS_DIR}/AndesUI/AndesUI.framework",
 				"${BUILT_PRODUCTS_DIR}/FXBlurView/FXBlurView.framework",
 				"${BUILT_PRODUCTS_DIR}/JRSwizzle/JRSwizzle.framework",
+				"${BUILT_PRODUCTS_DIR}/MLBusinessComponents/MLBusinessComponents.framework",
 				"${BUILT_PRODUCTS_DIR}/MLUI/MLUI.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -276,6 +277,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AndesUI.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FXBlurView.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JRSwizzle.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MLBusinessComponents.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MLUI.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ExampleSwift/Podfile
+++ b/ExampleSwift/Podfile
@@ -13,5 +13,4 @@ target 'ExampleSwift' do
 
   # Pods for ExampleSwift
   pod 'MercadoPagoSDKV4', :path => '../', :testspecs => ['MercadoPagoSDKTests']
-  pod 'MLCardDrawer', :git => 'https://github.com/mercadolibre/meli-card-drawer-ios', :branch => '1.5.7'
 end

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXFooter/PXFooterViewModelHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXFooter/PXFooterViewModelHelper.swift
@@ -18,7 +18,7 @@ internal extension PXResultViewModel {
     }
 
     func getActionLink() -> PXAction? {
-        return getAction(label: getLinkLabel(), action: getLinkAction())
+        return getButtonLabel() ==  getLinkLabel() ? nil : getAction(label: getLinkLabel(), action: getLinkAction())
     }
 
     private func getAction(label: String?, action: Action) -> PXAction? {


### PR DESCRIPTION
## What have changed?

Before adds a secondaryButton on `PXFooterView` there is a condition to check if the buttons will not be duplicated

## Kind of pr:

- [x] BugFix
- [ ] Feature
- [ ] Improvement

## How to test:

Make a payment with wrong `cvv`, on congrats view you should only see one button with text "Pagar con otro medio"

## Extras
