### PR TITLE
Update change log and bumping app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v4.39.5
+🚀Private Release - 4.39.5 🚀
+- Fix crashes caused because of mapToJSON() method on PaymentMethodSearchService class
+- Fix duplicate views on congrats after unlock phone
+- Remove forced unwrap from tracks
+- 
+
 # v4.39.4
 🚀Private Release - 4.39.4 🚀
 - Adjusting project to manage tracks in a new way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 - Fix crashes caused because of mapToJSON() method on PaymentMethodSearchService class
 - Fix duplicate views on congrats after unlock phone
 - Remove forced unwrap from tracks
-- 
 
 # v4.39.4
 🚀Private Release - 4.39.4 🚀

--- a/MercadoPagoSDKV4.podspec
+++ b/MercadoPagoSDKV4.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDKV4"
-  s.version          = "4.39.4"
+  s.version          = "4.39.5"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
# v4.39.5
🚀Private Release - 4.39.5 🚀
- Fix crashes caused because of mapToJSON() method on PaymentMethodSearchService class
- Fix duplicate views on congrats after unlock phone
- Remove forced unwrap from tracks