### PR TITLE
Adding payment_type_id on congrats request parameters

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow+Services.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/PaymentFlow/PXPaymentFlow+Services.swift
@@ -109,7 +109,7 @@ internal extension PXPaymentFlow {
 
         model.shouldSearchPointsAndDiscounts = false
         let platform = MLBusinessAppDataService().getAppIdentifier().rawValue
-        model.mercadoPagoServices.getPointsAndDiscounts(url: PXServicesURLConfigs.MP_API_BASE_URL, uri: PXServicesURLConfigs.shared().MP_POINTS_URI, paymentIds: paymentIds, paymentMethodsIds: paymentMethodsIds, campaignId: campaignId, prefId: model.checkoutPreference?.id, platform: platform, ifpe: ifpe, merchantOrderId: model.checkoutPreference?.merchantOrderId, headers: headers, callback: { [weak self] (pointsAndBenef) in
+        model.mercadoPagoServices.getPointsAndDiscounts(url: PXServicesURLConfigs.MP_API_BASE_URL, uri: PXServicesURLConfigs.shared().MP_POINTS_URI, paymentIds: paymentIds, paymentMethodsIds: paymentMethodsIds, campaignId: campaignId, prefId: model.checkoutPreference?.id, platform: platform, ifpe: ifpe, merchantOrderId: model.checkoutPreference?.merchantOrderId, headers: headers, paymentTypeId: model.businessResult?.getPaymentMethodTypeId(), callback: { [weak self] (pointsAndBenef) in
                 guard let self = self else { return }
                 self.model.pointsAndDiscounts = pointsAndBenef
                 self.model.instructionsInfo = pointsAndBenef.instruction

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Constants/ApiParam.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Constants/ApiParam.swift
@@ -39,4 +39,5 @@ internal struct ApiParam {
     static let MERCHANT_ORDER_ID = "merchant_order_id"
     static let IFPE = "ifpe"
     static let PREF_ID = "pref_id"
+    static let PAYMENT_TYPE_ID = "payment_type_id"
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/MercadoPagoServices.swift
@@ -81,7 +81,7 @@ internal class MercadoPagoServices: NSObject {
         service.createPayment(headers: headers, body: paymentDataJSON, params: params, success: callback, failure: failure)
     }
 
-    func getPointsAndDiscounts(url: String, uri: String, paymentIds: [String]? = nil, paymentMethodsIds: [String]? = nil, campaignId: String?, prefId: String?, platform: String, ifpe: Bool, merchantOrderId: Int?, headers: [String: String], callback : @escaping (PXPointsAndDiscounts) -> Void, failure: @escaping (() -> Void)) {
+    func getPointsAndDiscounts(url: String, uri: String, paymentIds: [String]? = nil, paymentMethodsIds: [String]? = nil, campaignId: String?, prefId: String?, platform: String, ifpe: Bool, merchantOrderId: Int?, headers: [String: String], paymentTypeId: String?, callback : @escaping (PXPointsAndDiscounts) -> Void, failure: @escaping (() -> Void)) {
         let service: CustomService = CustomService(baseURL: url, URI: uri)
 
         var params = MercadoPagoServices.getParamsAccessTokenAndPaymentIdsAndPlatform(privateKey, paymentIds, platform)
@@ -91,9 +91,13 @@ internal class MercadoPagoServices: NSObject {
         params.paramsAppend(key: ApiParam.IFPE, value: String(ifpe))
         params.paramsAppend(key: ApiParam.PREF_ID, value: prefId)
         params.paramsAppend(key: ApiParam.PUBLIC_KEY, value: publicKey)
-
+        
         if let campaignId = campaignId {
             params.paramsAppend(key: ApiParam.CAMPAIGN_ID, value: campaignId)
+        }
+        
+        if let paymentTypeId = paymentTypeId {
+            params.paramsAppend(key: ApiParam.PAYMENT_TYPE_ID, value: paymentTypeId)
         }
 
         if let flowName = MPXTracker.sharedInstance.getFlowName() {


### PR DESCRIPTION
## What have changed?

Adds a parameter on congrats request
## Kind of pr:

- [ ] BugFix
- [ ] Feature
- [x] Improvement

## How to test:
Make a payment and send a parameter to congrats request

## Extras
