### PR TITLE
Fix: raw amount rounding issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v4.45.0
+🚀Private Release - 4.45.0 🚀
+- Fixed decimal calculation for getRawAmount
+
+# v4.44.0
+🚀Private Release - 4.44.0 🚀
+- Added new network layer with access token in header instead query param
+- Added AndesMessage on congrats screen
+- Fix label on oneTap header to limit its characters and not invading value label
+- Fix on OneTapFlow where OneTapFlow instance was being killed intead of being updated
+
 # v4.43.2
 🚀Private Release - 4.43.2 🚀
 - Added ProfileID protocol, default and header key-value for payments call with default processor

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/PXAmountHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/PXAmountHelper.swift
@@ -141,23 +141,7 @@ internal struct PXAmountHelper {
     }
     
     internal func getPaymentData() -> PXPaymentData {
-
         // Set total card amount with charges without discount
-        if paymentData.transactionAmount == nil || paymentData.transactionAmount == 0 {
-            
-            if let paymentMethod = paymentData.paymentMethod,
-               let paymentOptionId = paymentData.paymentOptionId,
-               let amount = paymentConfigurationService.getAmount(paymentOptionId: paymentOptionId, paymentMethodId: paymentMethod.id, paymentTypeId: paymentMethod.paymentTypeId),
-               let taxFreeAmount = paymentConfigurationService.getTaxFreeAmount(paymentOptionId: paymentOptionId, paymentMethodId: paymentMethod.id, paymentTypeId: paymentMethod.paymentTypeId),
-               let noDiscountAmount = paymentConfigurationService.getNoDiscountAmount(paymentOptionId: paymentOptionId, paymentMethodId: paymentMethod.id, paymentTypeId: paymentMethod.paymentTypeId) {
-                self.paymentData.transactionAmount = NSDecimalNumber(string: String(taxFreeAmount))
-                self.paymentData.amount = amount
-                self.paymentData.taxFreeAmount = taxFreeAmount
-                self.paymentData.noDiscountAmount = noDiscountAmount
-            } else {
-                self.paymentData.transactionAmount = NSDecimalNumber(string: String(preferenceAmountWithCharges))
-            }
-        }
         return paymentData
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/PXAmountHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/PXAmountHelper.swift
@@ -41,7 +41,15 @@ internal struct PXAmountHelper {
     }
 
     var preferenceAmountWithCharges: Double {
-        return preferenceAmount + chargeRuleAmount
+        // preferenceAmount + chargeRuleAmount
+        let decimalPreferenceAmount = PXAmountHelper.getRoundedAmountAsNsDecimalNumber(amount: preferenceAmount)
+        let decimalChargeRuleAmount = PXAmountHelper.getRoundedAmountAsNsDecimalNumber(amount: chargeRuleAmount)
+        
+        let sum = decimalPreferenceAmount.adding(decimalChargeRuleAmount)
+        
+        guard let doubleSum = Double(sum.stringValue) else { return preferenceAmount + chargeRuleAmount }
+        
+        return doubleSum
     }
     
     var amount: Double? {
@@ -60,11 +68,7 @@ internal struct PXAmountHelper {
         if let payerCost = paymentData.payerCost {
             return payerCost.totalAmount
         }
-        if let couponAmount = paymentData.discount?.couponAmount {
-            return preferenceAmount - couponAmount + chargeRuleAmount
-        } else {
-            return preferenceAmount + chargeRuleAmount
-        }
+        return amountToPayWithoutPayerCost
     }
 
     var isSplitPayment: Bool {
@@ -81,9 +85,19 @@ internal struct PXAmountHelper {
 
     private var amountToPayWithoutPayerCost: Double {
         if let couponAmount = paymentData.discount?.couponAmount {
-            return preferenceAmount - couponAmount + chargeRuleAmount
+            // preferenceAmount - couponAmount + chargeRuleAmount
+            let decimalPreferenceAmount = PXAmountHelper.getRoundedAmountAsNsDecimalNumber(amount: preferenceAmount)
+            let decimalCouponAmount = PXAmountHelper.getRoundedAmountAsNsDecimalNumber(amount: couponAmount)
+            let decimalChargeRuleAmount = PXAmountHelper.getRoundedAmountAsNsDecimalNumber(amount: chargeRuleAmount)
+            
+            let sum = (decimalPreferenceAmount.subtracting(decimalCouponAmount)).adding(decimalChargeRuleAmount)
+            
+            guard let doubleSum = Double(sum.stringValue) else { return preferenceAmount + chargeRuleAmount }
+            
+            return doubleSum
         } else {
-            return preferenceAmount + chargeRuleAmount
+            // preferenceAmount + chargeRuleAmount
+            return preferenceAmountWithCharges
         }
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/PXAmountHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/PXAmountHelper.swift
@@ -136,12 +136,12 @@ internal struct PXAmountHelper {
                let amount = paymentConfigurationService.getAmount(paymentOptionId: paymentOptionId, paymentMethodId: paymentMethod.id, paymentTypeId: paymentMethod.paymentTypeId),
                let taxFreeAmount = paymentConfigurationService.getTaxFreeAmount(paymentOptionId: paymentOptionId, paymentMethodId: paymentMethod.id, paymentTypeId: paymentMethod.paymentTypeId),
                let noDiscountAmount = paymentConfigurationService.getNoDiscountAmount(paymentOptionId: paymentOptionId, paymentMethodId: paymentMethod.id, paymentTypeId: paymentMethod.paymentTypeId) {
-                self.paymentData.transactionAmount = NSDecimalNumber(floatLiteral: taxFreeAmount)
+                self.paymentData.transactionAmount = NSDecimalNumber(string: String(taxFreeAmount))
                 self.paymentData.amount = amount
                 self.paymentData.taxFreeAmount = taxFreeAmount
                 self.paymentData.noDiscountAmount = noDiscountAmount
             } else {
-                self.paymentData.transactionAmount = NSDecimalNumber(floatLiteral: preferenceAmountWithCharges)
+                self.paymentData.transactionAmount = NSDecimalNumber(string: String(preferenceAmountWithCharges))
             }
         }
         return paymentData

--- a/MercadoPagoSDK/MercadoPagoSDK/Core/PXAmountHelper.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Core/PXAmountHelper.swift
@@ -142,6 +142,21 @@ internal struct PXAmountHelper {
     
     internal func getPaymentData() -> PXPaymentData {
         // Set total card amount with charges without discount
+        if paymentData.transactionAmount == nil || paymentData.transactionAmount == 0 {
+            
+            if let paymentMethod = paymentData.paymentMethod,
+               let paymentOptionId = paymentData.paymentOptionId,
+               let amount = paymentConfigurationService.getAmount(paymentOptionId: paymentOptionId, paymentMethodId: paymentMethod.id, paymentTypeId: paymentMethod.paymentTypeId),
+               let taxFreeAmount = paymentConfigurationService.getTaxFreeAmount(paymentOptionId: paymentOptionId, paymentMethodId: paymentMethod.id, paymentTypeId: paymentMethod.paymentTypeId),
+               let noDiscountAmount = paymentConfigurationService.getNoDiscountAmount(paymentOptionId: paymentOptionId, paymentMethodId: paymentMethod.id, paymentTypeId: paymentMethod.paymentTypeId) {
+                self.paymentData.transactionAmount = NSDecimalNumber(floatLiteral: taxFreeAmount)
+                self.paymentData.amount = amount
+                self.paymentData.taxFreeAmount = taxFreeAmount
+                self.paymentData.noDiscountAmount = noDiscountAmount
+            } else {
+                self.paymentData.transactionAmount = NSDecimalNumber(floatLiteral: preferenceAmountWithCharges)
+            }
+        }
         return paymentData
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXOneTapViewController.swift
@@ -656,12 +656,26 @@ extension PXOneTapViewController: PXCardSliderProtocol {
             currentPaymentData.payerCost = newPayerCost
             currentPaymentData.paymentMethod = newPaymentMethod
             currentPaymentData.issuer = selectedApplication.payerPaymentMethod?.issuer ?? PXIssuer(id: targetModel.issuerId, name: nil)
+            
+            currentPaymentData.amount = selectedApplication.payerPaymentMethod?.selectedPaymentOption?.amount
+            currentPaymentData.taxFreeAmount = selectedApplication.payerPaymentMethod?.selectedPaymentOption?.taxFreeAmount
+            currentPaymentData.noDiscountAmount = selectedApplication.payerPaymentMethod?.selectedPaymentOption?.noDiscountAmount
+            
+            if let taxFreeAmount = selectedApplication.payerPaymentMethod?.selectedPaymentOption?.taxFreeAmount {
+                currentPaymentData.transactionAmount = NSDecimalNumber(string: String(taxFreeAmount))
+            } else {
+                currentPaymentData.transactionAmount = NSDecimalNumber(string: String(viewModel.amountHelper.preferenceAmountWithCharges))
+            }
+            
+            currentPaymentData.paymentOptionId = targetModel.cardId ?? targetModel.selectedApplication?.paymentMethodId
+            
             callbackUpdatePaymentOption(targetModel)
             loadingButtonComponent?.setEnabled()
         } else {
             currentPaymentData.payerCost = nil
             currentPaymentData.paymentMethod = nil
             currentPaymentData.issuer = nil
+            currentPaymentData.paymentOptionId = nil
             loadingButtonComponent?.setDisabled()
         }
         headerView?.updateModel(viewModel.getHeaderViewModel(selectedCard: selectedCard, pxOneTapContext: pxOneTapContext))

--- a/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentData.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Models/PXPaymentData.swift
@@ -232,6 +232,7 @@ extension PXPaymentData {
         cleanIssuer()
         cleanToken()
         cleanPayerCost()
+        cleanPaymentOptionId()
         self.paymentMethod = paymentMethod
     }
     
@@ -242,6 +243,7 @@ extension PXPaymentData {
         cleanIssuer()
         cleanToken()
         cleanPayerCost()
+        cleanPaymentOptionId()
         self.paymentMethod = paymentMethod
         self.paymentOptionId = paymentOptionId
     }
@@ -293,6 +295,10 @@ extension PXPaymentData {
     internal func cleanPaymentMethod() {
         self.paymentMethod = nil
     }
+    
+    internal func cleanPaymentOptionId() {
+        self.paymentOptionId = nil
+    }
 
     internal func clearCollectedData() {
         clearPaymentMethodData()
@@ -305,6 +311,7 @@ extension PXPaymentData {
         self.payerCost = nil
         self.token = nil
         self.transactionDetails = nil
+        self.paymentOptionId = nil
         // No borrar el descuento
     }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXReview/PXReviewViewModel.swift
@@ -47,7 +47,7 @@ class PXReviewViewModel: NSObject {
 
     func validateWithBiometric(onSuccess: @escaping () -> Void, onError: @escaping (Error) -> Void) {
         let config = PXConfiguratorManager.biometricConfig
-        config.setAmount(NSDecimalNumber(value: amountHelper.amountToPay))
+        config.setAmount(NSDecimalNumber(string: String(amountHelper.amountToPay)))
         PXConfiguratorManager.biometricProtocol.validate(config: PXConfiguratorManager.biometricConfig, onSuccess: onSuccess, onError: onError)
     }
 }

--- a/MercadoPagoSDKV4.podspec
+++ b/MercadoPagoSDKV4.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDKV4"
-  s.version          = "4.43.2"
+  s.version          = "4.45.0"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
## What have changed?

Now we are using NSDecimalNumber instead of Double for calculations on preferenceAmount, chargesAmount and discountsAmount when needed.

This way we prevent calculation issues that could end on invalid payments by decimal inconsistencies.

## Kind of pr:

- [ ] BugFix
- [ ] Feature
- [x] Improvement

## How to test:

If you pay $200 + $8.48 ticket it will return $200.48 with getRawAmount(), before it used to return $200.47999999999

## Extras
