### PR TITLE
Chore/andes message on congrats

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Models/BusinessResult/PXBusinessResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/BusinessResult/PXBusinessResultViewModel.swift
@@ -259,6 +259,11 @@ extension PXBusinessResultViewModel {
         // URL Managment
         paymentCongratsData.withRedirectURLs(getRedirectUrl())
             .shouldAutoReturn(shouldAutoReturn())
+        
+        if let infoOperation = pointsAndDiscounts?.infoOperation {
+            paymentCongratsData.withInfoOperation(infoOperation)
+        }
+        
         return paymentCongratsData
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/Congrats/PXPaymentCongrats.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/Congrats/PXPaymentCongrats.swift
@@ -84,9 +84,11 @@ public final class PXPaymentCongrats: NSObject {
 
     // Buttons
     private(set) var primaryButton: PXButton?
+    
+    // AndesMessage
+    private(set) var infoOperation: InfoOperation?
 
     // MARK: Initializer
-
     public override init() {
         super.init()
     }
@@ -136,6 +138,12 @@ extension PXPaymentCongrats {
     @discardableResult
     internal func withInstructions(_ instruction: PXInstruction?) -> PXPaymentCongrats {
         self.instructions = instruction
+        return self
+    }
+    
+    @discardableResult
+    internal func withInfoOperation(_ infoOperation: InfoOperation?) -> PXPaymentCongrats {
+        self.infoOperation = infoOperation
         return self
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/InfoOperation.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/InfoOperation.swift
@@ -1,0 +1,12 @@
+//
+//  InfoOperation.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 09/08/21.
+//
+
+struct InfoOperation: Codable {
+    let hierarchy: String
+    let type: String
+    let body: String
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/InfoOperation.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/InfoOperation.swift
@@ -5,8 +5,28 @@
 //  Created by Matheus Leandro Martins on 09/08/21.
 //
 
+import AndesUI
+
 struct InfoOperation: Codable {
     let hierarchy: String
     let type: String
     let body: String
+    
+    var andesHierarchy: AndesMessageHierarchy {
+        switch hierarchy.uppercased() {
+        case "LOUD": return .loud
+        case "QUIET": return .quiet
+        default: return .quiet
+        }
+    }
+    
+    var andesType: AndesMessageType {
+        switch type.uppercased() {
+        case "NEUTRAL": return .neutral
+        case "SUCCESS": return .success
+        case "WARNING": return .warning
+        case "ERROR": return .error
+        default: return .neutral
+        }
+    }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPointsAndDiscounts.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXPointsAndDiscounts.swift
@@ -23,8 +23,25 @@ struct PXPointsAndDiscounts: Decodable {
     let backUrl: String?
     let autoReturn: PXAutoReturn?
     let instruction: PXInstruction?
+    let infoOperation: InfoOperation?
 
-    init(points: PXPoints?, discounts: PXDiscounts?, crossSelling: [PXCrossSellingItem]?, viewReceiptAction: PXRemoteAction?, topTextBox: PXText?, customOrder: Bool?, expenseSplit: PXExpenseSplit?, paymentMethodsImages: [String: String]?, primaryButton: PXButton?, secondaryButton: PXButton?, redirectUrl: String?, backUrl: String?, autoReturn: PXAutoReturn?, instruction: PXInstruction?) {
+    init(
+        points: PXPoints?,
+        discounts: PXDiscounts?,
+        crossSelling: [PXCrossSellingItem]?,
+        viewReceiptAction: PXRemoteAction?,
+        topTextBox: PXText?,
+        customOrder: Bool?,
+        expenseSplit: PXExpenseSplit?,
+        paymentMethodsImages: [String: String]?,
+        primaryButton: PXButton?,
+        secondaryButton: PXButton?,
+        redirectUrl: String?,
+        backUrl: String?,
+        autoReturn: PXAutoReturn?,
+        instruction: PXInstruction?,
+        infoOperation: InfoOperation?
+    ) {
         self.points = points
         self.discounts = discounts
         self.crossSelling = crossSelling
@@ -39,6 +56,7 @@ struct PXPointsAndDiscounts: Decodable {
         self.backUrl = backUrl
         self.autoReturn = autoReturn
         self.instruction = instruction
+        self.infoOperation = infoOperation
     }
 
     enum PointsAndDiscountsCodingKeys: String, CodingKey {
@@ -56,6 +74,7 @@ struct PXPointsAndDiscounts: Decodable {
         case backUrl = "back_url"
         case autoReturn = "auto_return"
         case instruction = "instructions"
+        case infoOperation = "operation_info"
     }
 
     init(from decoder: Decoder) throws {
@@ -74,6 +93,23 @@ struct PXPointsAndDiscounts: Decodable {
         let backUrl: String? = try container.decodeIfPresent(String.self, forKey: .backUrl)
         let autoReturn: PXAutoReturn? = try container.decodeIfPresent(PXAutoReturn.self, forKey: .autoReturn)
         let instruction: PXInstruction? = try container.decodeIfPresent(PXInstruction.self, forKey: .instruction)
-        self.init(points: points, discounts: discounts, crossSelling: crossSelling, viewReceiptAction: viewReceiptAction, topTextBox: topTextBox, customOrder: customOrder, expenseSplit: expenseSplit, paymentMethodsImages: paymentMethodsImages, primaryButton: primaryButton, secondaryButton: secondaryButton, redirectUrl: redirectUrl, backUrl: backUrl, autoReturn: autoReturn, instruction: instruction)
+        let infoOperation: InfoOperation? = try container.decodeIfPresent(InfoOperation.self, forKey: .infoOperation)
+        self.init(
+            points: points,
+            discounts: discounts,
+            crossSelling: crossSelling,
+            viewReceiptAction: viewReceiptAction,
+            topTextBox: topTextBox,
+            customOrder: customOrder,
+            expenseSplit: expenseSplit,
+            paymentMethodsImages: paymentMethodsImages,
+            primaryButton: primaryButton,
+            secondaryButton: secondaryButton,
+            redirectUrl: redirectUrl,
+            backUrl: backUrl,
+            autoReturn: autoReturn,
+            instruction: instruction,
+            infoOperation: infoOperation
+        )
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
@@ -275,6 +275,15 @@ extension PXNewResultViewController {
         if let instruction = viewModel.getInstructions() {
             views.append(ResultViewData(view: InstructionView(instruction: instruction, delegate: self)))
         }
+        
+        //AndesMessage
+        if let message = viewModel.getAndesMessage() {
+            views.append(ResultViewData(view: AndesMessage(hierarchy: message.andesHierarchy,
+                                                           type: message.andesType,
+                                                           title: "",
+                                                           body: message.body)))
+            
+        }
 
         if let topTextBoxView = buildTopTextBoxView() {
             views.append(ResultViewData(view: topTextBoxView, verticalMargin: PXLayout.ZERO_MARGIN, horizontalMargin: PXLayout.ZERO_MARGIN))

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewModel.swift
@@ -103,4 +103,7 @@ protocol PXNewResultViewModelInterface: PXViewModelTrackingDataProtocol {
     func shouldAutoReturn() -> Bool
     func getBackUrl() -> URL?
     func getAutoReturn() -> PXAutoReturn?
+    
+    ///AndesMessage
+    func getAndesMessage()
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewModel.swift
@@ -105,5 +105,5 @@ protocol PXNewResultViewModelInterface: PXViewModelTrackingDataProtocol {
     func getAutoReturn() -> PXAutoReturn?
     
     ///AndesMessage
-    func getAndesMessage()
+    func getAndesMessage() -> InfoOperation?
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
@@ -38,6 +38,8 @@ class PXPaymentCongratsViewModel {
 }
 
 extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
+    func getAndesMessage() { }
+    
     // HEADER
     func getHeaderColor() -> UIColor {
         guard let color = paymentCongrats.headerColor else {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
@@ -38,7 +38,9 @@ class PXPaymentCongratsViewModel {
 }
 
 extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
-    func getAndesMessage() { }
+    func getAndesMessage() -> InfoOperation? {
+        return paymentCongrats.infoOperation
+    }
     
     // HEADER
     func getHeaderColor() -> UIColor {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXResultViewModel.swift
@@ -444,6 +444,10 @@ extension PXResultViewModel {
             let splitPaymentInfo = getPaymentMethod(paymentData: splitPaymentData, amountHelper: amountHelper) {
             paymentcongrats.withSplitPaymentInfo(splitPaymentInfo)
         }
+        
+        if let infoOperation = pointsAndDiscounts?.infoOperation {
+            paymentcongrats.withInfoOperation(infoOperation)
+        }
 
         paymentcongrats.withStatementDescription(paymentResult.statementDescription)
 


### PR DESCRIPTION
## What have changed?

This PR adds a new node on `PXPointsAndDiscounts.swift ` that feeds AndesMessage that was added on congrats

## Kind of pr:

- [ ] BugFix
- [ ] Feature
- [x] Improvement

## How to test:
Make a payment with a third party card
