### PR TITLE
fix: Fixed header merchant view cornerRadius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.40.1
+🚀Private Release - 4.40.1 🚀
+- Fixed header merchant view cornerRadius
+
 # v4.40.0
 🚀Private Release - 4.40.0 🚀
 - Added the new installments v2.1 component on OneTap

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeader/PXOneTapHeaderMerchantView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeader/PXOneTapHeaderMerchantView.swift
@@ -90,6 +90,7 @@ class PXOneTapHeaderMerchantView: UIStackView {
         
         let imageView = PXUIImageView()
         
+        imageView.layer.masksToBounds = true
         imageView.layer.cornerRadius = layout.IMAGE_SIZE / 2
         
         PXLayout.setWidth(owner: imageView, width: layout.IMAGE_SIZE).isActive = true

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeader/PXOneTapHeaderView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapHeader/PXOneTapHeaderView.swift
@@ -77,7 +77,13 @@ private extension PXOneTapHeaderView {
         switch deviceSize {
         case .small:
             // On small devices always use horizontal header
-            return true
+            if pxOneTapContext.hasInstallments && ((pxOneTapContext.hasSplit && pxOneTapContext.hasCharges) || (pxOneTapContext.hasSplit && pxOneTapContext.hasDiscounts)) {
+                // If it has installments, or split payment, or charges and discounts, use horizontal header
+                return true
+            } else {
+                // If it just has charges or discounts use vertical header
+                return false
+            }
         case .regular:
             // On regular devices
             if pxOneTapContext.hasInstallments || pxOneTapContext.hasSplit || (pxOneTapContext.hasCharges && pxOneTapContext.hasDiscounts) {

--- a/MercadoPagoSDKV4.podspec
+++ b/MercadoPagoSDKV4.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDKV4"
-  s.version          = "4.40.0"
+  s.version          = "4.40.1"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
## What have changed?

We've added back 'maskToBounds = true' property to header merchant image view for proper image rounding for all source formats

## Kind of pr:

- [x] BugFix
- [ ] Feature
- [ ] Improvement

## How to test:

Open a preference with a '.jpg' source header merchant image view

## Extras
