### PR TITLE
feat: Added extra step to oneTapFlow for mode = .optional

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlow.swift
@@ -51,6 +51,8 @@ final class OneTapFlow: NSObject, PXFlow {
                 self.showOneTapViewController()
             case .screenSecurityCode:
                 self.showSecurityCodeScreen()
+            case .serviceCreateOptionalToken:
+                self.getTokenizationService().createCardTokenWithoutCVV()
             case .serviceCreateESCCardToken:
                 self.getTokenizationService().createCardToken()
             case .serviceCreateWebPayCardToken:

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
@@ -315,20 +315,11 @@ internal extension OneTapFlowModel {
     }
     
     func needCreateOptionalToken() -> Bool {
-        guard let paymentMethod = self.paymentData.getPaymentMethod() else {
-            return false
-        }
-
-        guard let paymentOptionSelected = paymentOptionSelected else {
-            return false
-        }
-
-        if !readyToPay {
-            return false
-        }
-        
-        if paymentData.hasToken() {
-           return false
+        guard let paymentMethod = self.paymentData.getPaymentMethod(),
+                let paymentOptionSelected = paymentOptionSelected,
+                readyToPay,
+                !paymentData.hasToken() else {
+          return false
         }
         
         let hasInstallmentsIfNeeded = paymentData.hasPayerCost() || !paymentMethod.isCreditCard

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/OneTap/OneTapFlowModel.swift
@@ -13,6 +13,7 @@ final internal class OneTapFlowModel: PXFlowModel {
         case finish
         case screenOneTap
         case screenSecurityCode
+        case serviceCreateOptionalToken
         case serviceCreateESCCardToken
         case serviceCreateWebPayCardToken
         case screenKyC
@@ -141,6 +142,7 @@ final internal class OneTapFlowModel: PXFlowModel {
     public func nextStep() -> Steps {
         if needShowOneTap() { return .screenOneTap }
         if needSecurityCode() { return .screenSecurityCode }
+        if needCreateOptionalToken() { return .serviceCreateOptionalToken }
         if needCreateESCToken() { return .serviceCreateESCCardToken }
         if needCreateWebPayToken() { return .serviceCreateWebPayCardToken }
         if needKyC() { return .screenKyC }
@@ -256,7 +258,7 @@ internal extension OneTapFlowModel {
         return true
     }
 
-    func needSecurityCode() -> Bool {
+    func needSecurityCode() -> Bool {        
         guard let paymentMethod = self.paymentData.getPaymentMethod() else {
             return false
         }
@@ -310,6 +312,38 @@ internal extension OneTapFlowModel {
         let savedCardWithESC = !paymentData.hasToken() && paymentMethod.isCard && hasSavedESC() && hasInstallmentsIfNeeded
 
         return savedCardWithESC
+    }
+    
+    func needCreateOptionalToken() -> Bool {
+        guard let paymentMethod = self.paymentData.getPaymentMethod() else {
+            return false
+        }
+
+        guard let paymentOptionSelected = paymentOptionSelected else {
+            return false
+        }
+
+        if !readyToPay {
+            return false
+        }
+        
+        if paymentData.hasToken() {
+           return false
+        }
+        
+        let hasInstallmentsIfNeeded = paymentData.hasPayerCost() || !paymentMethod.isCreditCard
+        let paymentOptionSelectedId = paymentOptionSelected.getId()
+        let isCustomerCard = paymentOptionSelected.isCustomerPaymentMethod() && paymentOptionSelectedId != PXPaymentTypes.ACCOUNT_MONEY.rawValue && paymentOptionSelectedId != PXPaymentTypes.CONSUMER_CREDITS.rawValue
+        
+        if isCustomerCard &&
+            !paymentData.hasToken() &&
+            hasInstallmentsIfNeeded &&
+            hasSecurityCode(),
+           search.oneTap?.first(where: { $0.oneTapCard?.cardId == paymentOptionSelected.getId()})?.oneTapCard?.cardUI?.securityCode?.mode == .optional {
+            return true
+        }
+        
+        return false
     }
 
     func needCreateWebPayToken() -> Bool {

--- a/MercadoPagoSDK/MercadoPagoSDK/Flows/TokenizationFlow/TokenizationService.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Flows/TokenizationFlow/TokenizationService.swift
@@ -63,6 +63,17 @@ internal class TokenizationService {
             createSavedCardToken(cardInformation: cardInfo, securityCode: securityCode)
         }
     }
+    
+    func createCardTokenWithoutCVV() {
+        // New Card Token
+        guard let cardInfo = paymentOptionSelected as? PXCardInformation else {
+            createNewCardToken()
+            return
+        }
+
+        let savedESCCardToken = PXSavedESCCardToken(cardId: cardInfo.getCardId(), securityCode: nil, requireESC: false)
+        createSavedESCCardToken(savedESCCardToken: savedESCCardToken)
+    }
 
     private func createNewCardToken() {
         guard let cardToken = cardToken else {


### PR DESCRIPTION
## What have changed?

Added extra step to oneTapFlow for tokenizing without cvv/ESC for mode = .optional

Before, if a card has securityMode == .optional, it didn't request cvv nor ESC but was not tokenizing too, causing the payment flow to fail.

Now, if it's optional, it gets tokenized without CVV nor ESC anyways.

## Kind of pr:

- [ ] BugFix
- [ ] Feature
- [x] Improvement

## How to test:

Try changing security mode between .optional / .mandatory with any card

## Extras
