### PR TITLE
Feature/modal on congrats

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+RemedyServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+RemedyServices.swift
@@ -27,7 +27,7 @@ extension MercadoPagoCheckout {
                                                                       securityCodeLength: oneTapCard?.cardUI?.securityCode?.length,
                                                                       installmentsList: installments,
                                                                       installment: nil,
-                                                                      cardSize: .medium)
+                                                                      cardSize: nil)
             alternativePayerPaymentMethods.append(alternativePayerPaymentMethod)
         }
         return alternativePayerPaymentMethods

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+RemedyServices.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/Checkout/Extensions/MercadoPagoCheckout+RemedyServices.swift
@@ -26,7 +26,8 @@ extension MercadoPagoCheckout {
                                                                       securityCodeLocation: oneTapCard?.cardUI?.securityCode?.cardLocation,
                                                                       securityCodeLength: oneTapCard?.cardUI?.securityCode?.length,
                                                                       installmentsList: installments,
-                                                                      installment: nil)
+                                                                      installment: nil,
+                                                                      cardSize: .medium)
             alternativePayerPaymentMethods.append(alternativePayerPaymentMethod)
         }
         return alternativePayerPaymentMethods

--- a/MercadoPagoSDK/MercadoPagoSDK/RequestLayer/RequestStruct/RequestInfos.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/RequestLayer/RequestStruct/RequestInfos.swift
@@ -18,6 +18,7 @@ enum BackendEnvironment: String {
     case alpha = "alpha/"
     case beta = "beta/"
     case prod = "production/"
+    case gamma = "gamma/"
 }
 
 internal protocol RequestInfos {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/Modal.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/Modal.swift
@@ -8,22 +8,10 @@
 import Foundation
 
 struct Modal: Codable {
-    let title: ModalText
-    let description: ModalText
+    let title: PXText
+    let description: PXText
     let mainButton: ModalAction
     let secondaryButton: ModalAction
-}
-
-struct ModalText: Codable {
-    let message: String
-    let weight: String
-    let textColor: String
-    
-    enum CodingKeys: String, CodingKey {
-        case message
-        case weight
-        case textColor = "text_color"
-    }
 }
 
 struct ModalAction: Codable {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/Modal.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/Modal.swift
@@ -1,0 +1,33 @@
+//
+//  Modal.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Matheus Leandro Martins on 30/08/21.
+//
+
+import Foundation
+
+struct Modal: Codable {
+    let title: ModalText
+    let description: ModalText
+    let mainButton: ModalAction
+    let secondaryButton: ModalAction
+}
+
+struct ModalText: Codable {
+    let message: String
+    let weight: String
+    let textColor: String
+    
+    enum CodingKeys: String, CodingKey {
+        case message
+        case weight
+        case textColor = "text_color"
+    }
+}
+
+struct ModalAction: Codable {
+    let label: String
+    let action: String
+    let type: String
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXRemedy.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXRemedy.swift
@@ -7,6 +7,14 @@
 
 import Foundation
 
+enum CardSize: String, Codable {
+    case mini = "mini"
+    case xSmall = "xsmall"
+    case small = "small"
+    case medium = "medium"
+    case large = "large"
+}
+
 struct PXRemedy: Codable {
     let cvv: PXInvalidCVV?
     let highRisk: PXHighRisk?
@@ -93,6 +101,7 @@ struct PXRemedyPaymentMethod: Codable {
     let securityCodeLength: Int?
     let installmentsList: [PXPaymentMethodInstallment]?
     let installment: PXPaymentMethodInstallment?
+    let cardSize: CardSize
 }
 
 struct PXPaymentMethodInstallment: Codable {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXRemedy.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXRemedy.swift
@@ -101,7 +101,7 @@ struct PXRemedyPaymentMethod: Codable {
     let securityCodeLength: Int?
     let installmentsList: [PXPaymentMethodInstallment]?
     let installment: PXPaymentMethodInstallment?
-    let cardSize: CardSize
+    let cardSize: CardSize?
 }
 
 struct PXPaymentMethodInstallment: Codable {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXRemedy.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXRemedy.swift
@@ -13,13 +13,12 @@ struct PXRemedy: Codable {
     let callForAuth: PXCallForAuth?
     let suggestedPaymentMethod: PXSuggestedPaymentMethod?
     let trackingData: [String: String]?
-    let modal: Modal?
 }
 
 // PXRemedy Helpers
 extension PXRemedy {
     init() {
-        self.init(cvv: nil, highRisk: nil, callForAuth: nil, suggestedPaymentMethod: nil, trackingData: nil, modal: nil)
+        self.init(cvv: nil, highRisk: nil, callForAuth: nil, suggestedPaymentMethod: nil, trackingData: nil)
     }
     
     var isEmpty: Bool {
@@ -79,6 +78,7 @@ struct PXSuggestedPaymentMethod: Codable {
     let actionLoud: PXButtonAction?
     let bottomMessage: PXRemedyBottomMessage?
     let alternativePaymentMethod: PXRemedyPaymentMethod?
+    let modal: Modal?
 }
 
 struct PXRemedyPaymentMethod: Codable {

--- a/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXRemedy.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Services/Models/PXRemedy.swift
@@ -13,12 +13,13 @@ struct PXRemedy: Codable {
     let callForAuth: PXCallForAuth?
     let suggestedPaymentMethod: PXSuggestedPaymentMethod?
     let trackingData: [String: String]?
+    let modal: Modal?
 }
 
 // PXRemedy Helpers
 extension PXRemedy {
     init() {
-        self.init(cvv: nil, highRisk: nil, callForAuth: nil, suggestedPaymentMethod: nil, trackingData: nil)
+        self.init(cvv: nil, highRisk: nil, callForAuth: nil, suggestedPaymentMethod: nil, trackingData: nil, modal: nil)
     }
     
     var isEmpty: Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
@@ -6,11 +6,16 @@
 //
 
 import UIKit
+import AndesUI
 import MLCardDrawer
 import MLCardForm
+import MLUI
 
-protocol PXRemedyViewProtocol: class {
+protocol PXRemedyViewDelegate: AnyObject {
     func remedyViewButtonTouchUpInside(_ sender: PXAnimatedButton)
+    func showModal(modalInfos: PXOneTapDisabledViewController)
+    func selectAnotherPaymentMethod()
+    func dismissModal()
 }
 
 struct PXRemedyViewData {
@@ -20,7 +25,7 @@ struct PXRemedyViewData {
     let remedy: PXRemedy
 
     weak var animatedButtonDelegate: PXAnimatedButtonDelegate?
-    weak var remedyViewProtocol: PXRemedyViewProtocol?
+    weak var remedyViewProtocol: PXRemedyViewDelegate?
     let remedyButtonTapped: ((String?) -> Void)?
 }
 
@@ -385,17 +390,47 @@ class PXRemedyView: UIView {
         button.setTitle(normalText, for: .normal)
         button.layer.cornerRadius = 4
         button.add(for: .touchUpInside, { [weak self] in
-            if let remedyButtonTapped = self?.data.remedyButtonTapped {
-                remedyButtonTapped(self?.textField?.getValue())
-            }
-            if let button = self?.button {
-                self?.data.remedyViewProtocol?.remedyViewButtonTouchUpInside(button)
-            }
+            self?.data.remedy.suggestedPaymentMethod?.modal != nil ? self?.showModal() : self?.handlePayment()
         })
         if shouldShowTextField() {
             button.setDisabled()
         }
         return button
+    }
+    
+    private func handlePayment() {
+        if let remedyButtonTapped = data.remedyButtonTapped {
+            remedyButtonTapped(textField?.getValue())
+        }
+        
+        if let button = button {
+            data.remedyViewProtocol?.remedyViewButtonTouchUpInside(button)
+        }
+    }
+    
+    private func showModal() {
+        guard let modalInfos = data.remedy.suggestedPaymentMethod?.modal else {
+            handlePayment()
+            return
+        }
+        
+        let primaryButton = PXAction(label: modalInfos.mainButton.label) { [weak self] in
+            self?.data.remedyViewProtocol?.dismissModal()
+            self?.handlePayment()
+        }
+        
+        let secondaryButton = PXAction(label: modalInfos.secondaryButton.label) { [weak self] in
+            self?.data.remedyViewProtocol?.dismissModal()
+            self?.data.remedyViewProtocol?.selectAnotherPaymentMethod()
+        }
+        
+        let modalController = PXOneTapDisabledViewController(title: modalInfos.title,
+                                                             description: modalInfos.description,
+                                                             primaryButton: primaryButton,
+                                                             secondaryButton: secondaryButton,
+                                                             iconUrl: nil)
+        
+        data.remedyViewProtocol?.showModal(modalInfos: modalController)
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
@@ -214,7 +214,7 @@ class PXRemedyView: UIView {
             return nil
         }
         
-        var cardSize: MLCardDrawerTypeV3 = .large
+        var cardSize: MLCardDrawerTypeV3 = .medium
         
         switch data.remedy.suggestedPaymentMethod?.alternativePaymentMethod?.cardSize {
         case .mini: cardSize = .small
@@ -224,7 +224,7 @@ class PXRemedyView: UIView {
         }
 
         let controller = MLCardDrawerController(cardUI: cardUI, cardSize, cardData, false)
-        controller.view.frame = CGRect(origin: CGPoint.zero, size: CardSizeManager.getSizeByGoldenAspectRatio(width: controller.view.frame.width, type: cardSize))
+        controller.view.frame = CGRect(origin: CGPoint.zero, size: CardSizeManager.getSizeByGoldenAspectRatio(width: PXLayout.getScreenWidth(applyingMarginFactor: CONTENT_WIDTH_PERCENT), type: cardSize))
         controller.view.translatesAutoresizingMaskIntoConstraints = false
         controller.animated(false)
         controller.show()

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
@@ -213,10 +213,18 @@ class PXRemedyView: UIView {
         } else {
             return nil
         }
+        
+        var cardSize: MLCardDrawerTypeV3 = .large
+        
+        switch data.remedy.suggestedPaymentMethod?.alternativePaymentMethod?.cardSize {
+        case .mini: cardSize = .small
+        case .small, .xSmall: cardSize = .medium
+        case .large, .medium: cardSize = .large
+        case .none: cardSize = .medium
+        }
 
-        let controller = MLCardDrawerController(cardUI, cardData, false, .medium)
-        let screenWidth = PXLayout.getScreenWidth(applyingMarginFactor: CONTENT_WIDTH_PERCENT)
-        controller.view.frame = CGRect(origin: CGPoint.zero, size: CGSize(width: screenWidth, height: CARD_VIEW_HEIGHT))
+        let controller = MLCardDrawerController(cardUI: cardUI, cardSize, cardData, false)
+        controller.view.frame = CGRect(origin: CGPoint.zero, size: CardSizeManager.getSizeByGoldenAspectRatio(width: controller.view.frame.width, type: cardSize))
         controller.view.translatesAutoresizingMaskIntoConstraints = false
         controller.animated(false)
         controller.show()

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewController.swift
@@ -16,6 +16,7 @@ class PXNewResultViewController: MercadoPagoUIViewController {
     private lazy var elasticHeader = UIView()
     private let statusBarHeight = PXLayout.getStatusBarHeight()
     private var contentViewHeightConstraint: NSLayoutConstraint?
+    internal var modalTeste: MLModal?
     let scrollView = UIScrollView()
     let contentView = UIView()
     let viewModel: PXNewResultViewModelInterface
@@ -734,7 +735,19 @@ extension PXNewResultViewController: PXAnimatedButtonDelegate {
     }
 }
 
-extension PXNewResultViewController: PXRemedyViewProtocol {
+extension PXNewResultViewController: PXRemedyViewDelegate {
+    func selectAnotherPaymentMethod() {
+        viewModel.getFooterSecondaryAction()?.action()
+    }
+    
+    func dismissModal() {
+        modalTeste?.dismiss()
+    }
+    
+    func showModal(modalInfos: PXOneTapDisabledViewController) {
+        modalTeste = PXComponentFactory.Modal.show(viewController: modalInfos, title: nil)
+    }
+    
     func remedyViewButtonTouchUpInside(_ sender: PXAnimatedButton) {
         subscribeToAnimatedButtonNotifications(button: sender)
         sender.startLoading()

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/New UI/PXNewResultViewModel.swift
@@ -77,7 +77,7 @@ protocol PXNewResultViewModelInterface: PXViewModelTrackingDataProtocol {
     func getErrorBodyView() -> UIView?
 
     //REMEDY
-    func getRemedyView(animatedButtonDelegate: PXAnimatedButtonDelegate?, remedyViewProtocol: PXRemedyViewProtocol?) -> UIView?
+    func getRemedyView(animatedButtonDelegate: PXAnimatedButtonDelegate?, remedyViewProtocol: PXRemedyViewDelegate?) -> UIView?
     func getRemedyButtonAction() -> ((String?) -> Void)?
     func isPaymentResultRejectedWithRemedy() -> Bool
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXResult/PXPaymentCongratsViewModel.swift
@@ -197,7 +197,7 @@ extension PXPaymentCongratsViewModel: PXNewResultViewModelInterface {
         return paymentCongrats.errorBodyView
     }
 
-    func getRemedyView(animatedButtonDelegate: PXAnimatedButtonDelegate?, remedyViewProtocol: PXRemedyViewProtocol?) -> UIView? {
+    func getRemedyView(animatedButtonDelegate: PXAnimatedButtonDelegate?, remedyViewProtocol: PXRemedyViewDelegate?) -> UIView? {
         if isPaymentResultRejectedWithRemedy(), var remedyViewData = paymentCongrats.remedyViewData {
             remedyViewData.animatedButtonDelegate = animatedButtonDelegate
             remedyViewData.remedyViewProtocol = remedyViewProtocol


### PR DESCRIPTION
## What have changed?

There is a new node on `PXSuggestedPaymentMethod` and basically if node `modal` is not null we have to show a modal with some warnings to our user before actually make the payment

## Kind of pr:

- [ ] BugFix
- [ ] Feature
- [x] Improvement

## How to test:
trigger a remedy scenario with this response while back is not live [url](https://run.mocky.io/v3/5fe78263-dcc3-48dc-9e7a-408cebe8db9d)

## Extras

right [here](https://mercadolibre.atlassian.net/jira/software/c/projects/PXN/boards/2743?modal=detail&selectedIssue=PXN-2307&assignee=5ff2c62e8332a1010ed10405) you can see the behavior
