### PR TITLE
removing print that should only be used for tests porpouse

### DIFF
--- a/ExampleSwift/ExampleSwift/Helpers/DataExtensions.swift
+++ b/ExampleSwift/ExampleSwift/Helpers/DataExtensions.swift
@@ -14,7 +14,7 @@ extension Data {
         do {
             return try JSONSerialization.jsonObject(with: self, options: [])
         } catch {
-            fatalError()
+            return error
         }
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentMethodSearchService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentMethodSearchService.swift
@@ -83,14 +83,3 @@ internal class PaymentMethodSearchService: MercadoPagoService {
         getInit(prefId: preferenceId, bodyJSON: bodyJSON, headers: headers, success: success, failure: failure)
     }
 }
-
-extension Data {
-    //MARK: - Support method, to debug requests
-    func mapToJSON() throws -> Any {
-        do {
-            return try JSONSerialization.jsonObject(with: self, options: [])
-        } catch {
-            fatalError()
-        }
-    }
-}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentMethodSearchService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Services/PaymentMethodSearchService.swift
@@ -33,7 +33,6 @@ internal class PaymentMethodSearchService: MercadoPagoService {
         self.request(uri: uri, params: params, body: bodyJSON, method: HTTPMethod.post, headers:
             headers, cache: false, success: { (data) -> Void in
                 do {
-                    print(try? data.mapToJSON())
                     let jsonResult = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
                     if let paymentSearchDic = jsonResult as? NSDictionary {
                         if paymentSearchDic["error"] != nil {


### PR DESCRIPTION
## What have changed?

Removing support method from `getInit` request on `PaymentMethodSearchService` class

## Kind of pr:

- [x] BugFix
- [ ] Feature
- [ ] Improvement

## How to test:
Its not a standard behavior, depending on the response it crashes

## Extras
Crash link: [here](https://app.bugsnag.com/mercadolibre/mercado-pago-ios/errors/60e8bfd99c7eb40007545edb?event_id=60ee19de007f8dff11c20000&i=jr&m=li)