### PR TITLE
Release/4.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v4.47.0
+🚀Private Release - 4.47.0 date: 23/09/2021 🚀
+- Bugfix terms and conditions opening yellow app
+- Removed old network layer
+- Remedy trackings
+- Mercado Créditos payment confirmation modal
+- Tracking external data improvements
+
 # v4.46.0
 🚀Private Release - 4.46.0 date: 16/09/2021 🚀
 - Showing modal when remedies card option given from BE is Mercado Creditos (disabled until tracks are done)

--- a/MercadoPagoSDKV4.podspec
+++ b/MercadoPagoSDKV4.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MercadoPagoSDKV4"
-  s.version          = "4.46.0"
+  s.version          = "4.47.0"
   s.summary          = "MercadoPagoSDK"
   s.homepage         = "https://www.mercadopago.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
# v4.47.0
🚀Private Release - 4.47.0 date: 23/09/2021 🚀
- Bugfix terms and conditions opening yellow app
- Removed old network layer
- Remedy trackings
- Mercado Créditos payment confirmation modal
- Tracking external data improvements