### PR TITLE
Release/4.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v4.38.0
+🚀Private Release - 4.38.0 🚀
+- Now backend sends behaviours inside applications node so we use it from there, using the old behaviours node as fallback
+- BugFix duplicated button on congrats
+- Changed applications location on PXOneTapViewModel+Tracking and replaced key by 'methods_applications'
+
 # v4.37.11
 🚀Private Release - 4.37.11 🚀
 - Added Combo Cards Support

--- a/MercadoPagoSDKV4.podspec
+++ b/MercadoPagoSDKV4.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDKV4"
-  s.version          = "4.37.11"
+  s.version          = "4.38.0"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
# v4.38.0
🚀Private Release - 4.38.0 🚀
- Now backend sends behaviours inside applications node so we use it from there, using the old behaviours node as fallback
- BugFix duplicated button on congrats
- Changed applications location on PXOneTapViewModel+Tracking and replaced key by 'methods_applications'