### PR TITLE
(Fixed)[PXN-2819] - Fixed bug with wrong suggested value for account money remedie

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -112,20 +112,19 @@ lane :deploy_private do
 end
 
 lane :pr_check do
-  UI.success 'Bypass'
-  # cocoapods(
-  #   clean_install: true,
-  #   podfile: "./ExampleSwift/Podfile"
-  # )
-  # run_tests(
-  #   workspace: "ExampleSwift/ExampleSwift.xcworkspace",
-  #   scheme: "ExampleSwift"
-  # )
-  # danger(
-  #   danger_id: "danger_pr",
-  #   verbose: true,
-  #   github_api_token: ENV["GITHUB_API_TOKEN"]
-  # )
+  cocoapods(
+    clean_install: true,
+    podfile: "./ExampleSwift/Podfile"
+  )
+  run_tests(
+    workspace: "ExampleSwift/ExampleSwift.xcworkspace",
+    scheme: "ExampleSwift"
+  )
+  danger(
+    danger_id: "danger_pr",
+    verbose: true,
+    github_api_token: ENV["GITHUB_API_TOKEN"]
+  )
 end
 
 lane :communicate_build_to_slack do |options|

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -1,6 +1,6 @@
 # This is the minimum version number required.
 # Update this, if you use features of a newer version
-fastlane_version "2.55.0"
+fastlane_version "2.199.0"
 
 # Disable Fastlane crash reporting because we're using UI.* methods for our custom errors and those aren't Fastlane bugs.
 opt_out_usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed bug with wrong suggested value for account money remedie
+
 
 ## v4.52.0 
 🚀 Private Release - 4.52.0 date: 16/12/2021 🚀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed bug with wrong suggested value for account money remedie
 
-
 ## v4.52.0 
 🚀 Private Release - 4.52.0 date: 16/12/2021 🚀
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem 'json'
 gem 'cocoapods', '~> 1.8.4'
-gem 'fastlane', '~>2.55'
+gem 'fastlane', '~>2.199.0'
 gem 'danger', '~> 8.4.1'
 gem 'danger-swiftlint'
 gem 'git_diff_parser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,9 +325,9 @@ DEPENDENCIES
   danger (~> 8.4.1)
   danger-swiftlint
   danger-xcov
-  fastlane (~> 2.55)
+  fastlane (~> 2.199.0)
   git_diff_parser
   json
 
 BUNDLED WITH
-   2.0.2
+   2.2.31

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
@@ -342,7 +342,6 @@ final class PXRemedyView: UIView {
                 }
             }
         } else {
-            // Caso account money
             let string = Utils.getAmountFormated(amount: amountHelper.amountToPay, forCurrency: currency)
             let attributed = NSAttributedString(string: string, attributes: PXNewCustomView.titleAttributes)
             firstString.append(attributed)

--- a/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/UI/PXRemedy/PXRemedyView.swift
@@ -343,15 +343,9 @@ final class PXRemedyView: UIView {
             }
         } else {
             // Caso account money
-            if let splitAccountMoneyAmount = paymentData.getTransactionAmountWithDiscount() {
-                let string = Utils.getAmountFormated(amount: splitAccountMoneyAmount, forCurrency: currency)
-                let attributed = NSAttributedString(string: string, attributes: PXNewCustomView.titleAttributes)
-                firstString.append(attributed)
-            } else {
-                let string = Utils.getAmountFormated(amount: amountHelper.amountToPay, forCurrency: currency)
-                let attributed = NSAttributedString(string: string, attributes: PXNewCustomView.titleAttributes)
-                firstString.append(attributed)
-            }
+            let string = Utils.getAmountFormated(amount: amountHelper.amountToPay, forCurrency: currency)
+            let attributed = NSAttributedString(string: string, attributes: PXNewCustomView.titleAttributes)
+            firstString.append(attributed)
         }
 
         // Discount


### PR DESCRIPTION
<!-- [
    Title template
    (Added|Changed|Deprecated|Removed|Fixed|Security)[JIRA-XXX] - Changelog description of this changes

    The title will be used as the entry in the changelog for this changes. Please take time to write this the best way you can. To write better changelog messages, refer to https://keepachangelog.com/en/1.0.0/

    Added: for new features.
    Changed: for changes in existing functionality.
    Deprecated: for soon-to-be removed features.
    Removed: for now removed features.
    Fixed: for any bug fixes.
    Security: in case of vulnerabilities.
] -->

## What have changed?
Fix account money remedie suggested value. There was an old business rule that was removed to fix the issue and make account money behave like any other payment method.

## How to test:
Execute a failed payment with a card that has taxes and get account money as remedie. If the value suggest for the account money is the proper one, then it is good.

## Prints for layout changes:


## Extras:
