### PR TITLE
Removing subviews from content view when screen is recreated

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
@@ -114,6 +114,7 @@ class PXNewResultViewController: MercadoPagoUIViewController {
 
     private func setupScrollView() {
         view.removeAllSubviews()
+        contentView.subviews.forEach { $0.removeFromSuperview() }
         view.addSubview(scrollView)
         view.backgroundColor = viewModel.getHeaderColor()
         scrollView.backgroundColor = .white


### PR DESCRIPTION
## What have changed?

Every single time user was on congrats screen, blocked its phone and returned the entire congrats was recreated without removing screens from content view, what was causing this behavior: 

<img width="369" alt="Captura de Tela 2021-07-01 às 14 09 14" src="https://user-images.githubusercontent.com/77017443/124163373-f0264200-da75-11eb-8d68-ea3913a422f5.png">

This PR fixes it

## Kind of pr:

- [x] BugFix
- [ ] Feature
- [ ] Improvement

## How to test:

Only testable on blue app , because on our test app biometric validation is not required and it that triggers the congrats recreation

## Extras
