### PR TITLE
[FEATURE] - [PXN-2403] - PXRemedyView layout fixes for correct viewing ConsumerCreditsCard

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXCreditsViewModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/UI/PXCreditsViewModel.swift
@@ -10,9 +10,11 @@ import Foundation
 struct PXCreditsViewModel {
 
     let displayInfo: PXDisplayInfoDto
+    let needsTermsAndConditions: Bool
 
-    init(_ withModel: PXOneTapCreditsDto) {
+    init(_ withModel: PXOneTapCreditsDto, needsTermsAndConditions: Bool = true) {
         self.displayInfo = withModel.displayInfo
+        self.needsTermsAndConditions = needsTermsAndConditions
     }
 }
 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Components/PXTermsAndConditionsTextView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Components/PXTermsAndConditionsTextView.swift
@@ -8,29 +8,27 @@
 import MLCardDrawer
 
 final class PXTermsAndConditionsTextView: UITextView {
-    init(terms: PXTermsDto, selectedInstallments: Int?, cardType: MLCardDrawerTypeV3? = .large, textColor: UIColor, linkColor: UIColor) {
+    
+    init(terms: PXTermsDto, selectedInstallments: Int?, textColor: UIColor, linkColor: UIColor) {
         super.init(frame: .zero, textContainer: nil)
-        
         linkTextAttributes = [.foregroundColor: linkColor]
-        isUserInteractionEnabled = true
-        isEditable = false
-        backgroundColor = .clear
-        translatesAutoresizingMaskIntoConstraints = false
-
         let attributedString = getTermsAndConditionsText(terms: terms, selectedCreditsInstallments: selectedInstallments)
-        
         attributedText = attributedString
-        textAlignment = .center
         self.textColor = textColor
-        
-        if cardType == .small {
-            font = self.font?.withSize(10)
-        }
+        setupView()
     }
     
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        isEditable = false
+        textAlignment = .center
+        backgroundColor = .clear
+        isUserInteractionEnabled = true
+        translatesAutoresizingMaskIntoConstraints = false
     }
     
     private func getTermsAndConditionsText(terms: PXTermsDto, selectedCreditsInstallments: Int?) -> NSMutableAttributedString {

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/Components/PXTermsAndConditionsTextView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/Components/PXTermsAndConditionsTextView.swift
@@ -1,0 +1,65 @@
+//
+//  PXTermsAndConditionsTextView.swift
+//  MercadoPagoSDKV4
+//
+//  Created by Victor Pereira De Paula on 09/09/21.
+//
+
+import MLCardDrawer
+
+final class PXTermsAndConditionsTextView: UITextView {
+    init(terms: PXTermsDto, selectedInstallments: Int?, cardType: MLCardDrawerTypeV3? = .large, textColor: UIColor, linkColor: UIColor) {
+        super.init(frame: .zero, textContainer: nil)
+        
+        linkTextAttributes = [.foregroundColor: linkColor]
+        isUserInteractionEnabled = true
+        isEditable = false
+        backgroundColor = .clear
+        translatesAutoresizingMaskIntoConstraints = false
+
+        let attributedString = getTermsAndConditionsText(terms: terms, selectedCreditsInstallments: selectedInstallments)
+        
+        attributedText = attributedString
+        textAlignment = .center
+        self.textColor = textColor
+        
+        if cardType == .small {
+            font = self.font?.withSize(10)
+        }
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func getTermsAndConditionsText(terms: PXTermsDto, selectedCreditsInstallments: Int?) -> NSMutableAttributedString {
+        let tycText = terms.text
+        let attributedString = NSMutableAttributedString(string: tycText)
+
+        var phrases: [PXLinkablePhraseDto] = [PXLinkablePhraseDto]()
+        if let remotePhrases = terms.linkablePhrases {
+            phrases = remotePhrases
+        }
+
+        for linkablePhrase in phrases {
+            var customLink = linkablePhrase.link
+            if customLink == nil, let customHtml = linkablePhrase.html {
+                customLink = HtmlStorage.shared.set(customHtml)
+            } else if let links = terms.links {
+                guard let installmentsSelected = selectedCreditsInstallments else { return attributedString }
+                let key = linkablePhrase.installments?[String(installmentsSelected)]
+                if let htmlKey = key, let customHtml = links[htmlKey] {
+                    customLink = HtmlStorage.shared.set(customHtml)
+                }
+            }
+            if let customLink = customLink {
+                let tycLinkRange = (tycText as NSString).range(of: linkablePhrase.phrase)
+                attributedString.addAttribute(NSAttributedString.Key.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: tycLinkRange)
+                attributedString.addAttribute(NSAttributedString.Key.link, value: customLink, range: tycLinkRange)
+            }
+        }
+
+        return attributedString
+    }
+}

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXCard/DefaultCards/ConsumerCreditsCard.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXCard/DefaultCards/ConsumerCreditsCard.swift
@@ -5,36 +5,50 @@
 //  Created by Esteban Adrian Boffa on 03/07/2019.
 //
 
-import Foundation
 import MLCardDrawer
 
-class ConsumerCreditsCard: NSObject, CustomCardDrawerUI {
+final class ConsumerCreditsCard: NSObject, CustomCardDrawerUI {
+    
+    private lazy var consumerCreditsImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .clear
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.textAlignment = .center
+        label.font = label.font.withSize(PXLayout.XXXS_FONT)
+        label.numberOfLines = 2
+        label.lineBreakMode = NSLineBreakMode.byWordWrapping
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
 
     weak var delegate: PXTermsAndConditionViewDelegate?
 
     // CustomCardDrawerUI
-    var placeholderName = ""
-    var placeholderExpiration = ""
-    var bankImage: UIImage?
+    let placeholderName = ""
+    let placeholderExpiration = ""
+    let bankImage: UIImage? = nil
     var cardPattern = [0]
-    var cardFontColor: UIColor = .white
-    var cardLogoImage: UIImage?
-    var cardBackgroundColor: UIColor = #colorLiteral(red: 0.0431372549, green: 0.7065708517, blue: 0.7140994326, alpha: 1)
-    var securityCodeLocation: MLCardSecurityCodeLocation = .back
-    var defaultUI = false
-    var securityCodePattern = 3
-    var fontType: String = "light"
-    var ownOverlayImage: UIImage? = ResourceManager.shared.getImage("creditsOverlayMask")
+    let cardFontColor: UIColor = .white
+    let cardLogoImage: UIImage?
+    let cardBackgroundColor: UIColor = #colorLiteral(red: 0.0431372549, green: 0.7065708517, blue: 0.7140994326, alpha: 1)
+    let securityCodeLocation: MLCardSecurityCodeLocation = .back
+    let defaultUI = false
+    let securityCodePattern = 3
+    let fontType: String = "light"
+    let ownOverlayImage: UIImage?
     var ownGradient: CAGradientLayer = CAGradientLayer()
-    private let needsTermsAndConditions: Bool
 
-    init(_ creditsViewModel: PXCreditsViewModel, isDisabled: Bool, needsTermsAndConditions: Bool = true) {
-        self.needsTermsAndConditions = needsTermsAndConditions
-        
-        if isDisabled {
-            ownOverlayImage = ResourceManager.shared.getImage("Overlay")
-        }
+    init(_ creditsViewModel: PXCreditsViewModel, isDisabled: Bool) {
+        ownOverlayImage = ResourceManager.shared.getImage(isDisabled ? "Overlay" : "creditsOverlayMask")
         ownGradient = ConsumerCreditsCard.getCustomGradient(creditsViewModel)
+        
+        cardLogoImage = creditsViewModel.needsTermsAndConditions ? nil : ResourceManager.shared.getImage("consumerCreditsOneTap")
     }
     
     static func getCustomGradient(_ creditsViewModel: PXCreditsViewModel) -> CAGradientLayer {
@@ -53,53 +67,43 @@ extension ConsumerCreditsCard {
         let creditsImageWidth: CGFloat = size.height * 0.60
         let margins: CGFloat = 16
         let termsAndConditionsTextHeight: CGFloat = 50
-
-        let consumerCreditsImage = getConsumerCreditsImageView(isDisabled: isDisabled)
-        containerView.addSubview(consumerCreditsImage)
-        
         var verticalMargin : CGFloat = 0
         
         if !isDisabled {
-            if cardType != .small {
-                verticalMargin = -creditsImageHeight/2
-            } else {
-                verticalMargin = -creditsImageHeight/2 - 12
-            }
-        }
-        
-        NSLayoutConstraint.activate([
-            PXLayout.setWidth(owner: consumerCreditsImage, width: creditsImageWidth),
-            PXLayout.setHeight(owner: consumerCreditsImage, height: creditsImageHeight),
-            PXLayout.centerHorizontally(view: consumerCreditsImage),
-            PXLayout.centerVertically(view: consumerCreditsImage, to: containerView, withMargin: verticalMargin)
-        ])
-
-        if !isDisabled {
-            
-            if cardType != .small {
-                //TITLE LABEL
-                let titleLabel = getTitleLabel(creditsViewModel: creditsViewModel)
-                containerView.addSubview(titleLabel)
-                NSLayoutConstraint.activate([
-                    PXLayout.pinLeft(view: titleLabel, to: containerView, withMargin: margins),
-                    PXLayout.pinRight(view: titleLabel, to: containerView, withMargin: margins),
-                    PXLayout.put(view: titleLabel, onBottomOf: consumerCreditsImage)
-                ])
-            }
-            
-            //TERMS AND CONDITIONS LABEL
-            if needsTermsAndConditions {
-                let termsAndConditionsText = getTermsAndConditionsTextView(terms: creditsViewModel.displayInfo.bottomText, selectedInstallments: selectedInstallments, cardType: cardType)
+            if creditsViewModel.needsTermsAndConditions {
+                let consumerCreditsImageRaw = ResourceManager.shared.getImage("consumerCreditsOneTap")
+                consumerCreditsImage.image = isDisabled ? consumerCreditsImageRaw?.imageGreyScale() : consumerCreditsImageRaw
+                containerView.addSubview(consumerCreditsImage)
                 
+                let termsAndConditionsText = PXTermsAndConditionsTextView(terms: creditsViewModel.displayInfo.bottomText, selectedInstallments: selectedInstallments, cardType: cardType, textColor: .white, linkColor: .white)
+                termsAndConditionsText.delegate = self
                 containerView.addSubview(termsAndConditionsText)
+                
+                if cardType != .small {
+                    verticalMargin = -creditsImageHeight/2
+
+                    titleLabel.text = creditsViewModel.displayInfo.topText.text
+                    containerView.addSubview(titleLabel)
+                    NSLayoutConstraint.activate([
+                        PXLayout.pinLeft(view: titleLabel, to: containerView, withMargin: margins),
+                        PXLayout.pinRight(view: titleLabel, to: containerView, withMargin: margins),
+                        PXLayout.put(view: titleLabel, onBottomOf: consumerCreditsImage)
+                    ])
+                } else {
+                    verticalMargin = -creditsImageHeight/2 - 12
+                }
                 
                 NSLayoutConstraint.activate([
                     PXLayout.pinBottom(view: termsAndConditionsText, to: containerView, withMargin: margins - PXLayout.XXXS_MARGIN),
                     PXLayout.pinLeft(view: termsAndConditionsText, to: containerView, withMargin: margins),
-                    PXLayout.pinRight(view: termsAndConditionsText, to: containerView, withMargin: margins)
-                    ])
-
-                PXLayout.setHeight(owner: termsAndConditionsText, height: termsAndConditionsTextHeight).isActive = true
+                    PXLayout.pinRight(view: termsAndConditionsText, to: containerView, withMargin: margins),
+                    PXLayout.setHeight(owner: termsAndConditionsText, height: termsAndConditionsTextHeight),
+        
+                    PXLayout.setWidth(owner: consumerCreditsImage, width: creditsImageWidth),
+                    PXLayout.setHeight(owner: consumerCreditsImage, height: creditsImageHeight),
+                    PXLayout.centerHorizontally(view: consumerCreditsImage),
+                    PXLayout.centerVertically(view: consumerCreditsImage, to: containerView, withMargin: verticalMargin)
+                ])
             }
         }
     }
@@ -114,82 +118,5 @@ extension ConsumerCreditsCard: UITextViewDelegate {
                 delegate?.shouldOpenTermsCondition(title, url: URL)
             }
         return false
-    }
-}
-
-// MARK: Privates
-extension ConsumerCreditsCard {
-
-    private func getConsumerCreditsImageView(isDisabled: Bool) -> UIImageView {
-        let consumerCreditsImage = UIImageView()
-        consumerCreditsImage.backgroundColor = .clear
-        consumerCreditsImage.contentMode = .scaleAspectFit
-        let consumerCreditsImageRaw = ResourceManager.shared.getImage("consumerCreditsOneTap")
-        consumerCreditsImage.image = isDisabled ? consumerCreditsImageRaw?.imageGreyScale() : consumerCreditsImageRaw
-        return consumerCreditsImage
-    }
-
-    private func getTitleLabel(creditsViewModel: PXCreditsViewModel) -> UILabel {
-        let titleLabel = UILabel()
-        titleLabel.text = creditsViewModel.displayInfo.topText.text
-        titleLabel.textColor = .white
-        titleLabel.textAlignment = .center
-        titleLabel.font = titleLabel.font.withSize(PXLayout.XXXS_FONT)
-        titleLabel.numberOfLines = 2
-        titleLabel.lineBreakMode = NSLineBreakMode.byWordWrapping
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        return titleLabel
-    }
-
-    private func getTermsAndConditionsTextView(terms: PXTermsDto, selectedInstallments: Int?, cardType: MLCardDrawerTypeV3? = .large) -> UITextView {
-        let termsAndConditionsText = UITextView()
-        termsAndConditionsText.linkTextAttributes = [.foregroundColor: UIColor.white]
-        termsAndConditionsText.delegate = self
-        termsAndConditionsText.isUserInteractionEnabled = true
-        termsAndConditionsText.isEditable = false
-        termsAndConditionsText.backgroundColor = .clear
-        termsAndConditionsText.translatesAutoresizingMaskIntoConstraints = false
-
-        let attributedString = getTermsAndConditionsText(terms: terms, selectedCreditsInstallments: selectedInstallments)
-        
-        termsAndConditionsText.attributedText = attributedString
-        termsAndConditionsText.textAlignment = .center
-        termsAndConditionsText.textColor = .white
-        
-        if cardType == .small {
-            termsAndConditionsText.font = termsAndConditionsText.font?.withSize(10)
-        }
-
-        return termsAndConditionsText
-    }
-
-    private func getTermsAndConditionsText(terms: PXTermsDto, selectedCreditsInstallments: Int?) -> NSMutableAttributedString {
-        let tycText = terms.text
-        let attributedString = NSMutableAttributedString(string: tycText)
-
-        var phrases: [PXLinkablePhraseDto] = [PXLinkablePhraseDto]()
-        if let remotePhrases = terms.linkablePhrases {
-            phrases = remotePhrases
-        }
-
-        for linkablePhrase in phrases {
-            var customLink = linkablePhrase.link
-            if customLink == nil, let customHtml = linkablePhrase.html {
-                customLink = HtmlStorage.shared.set(customHtml)
-            } else if let links = terms.links {
-                guard let installmentsSelected = selectedCreditsInstallments else { return attributedString }
-                let key = linkablePhrase.installments?[String(installmentsSelected)]
-                if let htmlKey = key, let customHtml = links[htmlKey] {
-                    customLink = HtmlStorage.shared.set(customHtml)
-                }
-            }
-            if let customLink = customLink {
-                let tycLinkRange = (tycText as NSString).range(of: linkablePhrase.phrase)
-                attributedString.addAttribute(NSAttributedString.Key.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: tycLinkRange)
-                attributedString.addAttribute(NSAttributedString.Key.link, value: customLink, range: tycLinkRange)
-            }
-        }
-
-        return attributedString
     }
 }

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXCard/DefaultCards/ConsumerCreditsCard.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXCard/DefaultCards/ConsumerCreditsCard.swift
@@ -75,7 +75,7 @@ extension ConsumerCreditsCard {
                 consumerCreditsImage.image = isDisabled ? consumerCreditsImageRaw?.imageGreyScale() : consumerCreditsImageRaw
                 containerView.addSubview(consumerCreditsImage)
                 
-                let termsAndConditionsText = PXTermsAndConditionsTextView(terms: creditsViewModel.displayInfo.bottomText, selectedInstallments: selectedInstallments, cardType: cardType, textColor: .white, linkColor: .white)
+                let termsAndConditionsText = PXTermsAndConditionsTextView(terms: creditsViewModel.displayInfo.bottomText, selectedInstallments: selectedInstallments, textColor: .white, linkColor: .white)
                 termsAndConditionsText.delegate = self
                 containerView.addSubview(termsAndConditionsText)
                 

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
@@ -31,6 +31,18 @@ struct PXRemedyViewData {
 
 final class PXRemedyView: UIView {
     
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .left
+        label.textColor = #colorLiteral(red: 0.1725280285, green: 0.1725597382, blue: 0.1725237072, alpha: 1)
+        label.numberOfLines = 0
+        label.font = .ml_semiboldSystemFont(ofSize: TITLE_FONT_SIZE) ?? Utils.getSemiBoldFont(size: TITLE_FONT_SIZE)
+        label.lineBreakMode = .byWordWrapping
+        label.lineBreakMode = .byTruncatingTail
+        return label
+    }()
+    
     private lazy var hintLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -95,8 +107,9 @@ final class PXRemedyView: UIView {
 
     private func render() {
         removeAllSubviews()
+        
         // Title Label
-        let titleLabel = buildTitleLabel(text: getRemedyMessage())
+        titleLabel.text = getRemedyMessage()
         addSubview(titleLabel)
         let screenWidth = PXLayout.getScreenWidth(applyingMarginFactor: CONTENT_WIDTH_PERCENT)
         let height = UILabel.requiredHeight(forText: getRemedyMessage(), withFont: titleLabel.font, inWidth: screenWidth)
@@ -113,6 +126,7 @@ final class PXRemedyView: UIView {
             NSLayoutConstraint.activate([
                 cardDrawerView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: PXLayout.M_MARGIN),
                 cardDrawerView.widthAnchor.constraint(equalTo: titleLabel.widthAnchor),
+                cardDrawerView.heightAnchor.constraint(equalToConstant: cardDrawerView.frame.height),
                 cardDrawerView.centerXAnchor.constraint(equalTo: centerXAnchor)
             ])
         }
@@ -170,19 +184,6 @@ final class PXRemedyView: UIView {
         self.layoutIfNeeded()
     }
 
-    private func buildTitleLabel(text: String) -> UILabel {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textAlignment = .left
-        label.textColor = #colorLiteral(red: 0.1725280285, green: 0.1725597382, blue: 0.1725237072, alpha: 1)
-        label.numberOfLines = 0
-        label.text = text
-        label.font = UIFont.ml_semiboldSystemFont(ofSize: TITLE_FONT_SIZE) ?? Utils.getSemiBoldFont(size: TITLE_FONT_SIZE)
-        label.lineBreakMode = .byWordWrapping
-        label.lineBreakMode = .byTruncatingTail
-        return label
-    }
-
     private func buildCardDrawerView() -> UIView? {
         guard data.remedy.cvv != nil || data.remedy.suggestedPaymentMethod != nil,
             let oneTapDto = data.oneTapDto else {
@@ -237,9 +238,7 @@ final class PXRemedyView: UIView {
         } else {
             return nil
         }
-        
         let cardSize: MLCardDrawerTypeV3
-        
         switch data.remedy.suggestedPaymentMethod?.alternativePaymentMethod?.cardSize {
         case .mini: cardSize = .mini
         case .small: cardSize = .small

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
@@ -87,7 +87,6 @@ final class PXRemedyView: UIView {
     let CONTENT_WIDTH_PERCENT: CGFloat = 84.0
     let TITLE_FONT_SIZE: CGFloat = PXLayout.XS_FONT
     let CARD_VIEW_WIDTH: CGFloat = 335
-    let CARD_VIEW_HEIGHT: CGFloat = 109
     let TEXTFIELD_HEIGHT: CGFloat = 50.0
     let TEXTFIELD_FONT_SIZE: CGFloat = PXLayout.M_FONT
     let TOTAL_FONT_SIZE: CGFloat = PXLayout.XS_FONT
@@ -114,7 +113,6 @@ final class PXRemedyView: UIView {
             NSLayoutConstraint.activate([
                 cardDrawerView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: PXLayout.M_MARGIN),
                 cardDrawerView.widthAnchor.constraint(equalTo: titleLabel.widthAnchor),
-                cardDrawerView.heightAnchor.constraint(equalToConstant: CARD_VIEW_HEIGHT),
                 cardDrawerView.centerXAnchor.constraint(equalTo: centerXAnchor)
             ])
         }
@@ -282,7 +280,7 @@ final class PXRemedyView: UIView {
     
     private func addCreditTermsIfNeeded(terms: PXTermsDto?) {
         guard let terms = terms else { return }
-        let termsAndConditionsTextView = PXTermsAndConditionsTextView(terms: terms, selectedInstallments: nil, cardType: .mini, textColor: .black, linkColor: .pxBlueMp)
+        let termsAndConditionsTextView = PXTermsAndConditionsTextView(terms: terms, selectedInstallments: nil, textColor: .black, linkColor: .pxBlueMp)
         termsAndConditionsTextView.delegate = self
         termsAndConditionsTextView.textAlignment = .center
         


### PR DESCRIPTION
## What have changed?
- Creation of PXTermsAndConditionsTextView, for reuse in Remedy screen;
- Adjustments by ConsumerCreditsCard to remove the extension equivalent to PXTermsAndConditionsTextView;
- ConsumerCreditsCard adjustments for the credit market logo to be at the top left when necessary;
- Adjustments in PXRemedyView to follow the layout.

## Kind of pr:

- [ ] BugFix
- [ ] Feature
- [x] Improvement

## How to test:


## Extras
