### PR TITLE
Bugfix deeplink through terms and conditions

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/UI/WebViewController.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/WebViewController.swift
@@ -103,6 +103,14 @@ extension WebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         loadingVC.dismiss(animated: false, completion: nil)
     }
+    
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let police =  WKNavigationActionPolicy(rawValue: WKNavigationActionPolicy.allow.rawValue + 2) else {
+            decisionHandler(.allow)
+            return
+        }
+        decisionHandler(police)
+    }
 }
 
 // MARK: Tracking


### PR DESCRIPTION
## What have changed?

We do not allow anymore universal links to be open through our `WKWebView`

## Kind of pr:

- [x] BugFix
- [ ] Feature
- [ ] Improvement

## How to test:
### Requirements

- You have to have Mercado Livre app on the phone

mock `px_mobile/v2/checkout` request with with this url `https://run.mocky.io/v3/a1ee741a-1e59-42a6-85f7-7ce4ffa38285 ` open terms and conditions on mercado creditos card, after this tap on `Ver termos e condições gerais` and the behavior should be not open Mercado Livre app and show you the terms and conditions on WKWebView

## Extras
