### PR TITLE
Updating changelog and podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v4.46.0
+🚀Private Release - 4.46.0 date: 16/09/2021 🚀
+- Showing modal when remedies card option given from BE is Mercado Creditos (disabled until tracks are done)
+- Card size on remedies dynamic according to BE response (disabled until tracks are done)
+- Tokenizing without cvv/ESC
+- Terms of use removed from customCard and added to top of payButton
+
 # v4.45.0
 🚀Private Release - 4.45.0 🚀
 - Fixed decimal calculation for getRawAmount

--- a/MercadoPagoSDKV4.podspec
+++ b/MercadoPagoSDKV4.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDKV4"
-  s.version          = "4.45.0"
+  s.version          = "4.46.0"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
# v4.46.0
🚀Private Release - 4.46.0 date: 16/09/2021 🚀
- Showing modal when remedies card option given from BE is Mercado Creditos (disabled until tracks are done)
- Card size on remedies dynamic according to BE response (disabled until tracks are done)
- Tokenizing without cvv/ESC
- Terms of use removed from customCard and added to top of payButton